### PR TITLE
How about add more Forked VM when run all tests in build

### DIFF
--- a/coverage-report/pom.xml
+++ b/coverage-report/pom.xml
@@ -213,7 +213,7 @@
                     <!-- which jacoco will not instrument. Hence it is important to add -->
                     <!-- those command-line params here (${argLine} holds those params) -->
                     <argLine>${argLine} -Xms256m -Xmx2048m</argLine>
-                    <forkCount>1</forkCount>
+                    <forkCount>1.5C</forkCount>
                     <runOrder>random</runOrder>
                 </configuration>
             </plugin>

--- a/pom.xml
+++ b/pom.xml
@@ -302,7 +302,7 @@
                         <exclude>**/*IntegrationTest.java</exclude>
                     </excludes>
                     <!-- optional: works also when skipped -->
-                    <forkCount>1</forkCount>
+                    <forkCount>1.5C</forkCount>
                 </configuration>
             </plugin>
 


### PR DESCRIPTION

Maven will run all tests in a single forked VM by default. This can be problematic if there are a lot of tests or some very memory-hungry ones. We can fork more test VM by setting `<fork>1.5C</fork>`.

=====================
If there are any inappropriate modifications in this PR, please give me a reply and I will change them.
