### PR TITLE
routeconverter.html new overlays

### DIFF
--- a/browser-mapview/src/main/resources/slash/navigation/mapview/browser/routeconverter.html
+++ b/browser-mapview/src/main/resources/slash/navigation/mapview/browser/routeconverter.html
@@ -611,6 +611,22 @@ ${tileservers1}
 
 ${tileservers2}
 
+           var stravaheatmapCyclingType = new google.maps.ImageMapType({
+               getTileUrl: function(coord, zoom) {
+                   return "http://globalheat.strava.com/tiles/cycling/color1/" + zoom + "/" + coord.x + "/" + coord.y + ".png";
+               },
+               tileSize: DEFAULT_TILE_SIZE,
+               isPng: true,
+               name: "Cycling database of Strava Heatmap data"
+           });
+           var stravaheatmapRunningType = new google.maps.ImageMapType({
+               getTileUrl: function(coord, zoom) {
+                   return "http://globalheat.strava.com/tiles/running/color1/" + zoom + "/" + coord.x + "/" + coord.y + ".png";
+               },
+               tileSize: DEFAULT_TILE_SIZE,
+               isPng: true,
+               name: "Running database of Strava Heatmap data"
+           });
            var hillshadingMapType = new google.maps.ImageMapType({
                getTileUrl: function(coord, zoom) {
                    return "http://" + getOpenStreetMapServerIndex() + ".tiles.wmflabs.org/hillshading/" + zoom + "/" + coord.x + "/" + coord.y + ".png";
@@ -674,7 +690,11 @@ ${tileservers2}
                    copyrightControl.innerHTML = 'Missing copyright';
                }
 
-               if (mapTypeId == "OSM Hike"){
+               if (mapTypeId == "Strava Cycling over OSM Cycle"){
+                   map.overlayMapTypes.setAt(0, stravaheatmapCyclingType);
+               } else if (mapTypeId == "Strava Running over OSM Cycle"){
+                   map.overlayMapTypes.setAt(0, stravaheatmapRunningType);
+               } else if (mapTypeId == "OSM Hike"){
                    map.overlayMapTypes.setAt(0, hillshadingMapType);
                } else if (mapTypeId == "Hike Symbols"){
             	   map.overlayMapTypes.setAt(0, hikingSymbolsMapType);


### PR DESCRIPTION
routeconverter.html update to include Strava Heatmap Cycling and Running overlays, in this case using "OSM Cycle" as the background map. 

Need to add the respective lines to $USER\\.routeconverter\tileservers\default.xml file (attached):
[default.zip](https://github.com/cpesch/RouteConverter/files/1020592/default.zip)

Tested with RouteConverter Prerelease 2.21-SNAPSHOT-856 with success, screenshots below:
![strava heatmap cycling over osm cycle map](https://cloud.githubusercontent.com/assets/28870592/26333544/bea31068-3f34-11e7-99f9-f7448c37b4b8.jpg)
![strava heatmap running over osm cycle map](https://cloud.githubusercontent.com/assets/28870592/26333567/ec188dde-3f34-11e7-912d-c5593828faf1.jpg)

