### PR TITLE
feedback: send full Locale.toString() on error-report + update-check

### DIFF
--- a/feedback/src/main/java/slash/navigation/feedback/domain/RouteFeedback.java
+++ b/feedback/src/main/java/slash/navigation/feedback/domain/RouteFeedback.java
@@ -128,6 +128,7 @@ public class RouteFeedback {
         Post request = new Post(errorReportUrl, credentials);
         request.addString("log", logOutput);
         request.addString("description", description);
+        request.addString("locale", getDefault().toString());
         if (file != null)
             request.addFile("file", file);
 
@@ -156,7 +157,7 @@ public class RouteFeedback {
         request.addString("javaBits", javaBits);
         request.addString("javaVersion", javaVersion);
         request.addString("javaFxVersion", javaFxVersion);
-        request.addString("locale", getDefault().getLanguage());
+        request.addString("locale", getDefault().toString());
         request.addString("osArch", osArch);
         request.addString("osName", osName);
         request.addString("osVersion", osVersion);


### PR DESCRIPTION
## Summary

Phase A of [docs/00028 — multilingual error-report ack](https://github.com/cpesch/rc-meta/blob/main/docs/00028-multilingual-error-report-ack.md) (rc-meta plan).

- `sendErrorReport()` now posts `locale=<Locale.getDefault().toString()>` (e.g. `de_DE`, `pt_BR`) so the Django side can pick a per-locale acknowledgement template.
- `checkForUpdate()` switches `locale` from `getLanguage()` to `toString()` so the first-known-wins `UserProfile.locale` backfill keeps region info. Without this, update-check (fires every RC start) would beat error-report to the first write and lock the row to bare language, hiding region-distinct templates (`pt_BR` vs `pt_PT`, `nb_NO` vs `nb`).

`getUpdateCheckUrl()` keeps `getLanguage()` — that path is content selection, language-only by design.

Back-compat: Django side accepts absent `locale` and falls back through `UserProfile.locale` → `'en'`, so old clients keep working until users upgrade.

## Test plan

- [ ] `mvn -pl feedback verify` — feedback unit + IT pass against staging
- [ ] Manual: trigger error report from RC, confirm `ErrorReport.locale` row in `feedback_errorreport` carries `de_DE` (or equivalent)
- [ ] Manual: trigger update-check from RC, confirm `UserProfile.locale` backfilled with full toString form