### PR TITLE
Kml name fix

### DIFF
--- a/common-gui/src/main/java/slash/navigation/gui/renderer/BackendListCellRenderer.java
+++ b/common-gui/src/main/java/slash/navigation/gui/renderer/BackendListCellRenderer.java
@@ -1,0 +1,29 @@
+package slash.navigation.gui.renderer;
+
+import java.awt.Component;
+
+import javax.swing.DefaultListCellRenderer;
+import javax.swing.JLabel;
+import javax.swing.JList;
+import javax.swing.ListCellRenderer;
+
+public class BackendListCellRenderer extends DefaultListCellRenderer {
+	private ListCellRenderer backend;
+	
+	public BackendListCellRenderer(ListCellRenderer backend) {
+		this.backend = backend;
+	}
+	
+	@Override
+	public Component getListCellRendererComponent(JList list, Object value, int index,
+			boolean isSelected, boolean cellHasFocus) {
+		Component c = backend.getListCellRendererComponent(list, value, index, isSelected, cellHasFocus);
+		
+		if(!(c instanceof JLabel)) {
+			c = super.getListCellRendererComponent(list, value, index, isSelected, cellHasFocus);
+		}
+		
+		return c;
+	}
+
+}

--- a/mapsforge-mapview/src/main/java/slash/navigation/mapview/mapsforge/MapSelector.java
+++ b/mapsforge-mapview/src/main/java/slash/navigation/mapview/mapsforge/MapSelector.java
@@ -23,6 +23,7 @@ import com.intellij.uiDesigner.core.GridConstraints;
 import com.intellij.uiDesigner.core.GridLayoutManager;
 import org.mapsforge.map.model.IMapViewPosition;
 import slash.navigation.gui.Application;
+import slash.navigation.maps.item.ItemWideComboBox;
 import slash.navigation.maps.mapsforge.LocalMap;
 import slash.navigation.maps.mapsforge.LocalTheme;
 import slash.navigation.maps.mapsforge.MapsforgeMapManager;
@@ -166,7 +167,7 @@ public class MapSelector {
     }
 
     private void createUIComponents() {
-        comboBoxMap = new JComboBox<LocalMap>() {
+        comboBoxMap = new ItemWideComboBox<LocalMap>() {
             public void setSelectedItem(Object anObject) {
                 if (DOWNLOAD_MAP.equals(anObject)) {
                     Application.getInstance().getContext().getActionManager().run("show-maps");
@@ -175,7 +176,7 @@ public class MapSelector {
                 super.setSelectedItem(anObject);
             }
         };
-        comboBoxTheme = new JComboBox<LocalTheme>() {
+        comboBoxTheme = new ItemWideComboBox<LocalTheme>() {
             public void setSelectedItem(Object anObject) {
                 if (DOWNLOAD_THEME.equals(anObject)) {
                     Application.getInstance().getContext().getActionManager().run("show-themes");

--- a/mapsforge-mapview/src/main/java/slash/navigation/mapview/mapsforge/MapSelector.java
+++ b/mapsforge-mapview/src/main/java/slash/navigation/mapview/mapsforge/MapSelector.java
@@ -99,7 +99,7 @@ public class MapSelector {
                 asList(SEPARATOR_TO_DOWNLOAD_MAP, DOWNLOAD_MAP))
         );
         comboBoxMap.setPrototypeDisplayValue(new MapsforgeFileMap("Map", "http://mal.url", null, null, null));
-        comboBoxMap.setRenderer(new LocalMapListCellRenderer());
+        comboBoxMap.setRenderer(new LocalMapListCellRenderer(comboBoxMap.getRenderer()));
         comboBoxMap.addItemListener(e -> {
             if (e.getStateChange() != SELECTED) {
                 return;
@@ -115,7 +115,7 @@ public class MapSelector {
                 asList(SEPARATOR_TO_DOWNLOAD_THEME, DOWNLOAD_THEME))
         );
         comboBoxTheme.setPrototypeDisplayValue(mapManager.getAvailableThemesModel().getItem(0));
-        comboBoxTheme.setRenderer(new LocalThemeListCellRenderer());
+        comboBoxTheme.setRenderer(new LocalThemeListCellRenderer(comboBoxTheme.getRenderer()));
         LocalMap selectedItem = (LocalMap) comboBoxMap.getSelectedItem();
         comboBoxTheme.setEnabled(selectedItem != null && selectedItem.getType().isThemed());
 

--- a/mapsforge-mapview/src/main/java/slash/navigation/mapview/mapsforge/renderer/LocalMapListCellRenderer.java
+++ b/mapsforge-mapview/src/main/java/slash/navigation/mapview/mapsforge/renderer/LocalMapListCellRenderer.java
@@ -20,6 +20,7 @@
 package slash.navigation.mapview.mapsforge.renderer;
 
 import slash.navigation.gui.Application;
+import slash.navigation.gui.renderer.BackendListCellRenderer;
 import slash.navigation.maps.mapsforge.LocalMap;
 import slash.navigation.maps.mapsforge.impl.MapsforgeFileMap;
 
@@ -32,11 +33,15 @@ import java.awt.*;
  * @author Christian Pesch
  */
 
-public class LocalMapListCellRenderer extends DefaultListCellRenderer {
-    public static final LocalMap SEPARATOR_TO_DOWNLOAD_MAP = new MapsforgeFileMap(null, null, null, null, null);
+public class LocalMapListCellRenderer extends BackendListCellRenderer {
+	public static final LocalMap SEPARATOR_TO_DOWNLOAD_MAP = new MapsforgeFileMap(null, null, null, null, null);
     public static final LocalMap DOWNLOAD_MAP = new MapsforgeFileMap(null, null, null, null, null);
     private static final JSeparator SEPARATOR = new JSeparator();
 
+    public LocalMapListCellRenderer(ListCellRenderer backend) {
+		super(backend);
+	}
+    
     public Component getListCellRendererComponent(JList list, Object value, int index, boolean isSelected, boolean cellHasFocus) {
         if (SEPARATOR_TO_DOWNLOAD_MAP.equals(value))
             return SEPARATOR;

--- a/mapsforge-mapview/src/main/java/slash/navigation/mapview/mapsforge/renderer/LocalThemeListCellRenderer.java
+++ b/mapsforge-mapview/src/main/java/slash/navigation/mapview/mapsforge/renderer/LocalThemeListCellRenderer.java
@@ -19,12 +19,17 @@
 */
 package slash.navigation.mapview.mapsforge.renderer;
 
+import java.awt.Component;
+
+import javax.swing.JLabel;
+import javax.swing.JList;
+import javax.swing.JSeparator;
+import javax.swing.ListCellRenderer;
+
 import slash.navigation.gui.Application;
+import slash.navigation.gui.renderer.BackendListCellRenderer;
 import slash.navigation.maps.mapsforge.LocalTheme;
 import slash.navigation.maps.mapsforge.impl.VectorTheme;
-
-import javax.swing.*;
-import java.awt.*;
 
 /**
  * Renders the {@link LocalTheme} labels of the map and theme selector combo box.
@@ -32,10 +37,14 @@ import java.awt.*;
  * @author Christian Pesch
  */
 
-public class LocalThemeListCellRenderer extends DefaultListCellRenderer {
-    public static final LocalTheme SEPARATOR_TO_DOWNLOAD_THEME = new VectorTheme(null, null, null);
+public class LocalThemeListCellRenderer extends BackendListCellRenderer {
+	public static final LocalTheme SEPARATOR_TO_DOWNLOAD_THEME = new VectorTheme(null, null, null);
     public static final LocalTheme DOWNLOAD_THEME = new VectorTheme(null, null, null);
     private static final JSeparator SEPARATOR = new JSeparator();
+
+    public LocalThemeListCellRenderer(ListCellRenderer backend) {
+		super(backend);
+	}
 
     public Component getListCellRendererComponent(JList list, Object value, int index, boolean isSelected, boolean cellHasFocus) {
         if (SEPARATOR_TO_DOWNLOAD_THEME.equals(value))

--- a/navigation-formats/src/main/java/slash/navigation/kml/Kml20Format.java
+++ b/navigation-formats/src/main/java/slash/navigation/kml/Kml20Format.java
@@ -20,20 +20,6 @@
 
 package slash.navigation.kml;
 
-import slash.common.type.CompactCalendar;
-import slash.navigation.base.ParserContext;
-import slash.navigation.base.RouteCharacteristics;
-import slash.navigation.common.NavigationPosition;
-import slash.navigation.kml.binding20.*;
-
-import javax.xml.bind.JAXBElement;
-import javax.xml.bind.JAXBException;
-import java.io.IOException;
-import java.io.InputStream;
-import java.io.OutputStream;
-import java.util.ArrayList;
-import java.util.List;
-
 import static java.lang.Boolean.TRUE;
 import static slash.common.io.Transfer.trim;
 import static slash.common.type.ISO8601.formatDate;
@@ -43,6 +29,34 @@ import static slash.navigation.common.PositionParser.parsePosition;
 import static slash.navigation.common.PositionParser.parsePositions;
 import static slash.navigation.kml.KmlUtil.marshal20;
 import static slash.navigation.kml.KmlUtil.unmarshal20;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.OutputStream;
+import java.util.ArrayList;
+import java.util.List;
+
+import javax.xml.bind.JAXBElement;
+import javax.xml.bind.JAXBException;
+
+import slash.common.type.CompactCalendar;
+import slash.navigation.base.ParserContext;
+import slash.navigation.base.RouteCharacteristics;
+import slash.navigation.common.NavigationPosition;
+import slash.navigation.kml.binding20.Document;
+import slash.navigation.kml.binding20.Folder;
+import slash.navigation.kml.binding20.GeometryCollection;
+import slash.navigation.kml.binding20.Kml;
+import slash.navigation.kml.binding20.LineString;
+import slash.navigation.kml.binding20.LineStyle;
+import slash.navigation.kml.binding20.MultiGeometry;
+import slash.navigation.kml.binding20.NetworkLink;
+import slash.navigation.kml.binding20.ObjectFactory;
+import slash.navigation.kml.binding20.Placemark;
+import slash.navigation.kml.binding20.Point;
+import slash.navigation.kml.binding20.Style;
+import slash.navigation.kml.binding20.TimeInstant;
+import slash.navigation.kml.binding20.TimePeriod;
 
 /**
  * Reads and writes Google Earth 3 (.kml) files.
@@ -193,7 +207,7 @@ public class Kml20Format extends KmlFormat {
                 waypoints.add(wayPoint);
             } else {
                 // each placemark with more than one position is one track
-                String routeName = concatPath(name, asName(placemarkName));
+                String routeName = fixName(concatPath(name, asName(placemarkName)), TRACK);
                 List<String> routeDescription = extractDescriptionList(placemark.getDescriptionOrNameOrSnippet());
                 if (routeDescription == null)
                     routeDescription = description;
@@ -203,7 +217,7 @@ public class Kml20Format extends KmlFormat {
         }
         if (waypoints.size() != 0) {
             RouteCharacteristics characteristics = parseCharacteristics(name, Waypoints);
-            context.prependRoute(new KmlRoute(this, characteristics, name, description, waypoints));
+            context.prependRoute(new KmlRoute(this, characteristics, fixName(name, WAYPOINTS), description, waypoints));
         }
     }
 

--- a/navigation-formats/src/main/java/slash/navigation/kml/Kml21Format.java
+++ b/navigation-formats/src/main/java/slash/navigation/kml/Kml21Format.java
@@ -20,19 +20,6 @@
 
 package slash.navigation.kml;
 
-import slash.common.type.CompactCalendar;
-import slash.navigation.base.ParserContext;
-import slash.navigation.base.RouteCharacteristics;
-import slash.navigation.kml.binding21.*;
-
-import javax.xml.bind.JAXBElement;
-import javax.xml.bind.JAXBException;
-import java.io.IOException;
-import java.io.InputStream;
-import java.io.OutputStream;
-import java.util.ArrayList;
-import java.util.List;
-
 import static java.lang.Boolean.TRUE;
 import static slash.common.io.Transfer.trim;
 import static slash.common.type.ISO8601.formatDate;
@@ -40,6 +27,37 @@ import static slash.navigation.base.RouteCharacteristics.Track;
 import static slash.navigation.base.RouteCharacteristics.Waypoints;
 import static slash.navigation.kml.KmlUtil.marshal21;
 import static slash.navigation.kml.KmlUtil.unmarshal21;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.OutputStream;
+import java.util.ArrayList;
+import java.util.List;
+
+import javax.xml.bind.JAXBElement;
+import javax.xml.bind.JAXBException;
+
+import slash.common.type.CompactCalendar;
+import slash.navigation.base.ParserContext;
+import slash.navigation.base.RouteCharacteristics;
+import slash.navigation.kml.binding21.ContainerType;
+import slash.navigation.kml.binding21.DocumentType;
+import slash.navigation.kml.binding21.FeatureType;
+import slash.navigation.kml.binding21.FolderType;
+import slash.navigation.kml.binding21.GeometryType;
+import slash.navigation.kml.binding21.KmlType;
+import slash.navigation.kml.binding21.LineStringType;
+import slash.navigation.kml.binding21.LineStyleType;
+import slash.navigation.kml.binding21.LinkType;
+import slash.navigation.kml.binding21.MultiGeometryType;
+import slash.navigation.kml.binding21.NetworkLinkType;
+import slash.navigation.kml.binding21.ObjectFactory;
+import slash.navigation.kml.binding21.PlacemarkType;
+import slash.navigation.kml.binding21.PointType;
+import slash.navigation.kml.binding21.StyleType;
+import slash.navigation.kml.binding21.TimePrimitiveType;
+import slash.navigation.kml.binding21.TimeSpanType;
+import slash.navigation.kml.binding21.TimeStampType;
 
 /**
  * Reads and writes Google Earth 4 (.kml) files.
@@ -138,7 +156,7 @@ public class Kml21Format extends KmlFormat {
                 waypoints.add(wayPoint);
             } else {
                 // each placemark with more than one position is one track
-                String routeName = concatPath(name, asName(placemarkName));
+                String routeName = fixName(concatPath(name, asName(placemarkName)), TRACK);
                 List<String> routeDescription = asDescription(placemarkTypeValue.getDescription() != null ? placemarkTypeValue.getDescription() : description);
                 RouteCharacteristics characteristics = parseCharacteristics(routeName, Track);
                 context.appendRoute(new KmlRoute(this, characteristics, routeName, routeDescription, positions));
@@ -146,7 +164,7 @@ public class Kml21Format extends KmlFormat {
         }
         if (waypoints.size() > 0) {
             RouteCharacteristics characteristics = parseCharacteristics(name, Waypoints);
-            context.prependRoute(new KmlRoute(this, characteristics, name, asDescription(description), waypoints));
+            context.prependRoute(new KmlRoute(this, characteristics, fixName(name, WAYPOINTS), asDescription(description), waypoints));
         }
     }
 

--- a/navigation-formats/src/main/java/slash/navigation/kml/Kml22BetaFormat.java
+++ b/navigation-formats/src/main/java/slash/navigation/kml/Kml22BetaFormat.java
@@ -20,19 +20,6 @@
 
 package slash.navigation.kml;
 
-import slash.common.type.CompactCalendar;
-import slash.navigation.base.ParserContext;
-import slash.navigation.base.RouteCharacteristics;
-import slash.navigation.kml.binding22beta.*;
-
-import javax.xml.bind.JAXBElement;
-import javax.xml.bind.JAXBException;
-import java.io.IOException;
-import java.io.InputStream;
-import java.io.OutputStream;
-import java.util.ArrayList;
-import java.util.List;
-
 import static java.lang.Boolean.FALSE;
 import static java.lang.Boolean.TRUE;
 import static slash.common.io.Transfer.trim;
@@ -41,6 +28,38 @@ import static slash.navigation.base.RouteCharacteristics.Track;
 import static slash.navigation.base.RouteCharacteristics.Waypoints;
 import static slash.navigation.kml.KmlUtil.marshal22Beta;
 import static slash.navigation.kml.KmlUtil.unmarshal22Beta;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.OutputStream;
+import java.util.ArrayList;
+import java.util.List;
+
+import javax.xml.bind.JAXBElement;
+import javax.xml.bind.JAXBException;
+
+import slash.common.type.CompactCalendar;
+import slash.navigation.base.ParserContext;
+import slash.navigation.base.RouteCharacteristics;
+import slash.navigation.kml.binding22beta.AbstractContainerType;
+import slash.navigation.kml.binding22beta.AbstractFeatureType;
+import slash.navigation.kml.binding22beta.AbstractGeometryType;
+import slash.navigation.kml.binding22beta.AbstractTimePrimitiveType;
+import slash.navigation.kml.binding22beta.DocumentType;
+import slash.navigation.kml.binding22beta.FolderType;
+import slash.navigation.kml.binding22beta.KmlType;
+import slash.navigation.kml.binding22beta.LineStringType;
+import slash.navigation.kml.binding22beta.LineStyleType;
+import slash.navigation.kml.binding22beta.Link;
+import slash.navigation.kml.binding22beta.LinkType;
+import slash.navigation.kml.binding22beta.MultiGeometryType;
+import slash.navigation.kml.binding22beta.NetworkLinkType;
+import slash.navigation.kml.binding22beta.ObjectFactory;
+import slash.navigation.kml.binding22beta.PlacemarkType;
+import slash.navigation.kml.binding22beta.PointType;
+import slash.navigation.kml.binding22beta.StyleType;
+import slash.navigation.kml.binding22beta.TimeSpanType;
+import slash.navigation.kml.binding22beta.TimeStampType;
 
 /**
  * Reads and writes Google Earth 4.2 (.kml) files.
@@ -139,7 +158,7 @@ public class Kml22BetaFormat extends KmlFormat {
                 waypoints.add(wayPoint);
             } else {
                 // each placemark with more than one position is one track
-                String routeName = concatPath(name, asName(placemarkName));
+                String routeName = fixName(concatPath(name, asName(placemarkName)), TRACK);
                 List<String> routeDescription = asDescription(placemarkTypeValue.getDescription() != null ? placemarkTypeValue.getDescription() : description);
                 RouteCharacteristics characteristics = parseCharacteristics(routeName, Track);
                 context.appendRoute(new KmlRoute(this, characteristics, routeName, routeDescription, positions));
@@ -147,7 +166,7 @@ public class Kml22BetaFormat extends KmlFormat {
         }
         if (waypoints.size() > 0) {
             RouteCharacteristics characteristics = parseCharacteristics(name, Waypoints);
-            context.prependRoute(new KmlRoute(this, characteristics, name, asDescription(description), waypoints));
+            context.prependRoute(new KmlRoute(this, characteristics, fixName(name, WAYPOINTS), asDescription(description), waypoints));
         }
     }
 

--- a/navigation-formats/src/main/java/slash/navigation/kml/KmlFormat.java
+++ b/navigation-formats/src/main/java/slash/navigation/kml/KmlFormat.java
@@ -301,4 +301,12 @@ public abstract class KmlFormat extends BaseKmlFormat {
     protected boolean isWriteDesc() {
         return preferences.getBoolean("writeDesc", true);
     }
+        
+    protected String fixName(String name, String type) {
+    	if (name != null && name.startsWith("/"+type+":")) {
+    		name = name.substring(name.indexOf(":")+1).trim();
+    	}
+    	
+    	return name;
+    }
 }

--- a/route-converter/src/main/java/slash/navigation/converter/gui/dialogs/CompleteFlightPlanDialog.java
+++ b/route-converter/src/main/java/slash/navigation/converter/gui/dialogs/CompleteFlightPlanDialog.java
@@ -118,7 +118,7 @@ public class CompleteFlightPlanDialog extends SimpleDialog {
             }
         });
 
-        comboBoxCountryCode.setRenderer(new CountryCodeListCellRenderer());
+        comboBoxCountryCode.setRenderer(new CountryCodeListCellRenderer(comboBoxCountryCode.getRenderer()));
         comboBoxCountryCode.setModel(new DefaultComboBoxModel<>(CountryCode.values()));
         comboBoxCountryCode.addItemListener(e -> {
             if (e.getStateChange() != SELECTED)
@@ -127,7 +127,7 @@ public class CompleteFlightPlanDialog extends SimpleDialog {
             getPosition().setCountryCode(countryCode);
             validateModel();
         });
-        comboBoxWaypointType.setRenderer(new WaypointTypeListCellRenderer());
+        comboBoxWaypointType.setRenderer(new WaypointTypeListCellRenderer(comboBoxWaypointType.getRenderer()));
         comboBoxWaypointType.setModel(new DefaultComboBoxModel<>(new WaypointType[]{
                 Airport, Intersection, NonDirectionalBeacon, UserWaypoint, VHFOmnidirectionalRadioRange
         }));

--- a/route-converter/src/main/java/slash/navigation/converter/gui/dialogs/FindPlaceDialog.java
+++ b/route-converter/src/main/java/slash/navigation/converter/gui/dialogs/FindPlaceDialog.java
@@ -106,7 +106,7 @@ public class FindPlaceDialog extends SimpleDialog {
             }
         }, getKeyStroke(VK_ENTER, 0), WHEN_ANCESTOR_OF_FOCUSED_COMPONENT);
 
-        listResult.setCellRenderer(new NavigationPositionListCellRenderer());
+        listResult.setCellRenderer(new NavigationPositionListCellRenderer(listResult.getCellRenderer()));
         listResult.setSelectionForeground(new Color(232, 232, 232));
         listResult.setSelectionBackground(new Color(0, 9 * 16 + 9, 255));
         listResult.addListSelectionListener(new ListSelectionListener() {

--- a/route-converter/src/main/java/slash/navigation/converter/gui/dialogs/OptionsDialog.java
+++ b/route-converter/src/main/java/slash/navigation/converter/gui/dialogs/OptionsDialog.java
@@ -158,7 +158,7 @@ public class OptionsDialog extends SimpleDialog {
         });
         localeModel.setSelectedItem(Application.getInstance().getLocale());
         comboBoxLocale.setModel(localeModel);
-        comboBoxLocale.setRenderer(new LocaleListCellRenderer());
+        comboBoxLocale.setRenderer(new LocaleListCellRenderer(comboBoxLocale.getRenderer()));
         comboBoxLocale.addItemListener(e -> {
             if (e.getStateChange() != SELECTED) {
                 return;
@@ -172,7 +172,7 @@ public class OptionsDialog extends SimpleDialog {
                 new DefaultComboBoxModel<>(mapViews.toArray(new MapViewImplementation[0]));
         mapViewModel.setSelectedItem(r.getMapViewPreference());
         comboBoxMapService.setModel(mapViewModel);
-        comboBoxMapService.setRenderer(new MapViewListCellRenderer());
+        comboBoxMapService.setRenderer(new MapViewListCellRenderer(comboBoxMapService.getRenderer()));
         comboBoxMapService.addItemListener(e -> {
             if (e.getStateChange() != SELECTED) {
                 return;
@@ -240,7 +240,7 @@ public class OptionsDialog extends SimpleDialog {
         });
         googleMapsServerModel.setSelectedItem(r.getGoogleMapsServerModel().getGoogleMapsServer());
         comboBoxGoogleMapsServer.setModel(googleMapsServerModel);
-        comboBoxGoogleMapsServer.setRenderer(new GoogleMapsServerListCellRenderer());
+        comboBoxGoogleMapsServer.setRenderer(new GoogleMapsServerListCellRenderer(comboBoxGoogleMapsServer.getRenderer()));
         comboBoxGoogleMapsServer.addItemListener(e -> {
             if (e.getStateChange() != SELECTED) {
                 return;
@@ -254,7 +254,7 @@ public class OptionsDialog extends SimpleDialog {
         });
         fixMapModeModel.setSelectedItem(r.getMapPreferencesModel().getFixMapModeModel().getFixMapMode());
         comboBoxFixMapMode.setModel(fixMapModeModel);
-        comboBoxFixMapMode.setRenderer(new FixMapModeListCellRenderer());
+        comboBoxFixMapMode.setRenderer(new FixMapModeListCellRenderer(comboBoxFixMapMode.getRenderer()));
         comboBoxFixMapMode.addItemListener(e -> {
             if (e.getStateChange() != SELECTED) {
                 return;
@@ -384,7 +384,7 @@ public class OptionsDialog extends SimpleDialog {
         }
         routingServiceModel.setSelectedItem(r.getRoutingServiceFacade().getRoutingService());
         comboBoxRoutingService.setModel(routingServiceModel);
-        comboBoxRoutingService.setRenderer(new RoutingServiceListCellRenderer());
+        comboBoxRoutingService.setRenderer(new RoutingServiceListCellRenderer(comboBoxRoutingService.getRenderer()));
         comboBoxRoutingService.addItemListener(new ItemListener() {
             public void itemStateChanged(ItemEvent e) {
                 if (e.getStateChange() != SELECTED) {
@@ -419,7 +419,7 @@ public class OptionsDialog extends SimpleDialog {
         });
         handleRoutingServiceUpdate();
 
-        comboboxTravelMode.setRenderer(new TravelModeListCellRenderer());
+        comboboxTravelMode.setRenderer(new TravelModeListCellRenderer(comboboxTravelMode.getRenderer()));
         comboboxTravelMode.addItemListener(new ItemListener() {
             public void itemStateChanged(ItemEvent e) {
                 if (e.getStateChange() != SELECTED) {
@@ -450,7 +450,7 @@ public class OptionsDialog extends SimpleDialog {
         });
         numberPatternModel.setSelectedItem(r.getNumberPatternPreference());
         comboboxNumberPattern.setModel(numberPatternModel);
-        comboboxNumberPattern.setRenderer(new NumberPatternListCellRenderer());
+        comboboxNumberPattern.setRenderer(new NumberPatternListCellRenderer(comboboxNumberPattern.getRenderer()));
         comboboxNumberPattern.addItemListener(new ItemListener() {
             public void itemStateChanged(ItemEvent e) {
                 if (e.getStateChange() != SELECTED) {
@@ -466,7 +466,7 @@ public class OptionsDialog extends SimpleDialog {
         });
         numberingStrategyModel.setSelectedItem(r.getNumberingStrategyPreference());
         comboBoxNumberingStrategy.setModel(numberingStrategyModel);
-        comboBoxNumberingStrategy.setRenderer(new NumberingStrategyListCellRenderer());
+        comboBoxNumberingStrategy.setRenderer(new NumberingStrategyListCellRenderer(comboBoxNumberingStrategy.getRenderer()));
         comboBoxNumberingStrategy.addItemListener(new ItemListener() {
             public void itemStateChanged(ItemEvent e) {
                 if (e.getStateChange() != SELECTED) {
@@ -483,7 +483,7 @@ public class OptionsDialog extends SimpleDialog {
         }
         elevationServiceModel.setSelectedItem(r.getElevationServiceFacade().getElevationService());
         comboBoxElevationService.setModel(elevationServiceModel);
-        comboBoxElevationService.setRenderer(new ElevationServiceListCellRenderer());
+        comboBoxElevationService.setRenderer(new ElevationServiceListCellRenderer(comboBoxElevationService.getRenderer()));
         comboBoxElevationService.addItemListener(new ItemListener() {
             public void itemStateChanged(ItemEvent e) {
                 if (e.getStateChange() != SELECTED) {
@@ -524,7 +524,7 @@ public class OptionsDialog extends SimpleDialog {
         }
         geocodingServiceModel.setSelectedItem(r.getGeocodingServiceFacade().getGeocodingService());
         comboBoxGeocodingService.setModel(geocodingServiceModel);
-        comboBoxGeocodingService.setRenderer(new GeocodingServiceListCellRenderer());
+        comboBoxGeocodingService.setRenderer(new GeocodingServiceListCellRenderer(comboBoxGeocodingService.getRenderer()));
         comboBoxGeocodingService.addItemListener(new ItemListener() {
             public void itemStateChanged(ItemEvent e) {
                 if (e.getStateChange() != SELECTED) {
@@ -540,7 +540,7 @@ public class OptionsDialog extends SimpleDialog {
         });
         unitSystemModel.setSelectedItem(r.getUnitSystemModel().getUnitSystem());
         comboBoxUnitSystem.setModel(unitSystemModel);
-        comboBoxUnitSystem.setRenderer(new UnitSystemListCellRenderer());
+        comboBoxUnitSystem.setRenderer(new UnitSystemListCellRenderer(comboBoxUnitSystem.getRenderer()));
         comboBoxUnitSystem.addItemListener(new ItemListener() {
             public void itemStateChanged(ItemEvent e) {
                 if (e.getStateChange() != SELECTED) {
@@ -556,7 +556,7 @@ public class OptionsDialog extends SimpleDialog {
         });
         degreeFormatModel.setSelectedItem(r.getUnitSystemModel().getDegreeFormat());
         comboBoxDegreeFormat.setModel(degreeFormatModel);
-        comboBoxDegreeFormat.setRenderer(new DegreeFormatListCellRenderer());
+        comboBoxDegreeFormat.setRenderer(new DegreeFormatListCellRenderer(comboBoxDegreeFormat.getRenderer()));
         comboBoxDegreeFormat.addItemListener(new ItemListener() {
             public void itemStateChanged(ItemEvent e) {
                 if (e.getStateChange() != SELECTED) {
@@ -571,7 +571,7 @@ public class OptionsDialog extends SimpleDialog {
         ComboBoxModel<TimeZoneAndId> timeZoneModel = new DefaultComboBoxModel<>(timeZoneAndIds.getTimeZones());
         timeZoneModel.setSelectedItem(timeZoneAndIds.getTimeZoneAndIdFor(r.getTimeZone().getTimeZone()));
         comboBoxTimeZone.setModel(timeZoneModel);
-        comboBoxTimeZone.setRenderer(new TimeZoneAndIdListCellRenderer());
+        comboBoxTimeZone.setRenderer(new TimeZoneAndIdListCellRenderer(comboBoxTimeZone.getRenderer()));
         comboBoxTimeZone.addItemListener(new ItemListener() {
             public void itemStateChanged(ItemEvent e) {
                 if (e.getStateChange() != SELECTED) {

--- a/route-converter/src/main/java/slash/navigation/converter/gui/panels/ConvertPanel.java
+++ b/route-converter/src/main/java/slash/navigation/converter/gui/panels/ConvertPanel.java
@@ -385,7 +385,7 @@ public class ConvertPanel implements PanelInTab {
             handleColumnVisibilityUpdate(column);
 
         comboBoxPositionLists.setModel(formatAndRoutesModel);
-        comboBoxPositionLists.setRenderer(new RouteListCellRenderer());
+        comboBoxPositionLists.setRenderer(new RouteListCellRenderer(comboBoxPositionLists.getRenderer()));
         comboBoxPositionLists.addItemListener(e -> {
             if (e.getStateChange() == SELECTED) {
                 r.getPositionAugmenter().interrupt();
@@ -393,7 +393,7 @@ public class ConvertPanel implements PanelInTab {
             }
         });
         comboBoxRouteCharacteristics.setModel(r.getCharacteristicsModel());
-        comboBoxRouteCharacteristics.setRenderer(new RouteCharacteristicsListCellRenderer());
+        comboBoxRouteCharacteristics.setRenderer(new RouteCharacteristicsListCellRenderer(comboBoxRouteCharacteristics.getRenderer()));
 
         convertPanel.setTransferHandler(dropHandler);
 

--- a/route-converter/src/main/java/slash/navigation/converter/gui/panels/PhotoPanel.java
+++ b/route-converter/src/main/java/slash/navigation/converter/gui/panels/PhotoPanel.java
@@ -180,7 +180,7 @@ public class PhotoPanel implements PanelInTab {
 
         comboBoxFilterPhotoPredicate.setModel(FILTER_PREDICATE_MODEL);
         comboBoxFilterPhotoPredicate.setSelectedItem(getFilterPredicatePreference());
-        comboBoxFilterPhotoPredicate.setRenderer(new FilterPredicateListCellRenderer());
+        comboBoxFilterPhotoPredicate.setRenderer(new FilterPredicateListCellRenderer(comboBoxFilterPhotoPredicate.getRenderer()));
         comboBoxFilterPhotoPredicate.addItemListener(new ItemListener() {
             public void itemStateChanged(ItemEvent e) {
                 if (e.getStateChange() != SELECTED) {
@@ -197,7 +197,7 @@ public class PhotoPanel implements PanelInTab {
         ComboBoxModel<TimeZoneAndId> timeZoneModel = new DefaultComboBoxModel<>(timeZoneAndIds.getTimeZones());
         timeZoneModel.setSelectedItem(timeZoneAndIds.getTimeZoneAndIdFor(r.getPhotoTimeZone().getTimeZone()));
         comboBoxPhotoTimeZone.setModel(timeZoneModel);
-        comboBoxPhotoTimeZone.setRenderer(new TimeZoneAndIdListCellRenderer());
+        comboBoxPhotoTimeZone.setRenderer(new TimeZoneAndIdListCellRenderer(comboBoxPhotoTimeZone.getRenderer()));
         comboBoxPhotoTimeZone.addItemListener(new ItemListener() {
             public void itemStateChanged(ItemEvent e) {
                 if (e.getStateChange() != SELECTED)
@@ -218,7 +218,7 @@ public class PhotoPanel implements PanelInTab {
         });
         tagStrategyModel.setSelectedItem(r.getTagStrategyPreference());
         comboBoxTagStrategy.setModel(tagStrategyModel);
-        comboBoxTagStrategy.setRenderer(new TagStrategyListCellRenderer());
+        comboBoxTagStrategy.setRenderer(new TagStrategyListCellRenderer(comboBoxTagStrategy.getRenderer()));
         comboBoxTagStrategy.addItemListener(new ItemListener() {
             public void itemStateChanged(ItemEvent e) {
                 if (e.getStateChange() != SELECTED) {

--- a/route-converter/src/main/java/slash/navigation/converter/gui/renderer/CountryCodeListCellRenderer.java
+++ b/route-converter/src/main/java/slash/navigation/converter/gui/renderer/CountryCodeListCellRenderer.java
@@ -22,6 +22,7 @@ package slash.navigation.converter.gui.renderer;
 
 import slash.navigation.converter.gui.RouteConverter;
 import slash.navigation.fpl.CountryCode;
+import slash.navigation.gui.renderer.BackendListCellRenderer;
 
 import javax.swing.*;
 import java.awt.*;
@@ -34,8 +35,12 @@ import static slash.navigation.fpl.CountryCode.None;
  * @author Christian Pesch
  */
 
-public class CountryCodeListCellRenderer extends DefaultListCellRenderer {
-    public Component getListCellRendererComponent(JList list, Object value, int index, boolean isSelected, boolean cellHasFocus) {
+public class CountryCodeListCellRenderer extends BackendListCellRenderer {
+    public CountryCodeListCellRenderer(ListCellRenderer backend) {
+		super(backend);
+	}
+
+	public Component getListCellRendererComponent(JList list, Object value, int index, boolean isSelected, boolean cellHasFocus) {
         JLabel label = (JLabel) super.getListCellRendererComponent(list, value, index, isSelected, cellHasFocus);
         CountryCode countryCode = (CountryCode) value;
         String text;

--- a/route-converter/src/main/java/slash/navigation/converter/gui/renderer/DegreeFormatListCellRenderer.java
+++ b/route-converter/src/main/java/slash/navigation/converter/gui/renderer/DegreeFormatListCellRenderer.java
@@ -24,6 +24,7 @@ package slash.navigation.converter.gui.renderer;
 
 import slash.navigation.common.DegreeFormat;
 import slash.navigation.converter.gui.RouteConverter;
+import slash.navigation.gui.renderer.BackendListCellRenderer;
 
 import javax.swing.*;
 import java.awt.*;
@@ -35,8 +36,12 @@ import java.util.MissingResourceException;
  * @author Christian Pesch
  */
 
-public class DegreeFormatListCellRenderer extends DefaultListCellRenderer {
-    public Component getListCellRendererComponent(JList list, Object value, int index, boolean isSelected, boolean cellHasFocus) {
+public class DegreeFormatListCellRenderer extends BackendListCellRenderer {
+    public DegreeFormatListCellRenderer(ListCellRenderer backend) {
+		super(backend);
+	}
+
+	public Component getListCellRendererComponent(JList list, Object value, int index, boolean isSelected, boolean cellHasFocus) {
         JLabel label = (JLabel) super.getListCellRendererComponent(list, value, index, isSelected, cellHasFocus);
         DegreeFormat degreeFormat = (DegreeFormat) value;
         String text;

--- a/route-converter/src/main/java/slash/navigation/converter/gui/renderer/ElevationServiceListCellRenderer.java
+++ b/route-converter/src/main/java/slash/navigation/converter/gui/renderer/ElevationServiceListCellRenderer.java
@@ -22,11 +22,15 @@
 
 package slash.navigation.converter.gui.renderer;
 
+import java.awt.Component;
+
+import javax.swing.JLabel;
+import javax.swing.JList;
+import javax.swing.ListCellRenderer;
+
 import slash.navigation.elevation.ElevationService;
 import slash.navigation.gui.Application;
-
-import javax.swing.*;
-import java.awt.*;
+import slash.navigation.gui.renderer.BackendListCellRenderer;
 
 /**
  * Renders the {@link ElevationService} labels of the elevation service combo box.
@@ -34,8 +38,12 @@ import java.awt.*;
  * @author Christian Pesch
  */
 
-public class ElevationServiceListCellRenderer extends DefaultListCellRenderer {
-    public Component getListCellRendererComponent(JList list, Object value, int index, boolean isSelected, boolean cellHasFocus) {
+public class ElevationServiceListCellRenderer extends BackendListCellRenderer {
+    public ElevationServiceListCellRenderer(ListCellRenderer backend) {
+		super(backend);
+	}
+
+	public Component getListCellRendererComponent(JList list, Object value, int index, boolean isSelected, boolean cellHasFocus) {
         JLabel label = (JLabel) super.getListCellRendererComponent(list, value, index, isSelected, cellHasFocus);
         ElevationService service = (ElevationService) value;
 

--- a/route-converter/src/main/java/slash/navigation/converter/gui/renderer/FilterPredicateListCellRenderer.java
+++ b/route-converter/src/main/java/slash/navigation/converter/gui/renderer/FilterPredicateListCellRenderer.java
@@ -20,12 +20,16 @@
 
 package slash.navigation.converter.gui.renderer;
 
-import slash.navigation.gui.models.FilterPredicate;
-import slash.navigation.converter.gui.RouteConverter;
-
-import javax.swing.*;
-import java.awt.*;
+import java.awt.Component;
 import java.util.MissingResourceException;
+
+import javax.swing.JLabel;
+import javax.swing.JList;
+import javax.swing.ListCellRenderer;
+
+import slash.navigation.converter.gui.RouteConverter;
+import slash.navigation.gui.models.FilterPredicate;
+import slash.navigation.gui.renderer.BackendListCellRenderer;
 
 /**
  * Renders the {@link FilterPredicate} labels of the show photos combo box.
@@ -33,8 +37,12 @@ import java.util.MissingResourceException;
  * @author Christian Pesch
  */
 
-public class FilterPredicateListCellRenderer extends DefaultListCellRenderer {
-    public Component getListCellRendererComponent(JList list, Object value, int index, boolean isSelected, boolean cellHasFocus) {
+public class FilterPredicateListCellRenderer extends BackendListCellRenderer {
+    public FilterPredicateListCellRenderer(ListCellRenderer backend) {
+		super(backend);
+	}
+
+	public Component getListCellRendererComponent(JList list, Object value, int index, boolean isSelected, boolean cellHasFocus) {
         JLabel label = (JLabel) super.getListCellRendererComponent(list, value, index, isSelected, cellHasFocus);
         FilterPredicate filterPredicate = (FilterPredicate) value;
         String text;

--- a/route-converter/src/main/java/slash/navigation/converter/gui/renderer/FixMapModeListCellRenderer.java
+++ b/route-converter/src/main/java/slash/navigation/converter/gui/renderer/FixMapModeListCellRenderer.java
@@ -20,12 +20,16 @@
 
 package slash.navigation.converter.gui.renderer;
 
+import java.awt.Component;
+import java.util.MissingResourceException;
+
+import javax.swing.JLabel;
+import javax.swing.JList;
+import javax.swing.ListCellRenderer;
+
 import slash.navigation.converter.gui.RouteConverter;
 import slash.navigation.converter.gui.models.FixMapMode;
-
-import javax.swing.*;
-import java.awt.*;
-import java.util.MissingResourceException;
+import slash.navigation.gui.renderer.BackendListCellRenderer;
 
 /**
  * Renders the {@link FixMapMode} labels of the fix map combo box.
@@ -33,8 +37,12 @@ import java.util.MissingResourceException;
  * @author Christian Pesch
  */
 
-public class FixMapModeListCellRenderer extends DefaultListCellRenderer {
-    public Component getListCellRendererComponent(JList list, Object value, int index, boolean isSelected, boolean cellHasFocus) {
+public class FixMapModeListCellRenderer extends BackendListCellRenderer {
+    public FixMapModeListCellRenderer(ListCellRenderer backend) {
+		super(backend);
+	}
+
+	public Component getListCellRendererComponent(JList list, Object value, int index, boolean isSelected, boolean cellHasFocus) {
         JLabel label = (JLabel) super.getListCellRendererComponent(list, value, index, isSelected, cellHasFocus);
         FixMapMode fixMapMode = (FixMapMode) value;
         String text;

--- a/route-converter/src/main/java/slash/navigation/converter/gui/renderer/GeocodingServiceListCellRenderer.java
+++ b/route-converter/src/main/java/slash/navigation/converter/gui/renderer/GeocodingServiceListCellRenderer.java
@@ -22,11 +22,15 @@
 
 package slash.navigation.converter.gui.renderer;
 
+import java.awt.Component;
+
+import javax.swing.JLabel;
+import javax.swing.JList;
+import javax.swing.ListCellRenderer;
+
 import slash.navigation.geocoding.GeocodingService;
 import slash.navigation.gui.Application;
-
-import javax.swing.*;
-import java.awt.*;
+import slash.navigation.gui.renderer.BackendListCellRenderer;
 
 /**
  * Renders the {@link GeocodingService} labels of the geocoding service combo box.
@@ -34,8 +38,12 @@ import java.awt.*;
  * @author Christian Pesch
  */
 
-public class GeocodingServiceListCellRenderer extends DefaultListCellRenderer {
-    public Component getListCellRendererComponent(JList list, Object value, int index, boolean isSelected, boolean cellHasFocus) {
+public class GeocodingServiceListCellRenderer extends BackendListCellRenderer {
+    public GeocodingServiceListCellRenderer(ListCellRenderer backend) {
+		super(backend);
+	}
+
+	public Component getListCellRendererComponent(JList list, Object value, int index, boolean isSelected, boolean cellHasFocus) {
         JLabel label = (JLabel) super.getListCellRendererComponent(list, value, index, isSelected, cellHasFocus);
         GeocodingService service = (GeocodingService) value;
 

--- a/route-converter/src/main/java/slash/navigation/converter/gui/renderer/GoogleMapsServerListCellRenderer.java
+++ b/route-converter/src/main/java/slash/navigation/converter/gui/renderer/GoogleMapsServerListCellRenderer.java
@@ -20,10 +20,14 @@
 
 package slash.navigation.converter.gui.renderer;
 
-import slash.navigation.googlemaps.GoogleMapsServer;
+import java.awt.Component;
 
-import javax.swing.*;
-import java.awt.*;
+import javax.swing.JLabel;
+import javax.swing.JList;
+import javax.swing.ListCellRenderer;
+
+import slash.navigation.googlemaps.GoogleMapsServer;
+import slash.navigation.gui.renderer.BackendListCellRenderer;
 
 /**
  * Renders the {@link GoogleMapsServer} labels of the map server combo box.
@@ -31,8 +35,12 @@ import java.awt.*;
  * @author Christian Pesch
  */
 
-public class GoogleMapsServerListCellRenderer extends DefaultListCellRenderer {
-    public Component getListCellRendererComponent(JList list, Object value, int index, boolean isSelected, boolean cellHasFocus) {
+public class GoogleMapsServerListCellRenderer extends BackendListCellRenderer {
+    public GoogleMapsServerListCellRenderer(ListCellRenderer backend) {
+		super(backend);
+	}
+
+	public Component getListCellRendererComponent(JList list, Object value, int index, boolean isSelected, boolean cellHasFocus) {
         JLabel label = (JLabel) super.getListCellRendererComponent(list, value, index, isSelected, cellHasFocus);
         GoogleMapsServer googleMapsServer = (GoogleMapsServer) value;
 

--- a/route-converter/src/main/java/slash/navigation/converter/gui/renderer/LocaleListCellRenderer.java
+++ b/route-converter/src/main/java/slash/navigation/converter/gui/renderer/LocaleListCellRenderer.java
@@ -20,14 +20,18 @@
 
 package slash.navigation.converter.gui.renderer;
 
-import slash.navigation.converter.gui.RouteConverter;
+import static java.util.Locale.ROOT;
 
-import javax.swing.*;
-import java.awt.*;
+import java.awt.Component;
 import java.util.Locale;
 import java.util.MissingResourceException;
 
-import static java.util.Locale.ROOT;
+import javax.swing.JLabel;
+import javax.swing.JList;
+import javax.swing.ListCellRenderer;
+
+import slash.navigation.converter.gui.RouteConverter;
+import slash.navigation.gui.renderer.BackendListCellRenderer;
 
 /**
  * Renders the {@link Locale} labels of the language combo box.
@@ -35,8 +39,12 @@ import static java.util.Locale.ROOT;
  * @author Christian Pesch
  */
 
-public class LocaleListCellRenderer extends DefaultListCellRenderer {
-    public Component getListCellRendererComponent(JList list, Object value, int index, boolean isSelected, boolean cellHasFocus) {
+public class LocaleListCellRenderer extends BackendListCellRenderer {
+    public LocaleListCellRenderer(ListCellRenderer backend) {
+		super(backend);
+	}
+
+	public Component getListCellRendererComponent(JList list, Object value, int index, boolean isSelected, boolean cellHasFocus) {
         JLabel label = (JLabel) super.getListCellRendererComponent(list, value, index, isSelected, cellHasFocus);
         Locale locale = (Locale) value;
 

--- a/route-converter/src/main/java/slash/navigation/converter/gui/renderer/MapViewListCellRenderer.java
+++ b/route-converter/src/main/java/slash/navigation/converter/gui/renderer/MapViewListCellRenderer.java
@@ -22,14 +22,18 @@
 
 package slash.navigation.converter.gui.renderer;
 
+import java.awt.Component;
+import java.util.MissingResourceException;
+
+import javax.swing.JLabel;
+import javax.swing.JList;
+import javax.swing.ListCellRenderer;
+
 import slash.navigation.converter.gui.RouteConverter;
 import slash.navigation.converter.gui.helpers.MapViewImplementation;
 import slash.navigation.gui.Application;
+import slash.navigation.gui.renderer.BackendListCellRenderer;
 import slash.navigation.mapview.MapView;
-
-import javax.swing.*;
-import java.awt.*;
-import java.util.MissingResourceException;
 
 /**
  * Renders the {@link MapView} labels of the map view combo box.
@@ -37,8 +41,12 @@ import java.util.MissingResourceException;
  * @author Christian Pesch
  */
 
-public class MapViewListCellRenderer extends DefaultListCellRenderer {
-    public Component getListCellRendererComponent(JList list, Object value, int index, boolean isSelected, boolean cellHasFocus) {
+public class MapViewListCellRenderer extends BackendListCellRenderer {
+    public MapViewListCellRenderer(ListCellRenderer backend) {
+		super(backend);
+	}
+
+	public Component getListCellRendererComponent(JList list, Object value, int index, boolean isSelected, boolean cellHasFocus) {
         JLabel label = (JLabel) super.getListCellRendererComponent(list, value, index, isSelected, cellHasFocus);
         MapViewImplementation mapView = (MapViewImplementation) value;
         String text;

--- a/route-converter/src/main/java/slash/navigation/converter/gui/renderer/NavigationPositionListCellRenderer.java
+++ b/route-converter/src/main/java/slash/navigation/converter/gui/renderer/NavigationPositionListCellRenderer.java
@@ -20,10 +20,14 @@
 
 package slash.navigation.converter.gui.renderer;
 
-import slash.navigation.common.NavigationPosition;
+import java.awt.Component;
 
-import javax.swing.*;
-import java.awt.*;
+import javax.swing.JLabel;
+import javax.swing.JList;
+import javax.swing.ListCellRenderer;
+
+import slash.navigation.common.NavigationPosition;
+import slash.navigation.gui.renderer.BackendListCellRenderer;
 
 /**
  * Renders the position labels of the position list.
@@ -31,8 +35,12 @@ import java.awt.*;
  * @author Christian Pesch
  */
 
-public class NavigationPositionListCellRenderer extends DefaultListCellRenderer {
-    public Component getListCellRendererComponent(JList list, Object value, int index, boolean isSelected, boolean cellHasFocus) {
+public class NavigationPositionListCellRenderer extends BackendListCellRenderer {
+    public NavigationPositionListCellRenderer(ListCellRenderer backend) {
+		super(backend);
+	}
+
+	public Component getListCellRendererComponent(JList list, Object value, int index, boolean isSelected, boolean cellHasFocus) {
         JLabel label = (JLabel) super.getListCellRendererComponent(list, value, index, isSelected, cellHasFocus);
         NavigationPosition position = (NavigationPosition) value;
         label.setText(position.getDescription() + " @ " + position.getLongitude() + "," + position.getLatitude());

--- a/route-converter/src/main/java/slash/navigation/converter/gui/renderer/NumberPatternListCellRenderer.java
+++ b/route-converter/src/main/java/slash/navigation/converter/gui/renderer/NumberPatternListCellRenderer.java
@@ -20,12 +20,16 @@
 
 package slash.navigation.converter.gui.renderer;
 
+import java.awt.Component;
+import java.util.MissingResourceException;
+
+import javax.swing.JLabel;
+import javax.swing.JList;
+import javax.swing.ListCellRenderer;
+
 import slash.navigation.common.NumberPattern;
 import slash.navigation.converter.gui.RouteConverter;
-
-import javax.swing.*;
-import java.awt.*;
-import java.util.MissingResourceException;
+import slash.navigation.gui.renderer.BackendListCellRenderer;
 
 /**
  * Renders the {@link NumberPattern} labels of the options dialog combo box.
@@ -33,9 +37,13 @@ import java.util.MissingResourceException;
  * @author Christian Pesch
  */
 
-public class NumberPatternListCellRenderer extends DefaultListCellRenderer {
+public class NumberPatternListCellRenderer extends BackendListCellRenderer {
 
-    public Component getListCellRendererComponent(JList list, Object value, int index, boolean isSelected, boolean cellHasFocus) {
+    public NumberPatternListCellRenderer(ListCellRenderer backend) {
+		super(backend);
+	}
+
+	public Component getListCellRendererComponent(JList list, Object value, int index, boolean isSelected, boolean cellHasFocus) {
         JLabel label = (JLabel) super.getListCellRendererComponent(list, value, index, isSelected, cellHasFocus);
         NumberPattern numberPattern = (NumberPattern) value;
         String text;

--- a/route-converter/src/main/java/slash/navigation/converter/gui/renderer/NumberingStrategyListCellRenderer.java
+++ b/route-converter/src/main/java/slash/navigation/converter/gui/renderer/NumberingStrategyListCellRenderer.java
@@ -20,12 +20,16 @@
 
 package slash.navigation.converter.gui.renderer;
 
+import java.awt.Component;
+import java.util.MissingResourceException;
+
+import javax.swing.JLabel;
+import javax.swing.JList;
+import javax.swing.ListCellRenderer;
+
 import slash.navigation.common.NumberingStrategy;
 import slash.navigation.converter.gui.RouteConverter;
-
-import javax.swing.*;
-import java.awt.*;
-import java.util.MissingResourceException;
+import slash.navigation.gui.renderer.BackendListCellRenderer;
 
 /**
  * Renders the {@link NumberingStrategy} labels of the options dialog combo box.
@@ -33,9 +37,14 @@ import java.util.MissingResourceException;
  * @author Christian Pesch
  */
 
-public class NumberingStrategyListCellRenderer extends DefaultListCellRenderer {
+public class NumberingStrategyListCellRenderer extends BackendListCellRenderer {
 
-    public Component getListCellRendererComponent(JList list, Object value, int index, boolean isSelected, boolean cellHasFocus) {
+    public NumberingStrategyListCellRenderer(ListCellRenderer backend) {
+		super(backend);
+		// TODO Auto-generated constructor stub
+	}
+
+	public Component getListCellRendererComponent(JList list, Object value, int index, boolean isSelected, boolean cellHasFocus) {
         JLabel label = (JLabel) super.getListCellRendererComponent(list, value, index, isSelected, cellHasFocus);
         NumberingStrategy numberingStrategy = (NumberingStrategy) value;
         String text;

--- a/route-converter/src/main/java/slash/navigation/converter/gui/renderer/RouteCharacteristicsListCellRenderer.java
+++ b/route-converter/src/main/java/slash/navigation/converter/gui/renderer/RouteCharacteristicsListCellRenderer.java
@@ -20,12 +20,16 @@
 
 package slash.navigation.converter.gui.renderer;
 
+import java.awt.Component;
+import java.util.MissingResourceException;
+
+import javax.swing.JLabel;
+import javax.swing.JList;
+import javax.swing.ListCellRenderer;
+
 import slash.navigation.base.RouteCharacteristics;
 import slash.navigation.converter.gui.RouteConverter;
-
-import javax.swing.*;
-import java.awt.*;
-import java.util.MissingResourceException;
+import slash.navigation.gui.renderer.BackendListCellRenderer;
 
 /**
  * Renders the route characteristic labels of the type combo box.
@@ -33,9 +37,13 @@ import java.util.MissingResourceException;
  * @author Christian Pesch
  */
 
-public class RouteCharacteristicsListCellRenderer extends DefaultListCellRenderer {
+public class RouteCharacteristicsListCellRenderer extends BackendListCellRenderer {
 
-    public Component getListCellRendererComponent(JList list, Object value, int index, boolean isSelected, boolean cellHasFocus) {
+    public RouteCharacteristicsListCellRenderer(ListCellRenderer backend) {
+		super(backend);
+	}
+
+	public Component getListCellRendererComponent(JList list, Object value, int index, boolean isSelected, boolean cellHasFocus) {
         JLabel label = (JLabel) super.getListCellRendererComponent(list, value, index, isSelected, cellHasFocus);
         RouteCharacteristics characteristics = (RouteCharacteristics) value;
         String text = "?";

--- a/route-converter/src/main/java/slash/navigation/converter/gui/renderer/RouteListCellRenderer.java
+++ b/route-converter/src/main/java/slash/navigation/converter/gui/renderer/RouteListCellRenderer.java
@@ -20,12 +20,16 @@
 
 package slash.navigation.converter.gui.renderer;
 
+import java.awt.Component;
+import java.util.MissingResourceException;
+
+import javax.swing.JLabel;
+import javax.swing.JList;
+import javax.swing.ListCellRenderer;
+
 import slash.navigation.base.BaseRoute;
 import slash.navigation.converter.gui.RouteConverter;
-
-import javax.swing.*;
-import java.awt.*;
-import java.util.MissingResourceException;
+import slash.navigation.gui.renderer.BackendListCellRenderer;
 
 /**
  * Renders the route labels of the route combo box.
@@ -33,8 +37,12 @@ import java.util.MissingResourceException;
  * @author Christian Pesch
  */
 
-public class RouteListCellRenderer extends DefaultListCellRenderer {
-    public Component getListCellRendererComponent(JList list, Object value, int index, boolean isSelected, boolean cellHasFocus) {
+public class RouteListCellRenderer extends BackendListCellRenderer {
+    public RouteListCellRenderer(ListCellRenderer backend) {
+		super(backend);
+	}
+
+	public Component getListCellRendererComponent(JList list, Object value, int index, boolean isSelected, boolean cellHasFocus) {
         JLabel label = (JLabel) super.getListCellRendererComponent(list, value, index, isSelected, cellHasFocus);
         BaseRoute route = (BaseRoute) value;
         String text = "?";

--- a/route-converter/src/main/java/slash/navigation/converter/gui/renderer/RoutingServiceListCellRenderer.java
+++ b/route-converter/src/main/java/slash/navigation/converter/gui/renderer/RoutingServiceListCellRenderer.java
@@ -22,11 +22,15 @@
 
 package slash.navigation.converter.gui.renderer;
 
-import slash.navigation.gui.Application;
-import slash.navigation.routing.RoutingService;
+import java.awt.Component;
 
-import javax.swing.*;
-import java.awt.*;
+import javax.swing.JLabel;
+import javax.swing.JList;
+import javax.swing.ListCellRenderer;
+
+import slash.navigation.gui.Application;
+import slash.navigation.gui.renderer.BackendListCellRenderer;
+import slash.navigation.routing.RoutingService;
 
 /**
  * Renders the {@link RoutingService} labels of the routing service combo box.
@@ -34,8 +38,12 @@ import java.awt.*;
  * @author Christian Pesch
  */
 
-public class RoutingServiceListCellRenderer extends DefaultListCellRenderer {
-    public Component getListCellRendererComponent(JList list, Object value, int index, boolean isSelected, boolean cellHasFocus) {
+public class RoutingServiceListCellRenderer extends BackendListCellRenderer {
+    public RoutingServiceListCellRenderer(ListCellRenderer backend) {
+		super(backend);
+	}
+
+	public Component getListCellRendererComponent(JList list, Object value, int index, boolean isSelected, boolean cellHasFocus) {
         JLabel label = (JLabel) super.getListCellRendererComponent(list, value, index, isSelected, cellHasFocus);
         RoutingService service = (RoutingService) value;
         String text = service.getName();

--- a/route-converter/src/main/java/slash/navigation/converter/gui/renderer/TagStrategyListCellRenderer.java
+++ b/route-converter/src/main/java/slash/navigation/converter/gui/renderer/TagStrategyListCellRenderer.java
@@ -20,12 +20,16 @@
 
 package slash.navigation.converter.gui.renderer;
 
+import java.awt.Component;
+import java.util.MissingResourceException;
+
+import javax.swing.JLabel;
+import javax.swing.JList;
+import javax.swing.ListCellRenderer;
+
 import slash.navigation.converter.gui.RouteConverter;
 import slash.navigation.converter.gui.helpers.TagStrategy;
-
-import javax.swing.*;
-import java.awt.*;
-import java.util.MissingResourceException;
+import slash.navigation.gui.renderer.BackendListCellRenderer;
 
 /**
  * Renders the {@link TagStrategy} labels of the photo panel combo box.
@@ -33,9 +37,13 @@ import java.util.MissingResourceException;
  * @author Christian Pesch
  */
 
-public class TagStrategyListCellRenderer extends DefaultListCellRenderer {
+public class TagStrategyListCellRenderer extends BackendListCellRenderer {
 
-    public Component getListCellRendererComponent(JList list, Object value, int index, boolean isSelected, boolean cellHasFocus) {
+    public TagStrategyListCellRenderer(ListCellRenderer backend) {
+		super(backend);
+	}
+
+	public Component getListCellRendererComponent(JList list, Object value, int index, boolean isSelected, boolean cellHasFocus) {
         JLabel label = (JLabel) super.getListCellRendererComponent(list, value, index, isSelected, cellHasFocus);
         TagStrategy tagStrategy = (TagStrategy) value;
         String text;

--- a/route-converter/src/main/java/slash/navigation/converter/gui/renderer/TimeZoneAndIdListCellRenderer.java
+++ b/route-converter/src/main/java/slash/navigation/converter/gui/renderer/TimeZoneAndIdListCellRenderer.java
@@ -22,10 +22,14 @@
 
 package slash.navigation.converter.gui.renderer;
 
-import slash.common.helpers.TimeZoneAndId;
+import java.awt.Component;
 
-import javax.swing.*;
-import java.awt.*;
+import javax.swing.JLabel;
+import javax.swing.JList;
+import javax.swing.ListCellRenderer;
+
+import slash.common.helpers.TimeZoneAndId;
+import slash.navigation.gui.renderer.BackendListCellRenderer;
 
 /**
  * Renders the {@link TimeZoneAndId} labels of the timezone combo boxes.
@@ -33,9 +37,13 @@ import java.awt.*;
  * @author Christian Pesch
  */
 
-public class TimeZoneAndIdListCellRenderer extends DefaultListCellRenderer {
+public class TimeZoneAndIdListCellRenderer extends BackendListCellRenderer {
 
-    public Component getListCellRendererComponent(JList list, Object value, int index, boolean isSelected, boolean cellHasFocus) {
+    public TimeZoneAndIdListCellRenderer(ListCellRenderer backend) {
+		super(backend);
+	}
+
+	public Component getListCellRendererComponent(JList list, Object value, int index, boolean isSelected, boolean cellHasFocus) {
         JLabel label = (JLabel) super.getListCellRendererComponent(list, value, index, isSelected, cellHasFocus);
         TimeZoneAndId timeZoneAndId = (TimeZoneAndId) value;
         String text = timeZoneAndId.getId() + " (" + timeZoneAndId.getTimeZone().getDisplayName() + ")";

--- a/route-converter/src/main/java/slash/navigation/converter/gui/renderer/TravelModeListCellRenderer.java
+++ b/route-converter/src/main/java/slash/navigation/converter/gui/renderer/TravelModeListCellRenderer.java
@@ -20,12 +20,16 @@
 
 package slash.navigation.converter.gui.renderer;
 
-import slash.navigation.converter.gui.RouteConverter;
-import slash.navigation.routing.TravelMode;
-
-import javax.swing.*;
-import java.awt.*;
+import java.awt.Component;
 import java.util.MissingResourceException;
+
+import javax.swing.JLabel;
+import javax.swing.JList;
+import javax.swing.ListCellRenderer;
+
+import slash.navigation.converter.gui.RouteConverter;
+import slash.navigation.gui.renderer.BackendListCellRenderer;
+import slash.navigation.routing.TravelMode;
 
 /**
  * Renders the {@link TravelMode} labels of the route travel mode combo box.
@@ -33,8 +37,12 @@ import java.util.MissingResourceException;
  * @author Christian Pesch
  */
 
-public class TravelModeListCellRenderer extends DefaultListCellRenderer {
-    public Component getListCellRendererComponent(JList list, Object value, int index, boolean isSelected, boolean cellHasFocus) {
+public class TravelModeListCellRenderer extends BackendListCellRenderer {
+    public TravelModeListCellRenderer(ListCellRenderer backend) {
+		super(backend);
+	}
+
+	public Component getListCellRendererComponent(JList list, Object value, int index, boolean isSelected, boolean cellHasFocus) {
         JLabel label = (JLabel) super.getListCellRendererComponent(list, value, index, isSelected, cellHasFocus);
         TravelMode travelMode = (TravelMode) value;
         String text;

--- a/route-converter/src/main/java/slash/navigation/converter/gui/renderer/UnitSystemListCellRenderer.java
+++ b/route-converter/src/main/java/slash/navigation/converter/gui/renderer/UnitSystemListCellRenderer.java
@@ -22,12 +22,16 @@
 
 package slash.navigation.converter.gui.renderer;
 
+import java.awt.Component;
+import java.util.MissingResourceException;
+
+import javax.swing.JLabel;
+import javax.swing.JList;
+import javax.swing.ListCellRenderer;
+
 import slash.navigation.common.UnitSystem;
 import slash.navigation.converter.gui.RouteConverter;
-
-import javax.swing.*;
-import java.awt.*;
-import java.util.MissingResourceException;
+import slash.navigation.gui.renderer.BackendListCellRenderer;
 
 /**
  * Renders the {@link UnitSystem} labels of the unit system combo box.
@@ -35,8 +39,12 @@ import java.util.MissingResourceException;
  * @author Christian Pesch
  */
 
-public class UnitSystemListCellRenderer extends DefaultListCellRenderer {
-    public Component getListCellRendererComponent(JList list, Object value, int index, boolean isSelected, boolean cellHasFocus) {
+public class UnitSystemListCellRenderer extends BackendListCellRenderer {
+    public UnitSystemListCellRenderer(ListCellRenderer backend) {
+		super(backend);
+	}
+
+	public Component getListCellRendererComponent(JList list, Object value, int index, boolean isSelected, boolean cellHasFocus) {
         JLabel label = (JLabel) super.getListCellRendererComponent(list, value, index, isSelected, cellHasFocus);
         UnitSystem unitSystem = (UnitSystem) value;
         String text;

--- a/route-converter/src/main/java/slash/navigation/converter/gui/renderer/WaypointTypeListCellRenderer.java
+++ b/route-converter/src/main/java/slash/navigation/converter/gui/renderer/WaypointTypeListCellRenderer.java
@@ -20,12 +20,16 @@
 
 package slash.navigation.converter.gui.renderer;
 
+import java.awt.Component;
+import java.util.MissingResourceException;
+
+import javax.swing.JLabel;
+import javax.swing.JList;
+import javax.swing.ListCellRenderer;
+
 import slash.navigation.base.WaypointType;
 import slash.navigation.converter.gui.RouteConverter;
-
-import javax.swing.*;
-import java.awt.*;
-import java.util.MissingResourceException;
+import slash.navigation.gui.renderer.BackendListCellRenderer;
 
 /**
  * Renders the {@link WaypointType} labels of the complete flight plan waypoint type combo box.
@@ -33,8 +37,12 @@ import java.util.MissingResourceException;
  * @author Christian Pesch
  */
 
-public class WaypointTypeListCellRenderer extends DefaultListCellRenderer {
-    public Component getListCellRendererComponent(JList list, Object value, int index, boolean isSelected, boolean cellHasFocus) {
+public class WaypointTypeListCellRenderer extends BackendListCellRenderer {
+    public WaypointTypeListCellRenderer(ListCellRenderer backend) {
+		super(backend);
+	}
+
+	public Component getListCellRendererComponent(JList list, Object value, int index, boolean isSelected, boolean cellHasFocus) {
         JLabel label = (JLabel) super.getListCellRendererComponent(list, value, index, isSelected, cellHasFocus);
         WaypointType waypointType = (WaypointType) value;
         String text = "?";

--- a/tileserver-maps/src/main/java/slash/navigation/maps/item/ItemWideComboBox.java
+++ b/tileserver-maps/src/main/java/slash/navigation/maps/item/ItemWideComboBox.java
@@ -1,0 +1,39 @@
+package slash.navigation.maps.item;
+
+import java.awt.Dimension;
+
+import javax.swing.JComboBox; 
+ 
+// Taken from http://www.jroller.com/santhosh/entry/make_jcombobox_popup_wide_enough
+//
+// got this workaround from the following bug: 
+//      http://bugs.sun.com/bugdatabase/view_bug.do?bug_id=4618607 
+public class ItemWideComboBox<E extends Item> extends JComboBox<E>{ 
+    private boolean layingOut = false; 
+ 
+    public void doLayout(){ 
+        try{ 
+            layingOut = true; 
+            super.doLayout(); 
+        }finally{ 
+            layingOut = false; 
+        } 
+    } 
+ 
+    public Dimension getSize(){ 
+        Dimension dim = super.getSize(); 
+        
+        if (!layingOut) {
+        	for (int i = 0; i < getItemCount(); i++) {
+        		Item item = getItemAt(i);
+        		
+        		if(item.getDescription() != null) {
+        			dim.width = Math.max(dim.width, getFontMetrics(getFont()).stringWidth(item.getDescription())+30);
+        		}
+        	}
+            dim.width = Math.max(dim.width, getPreferredSize().width);
+        }
+        
+        return dim; 
+    }
+}


### PR DESCRIPTION
When loading KML files that were saved by RouteConverter the name of the position lists keep adding "/Waypoints:" or "/Track:" at the beginning. So this change checks for those and removes them.

On small screens the popup of the JComboBoxes for map and map style selection are too small to be able to see the full description of the entries, so one sometimes doesn't see what to select. This changes the popup size to be at least as wide as the entry with the widest description.