### PR TITLE
Rezoom und Neuzentrierung abschaltbar

### DIFF
--- a/mapview/src/main/java/slash/navigation/converter/gui/mapview/BaseMapView.java
+++ b/mapview/src/main/java/slash/navigation/converter/gui/mapview/BaseMapView.java
@@ -90,6 +90,7 @@ public abstract class BaseMapView implements MapView {
     private static final String CENTER_LATITUDE_PREFERENCE = "centerLatitude";
     private static final String CENTER_LONGITUDE_PREFERENCE = "centerLongitude";
     private static final String CENTER_ZOOM_PREFERENCE = "centerZoom";
+    private static final String AUTO_ZOOM = "autoZoom";
 
     private PositionsModel positionsModel;
     private List<NavigationPosition> positions;
@@ -232,6 +233,9 @@ public abstract class BaseMapView implements MapView {
     }
 
     protected void initializeBrowserInteraction() {
+
+        final boolean autoRezoomCenter = preferences.getBoolean(AUTO_ZOOM, true);
+
         getComponent().addComponentListener(new ComponentListener() {
             public void componentResized(ComponentEvent e) {
                 resize();
@@ -298,7 +302,7 @@ public abstract class BaseMapView implements MapView {
                                     " haveToReplaceRoute:" + haveToReplaceRoute +
                                     " haveToRepaintRouteImmediately:" + haveToRepaintRouteImmediately);
                             copiedPositions = new ArrayList<NavigationPosition>(positions);
-                            recenter = haveToReplaceRoute;
+                            recenter = autoRezoomCenter && haveToReplaceRoute;
                             haveToUpdateRoute = false;
                             haveToReplaceRoute = false;
                             haveToRepaintRouteImmediately = false;
@@ -358,7 +362,7 @@ public abstract class BaseMapView implements MapView {
                                     " haveToRepaintSelection: " + haveToRepaintSelection +
                                     " haveToRepaintSelectionImmediately: " + haveToRepaintSelectionImmediately +
                                     " haveToRecenterMap: " + haveToRecenterMap);
-                            recenter = haveToRecenterMap;
+                            recenter = autoRezoomCenter && haveToRecenterMap;
                             haveToRecenterMap = false;
                             haveToRepaintSelectionImmediately = false;
                             haveToRepaintSelection = false;


### PR DESCRIPTION
Hallo Christian,

anbei mal der Code, mit dem man per versteckter Option die Auto-Zentrierung und den Auto-Zoom abschalten kann.
Das Reg-File mit den Default-Werten bzw. das File für Linux habe ich im Repo nicht gefunden.

Entscheidend ist der letzte Commit. Wie ich hier die anderen Commits ausblenden kann, weiss ich nicht.

Gruß
Thomas
