### PR TITLE
fix: use https for spring-plugins-repository

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -28,7 +28,7 @@
         </repository>
         <repository>
             <id>spring-plugins-repository</id>
-            <url>http://repo.spring.io/plugins-release/</url>
+            <url>https://repo.spring.io/plugins-release/</url>
         </repository>
     </repositories>
 


### PR DESCRIPTION
Fixes dependency fetching error

```
Failed to execute goal on project browser-mapview: Could not resolve dependencies for
project slash.navigation:browser-mapview:jar:2.27.1: Failed to collect dependencies at
net.andreinc.aleph:aleph-formatter:jar:0.1.0: Failed to read artifact descriptor for
net.andreinc.aleph:aleph-formatter:jar:0.1.0: Could not transfer artifact
net.andreinc.aleph:aleph-formatter:pom:0.1.0 from/to spring-plugins-repository
(http://repo.spring.io/plugins-release/): Access denied to:
http://repo.spring.io/plugins-release/net/andreinc/aleph/aleph-formatter/0.1.0/aleph-formatter-0.1.0.pom ,
ReasonPhrase:Forbidden.
```

Unfortunately, as this is a change to the 3rd party repository it is likely that older versions are not buildable any more now. Not sure if you want to port back this on older tags/branches as well...