### PR TITLE
Retina display support for Mac64

### DIFF
--- a/RouteConverterMac64/src/main/app-resources/Info.plist
+++ b/RouteConverterMac64/src/main/app-resources/Info.plist
@@ -35,5 +35,7 @@
             <key>ClassPath</key>
             <string>$JAVAROOT/RouteConverterMac64.jar</string>
         </dict>
+        <key>NSHighResolutionCapable</key>
+        <true/>
     </dict>
 </plist>


### PR DESCRIPTION
Fill in the lines for supporting retina displays and their high resolution on Apple computer.
