### PR TITLE
fix(download): drop ETag on outdated file so re-download is unconditional

### DIFF
--- a/download/src/main/java/slash/navigation/download/DownloadManager.java
+++ b/download/src/main/java/slash/navigation/download/DownloadManager.java
@@ -307,6 +307,10 @@ public class DownloadManager {
                 if (!validator.isChecksumsValid()) {
                     log.info("Found outdated download " + download);
 
+                    // drop the ETag so the re-download issues an unconditional GET:
+                    // a corrupt/outdated local file must be re-fetched, otherwise the
+                    // conditional request keeps returning 304 and the file is never replaced
+                    download.setETag(null);
                     download.setState(Outdated);
                     getModel().updateDownload(download);
 

--- a/download/src/test/java/slash/navigation/download/DownloadManager304Test.java
+++ b/download/src/test/java/slash/navigation/download/DownloadManager304Test.java
@@ -29,15 +29,18 @@ import java.io.IOException;
 import java.io.OutputStream;
 import java.net.InetSocketAddress;
 import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
 import java.util.concurrent.atomic.AtomicInteger;
 
 import static java.io.File.createTempFile;
 import static java.util.Collections.singletonList;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
 import static slash.common.io.InputOutput.readFileToString;
 import static slash.navigation.download.Action.Copy;
 import static slash.navigation.download.State.NotModified;
+import static slash.navigation.download.State.Outdated;
 import static slash.navigation.download.State.Succeeded;
 
 /**
@@ -119,6 +122,32 @@ public class DownloadManager304Test {
         assertEquals(1, bodiesServed.get());
         assertEquals(lengthAfterFirst, target.length());
         assertEquals(lastModifiedAfterFirst, target.lastModified());
+        assertEquals(BODY, readFileToString(target));
+    }
+
+    @Test
+    public void testOutdatedFileDropsETagSoReDownloadIsUnconditional() throws IOException {
+        // first download stores the ETag and a valid target
+        Checksum expected = new Checksum(null, (long) BODY.length(), null);
+        Download download = manager.queueForDownload("resource", url(), Copy, new FileAndChecksum(target, expected), null);
+        manager.waitForCompletion(singletonList(download));
+        assertEquals(Succeeded, download.getState());
+        assertNotNull(download.getETag());
+        assertEquals(1, bodiesServed.get());
+
+        // corrupt the target on disk so its checksum no longer matches the expected one
+        Files.writeString(target.toPath(), "corrupt local content of a different length");
+
+        // scan detects the mismatch, marks the download Outdated and drops the now-stale ETag
+        manager.scanForOutdatedFilesInQueue();
+        assertEquals(Outdated, download.getState());
+        assertNull(download.getETag());
+
+        // re-download must send no If-None-Match -> server answers 200 and overwrites the corrupt file
+        Download second = manager.queueForDownload("resource", url(), Copy, new FileAndChecksum(target, expected), null);
+        manager.waitForCompletion(singletonList(second));
+        assertEquals(Succeeded, second.getState());
+        assertEquals(2, bodiesServed.get());
         assertEquals(BODY, readFileToString(target));
     }
 }


### PR DESCRIPTION
## Problem

A corrupt or outdated local target whose checksum no longer matches kept its stored ETag. `scanForOutdatedFilesInQueue` marked it `Outdated` and re-queued it, but the re-download still sent `If-None-Match`, so the server answered `304 Not Modified` and the bad file was never overwritten — an endless loop.

Observed in the wild (error report 1311): a stale `world.map` (1403310 bytes vs expected 111927, a 2014 file) survived every restart across 13 sessions / builds 74–89, leaving the map blank.

## Fix

Clear the ETag when marking a download `Outdated` so the re-download issues an unconditional GET, gets 200 with a body, and replaces the file.

## Test

Adds a hermetic regression test (`DownloadManager304Test`) covering the full corrupt → re-fetch cycle: corrupt the target, scan marks it Outdated + drops ETag, re-download serves a 200 body and restores the file. `download/` module green (75 tests).