### PR TITLE
New read() method in NavigationFormatParser

### DIFF
--- a/navigation-formats/src/main/java/slash/navigation/base/NavigationFormatParser.java
+++ b/navigation-formats/src/main/java/slash/navigation/base/NavigationFormatParser.java
@@ -241,6 +241,10 @@ public class NavigationFormatParser {
         return read(source, READ_BUFFER_SIZE, null, getReadFormats());
     }
 
+    public ParserResult read(InputStream source, List<NavigationFormat> formats) throws IOException {
+        return read(source, READ_BUFFER_SIZE, null, formats);
+    }
+
     private int getSize(URL url) throws IOException {
         try {
             if (url.getProtocol().equals("file"))


### PR DESCRIPTION
The public interface of NavigationFormatParser is missing a public read() method which allows to specify the list of formats to consider also for input streams.
An analogous method already exists for files instead of input streams.

For our specific case this is important to have in a setting with GPSBabel removed, so that we can specify non-Babel-related formats only.
In general, this rounds off the public interface of the class consistently.
