### PR TITLE
Plural date-time-format-error for "date and time"

### DIFF
--- a/route-converter/src/main/resources/slash/navigation/converter/gui/RouteConverter_en.properties
+++ b/route-converter/src/main/resources/slash/navigation/converter/gui/RouteConverter_en.properties
@@ -382,7 +382,7 @@ scan-error=<html>Cannot scan for maps and themes:<p>{0}
 out-of-memory-error=<html>RouteConverter ran out of memory with {0} MByte of memory.<p>Please restart RouteConverter on the console with<p>"java -jar -mx{1}m RouteConverterSUFFIX_FOR_PLATFORM.jar"<p>to double the memory limit.
 unhandled-throwable-error=An error occured while executing the ''{0}'' action:\n{1}
 
-date-time-format-error=Could not parse date and time ''{0}''\nsince it does not match the required format ''{1}''.
+date-time-format-error=Could not parse date and time ''{0}''\nsince they do not match the required format ''{1}''.
 date-format-error=Could not parse date ''{0}''\nsince it does not match the required format ''{1}''.
 time-format-error=Could not parse time ''{0}''\nsince it does not match the required format ''{1}''.
 


### PR DESCRIPTION
Alternatively, "due to not matching the required format", which works for all.

Is it specifically both failing, or just one or more?
Should I bump the version number and date of the maven.buildNumber.plugin properties file manually?