### PR TITLE
Fix for navigon route-format

### DIFF
--- a/navigation-formats/src/main/java/slash/navigation/nmn/NmnRouteFormat.java
+++ b/navigation-formats/src/main/java/slash/navigation/nmn/NmnRouteFormat.java
@@ -288,6 +288,8 @@ public class NmnRouteFormat extends SimpleFormat<Wgs84Route> {
           n byte Text
          */
         long blockLength = byteBuffer.getLong();
+        if ((byteBuffer.remaining() == 0) || (blockLength == 0))
+            return positionPoint;
         int startPosition = byteBuffer.position();
         String waypointDescription = getText(byteBuffer);
 


### PR DESCRIPTION
Der Patch behebt ein Problem mit dem Navigon Route-Format. Die Blocklänge war in diesem Fall 0, was dazu geführt hat, dass zu viel eingelesen wurde.