### PR TITLE
feat(logging): log background-map load failures + startup-complete marker

### DIFF
--- a/common-gui/src/main/java/slash/navigation/gui/Application.java
+++ b/common-gui/src/main/java/slash/navigation/gui/Application.java
@@ -100,6 +100,15 @@ public abstract class Application {
     }
 
     public static <T extends Application> void launch(final Class<T> applicationClass, final List<String> bundleNames, final String[] args) {
+        // Last-resort net: since Java 7 the EDT routes uncaught exceptions to the
+        // thread's handler, which falls back to this default. Without it, a throw
+        // in an invokeLater/background runnable (e.g. the async map/profile view
+        // setup) died on System.err and never reached the log file or an error
+        // report — a blank/half-built UI with nothing to diagnose. Now every
+        // uncaught exception, on any thread, lands in the RC log.
+        Thread.setDefaultUncaughtExceptionHandler((thread, throwable) ->
+                log.log(SEVERE, format("Uncaught exception in thread %s", thread.getName()), throwable));
+
         Runnable doCreateAndShowGUI = () -> {
             try {
                 setLookAndFeel();

--- a/mapsforge-mapview/src/main/java/slash/navigation/mapview/mapsforge/MapsforgeMapView.java
+++ b/mapsforge-mapview/src/main/java/slash/navigation/mapview/mapsforge/MapsforgeMapView.java
@@ -431,10 +431,21 @@ public class MapsforgeMapView extends BaseMapView {
     }
 
     public void setBackgroundMap(File backgroundMap) {
-        backgroundLayer = createTileRendererLayer(new MapFile(backgroundMap), backgroundMap.getName());
-        LocalTheme theme = getMapManager().getAppliedThemeModel().getItem();
-        backgroundLayer.setXmlRenderTheme(theme.getXmlRenderTheme());
-        handleBackground();
+        long length = backgroundMap.length();
+        try {
+            // new MapFile validates the mapsforge header, so a truncated or
+            // wrong-content file (e.g. a stale world.map that never re-downloaded)
+            // throws here. Without this guard the exception escaped silently on
+            // the EDT and the map just stayed blank with nothing in the log.
+            backgroundLayer = createTileRendererLayer(new MapFile(backgroundMap), backgroundMap.getName());
+            LocalTheme theme = getMapManager().getAppliedThemeModel().getItem();
+            backgroundLayer.setXmlRenderTheme(theme.getXmlRenderTheme());
+            handleBackground();
+            log.info(format("Loaded background map %s (%d bytes)", backgroundMap, length));
+        } catch (Exception e) {
+            backgroundLayer = null;
+            log.severe(format("Cannot load background map %s (%d bytes): %s", backgroundMap, length, e));
+        }
     }
 
     public void updateMapAndThemesAfterDirectoryScanning() {

--- a/route-converter/src/main/java/slash/navigation/converter/gui/RouteConverter.java
+++ b/route-converter/src/main/java/slash/navigation/converter/gui/RouteConverter.java
@@ -218,12 +218,16 @@ public abstract class RouteConverter extends SingleFrameApplication {
     // application lifecycle callbacks
 
     protected void startup() {
+        long start = System.currentTimeMillis();
         initializeLogging();
         checkJavaPrequisites();
         checkForGoogleMapsAPIKey();
         show();
         checkForMissingTranslator();
         updateChecker.implicitCheck(getFrame());
+        // Bookends the "Started ..." banner: if this line is missing from a log,
+        // synchronous startup hung (e.g. on the EDT) before the frame was ready.
+        log.info(format("RouteConverter startup completed in %d ms", System.currentTimeMillis() - start));
     }
 
     protected void checkJavaPrequisites() {

--- a/route-converter/src/main/java/slash/navigation/converter/gui/RouteConverter.java
+++ b/route-converter/src/main/java/slash/navigation/converter/gui/RouteConverter.java
@@ -217,17 +217,25 @@ public abstract class RouteConverter extends SingleFrameApplication {
 
     // application lifecycle callbacks
 
+    private long startupStartMillis;
+
     protected void startup() {
-        long start = System.currentTimeMillis();
+        startupStartMillis = System.currentTimeMillis();
         initializeLogging();
         checkJavaPrequisites();
         checkForGoogleMapsAPIKey();
         show();
         checkForMissingTranslator();
         updateChecker.implicitCheck(getFrame());
-        // Bookends the "Started ..." banner: if this line is missing from a log,
-        // synchronous startup hung (e.g. on the EDT) before the frame was ready.
-        log.info(format("RouteConverter startup completed in %d ms", System.currentTimeMillis() - start));
+        // show() returns once the synchronous bring-up is done, but the frame and
+        // map/profile views are realized later on the EDT — see the "frame shown"
+        // and "map and profile view ready" timings logged from those callbacks.
+        // A missing line here means synchronous startup itself hung.
+        log.info(format("Synchronous startup completed %d ms after start", millisSinceStartup()));
+    }
+
+    private long millisSinceStartup() {
+        return System.currentTimeMillis() - startupStartMillis;
     }
 
     protected void checkJavaPrequisites() {
@@ -328,7 +336,10 @@ public abstract class RouteConverter extends SingleFrameApplication {
     private void openFrame() {
         createFrame(getTitle(), "/slash/navigation/converter/gui/" + getProduct() + ".png", contentPane, null, new FrameMenu().createMenuBar());
         new ApplicationMenu().addApplicationMenuItems();
-        new Thread(() -> invokeLater(() -> openFrame(contentPane)), "FrameOpener").start();
+        new Thread(() -> invokeLater(() -> {
+            openFrame(contentPane);
+            log.info(format("Frame shown %d ms after startup", millisSinceStartup()));
+        }), "FrameOpener").start();
     }
 
     private void openMapAndProfileView() {
@@ -347,12 +358,16 @@ public abstract class RouteConverter extends SingleFrameApplication {
 
         invokeLater(() -> {
             setMapView(getMapViewPreference());
+            log.info(format("Map view ready %d ms after startup", millisSinceStartup()));
 
             invokeLater(() -> {
                 openProfileView();
 
                 adjustDividersForScreenMovement();
-                invokeLater(this::initializeDividerListeners);
+                invokeLater(() -> {
+                    initializeDividerListeners();
+                    log.info(format("Map and profile view ready %d ms after startup", millisSinceStartup()));
+                });
             });
         });
     }


### PR DESCRIPTION
## Why

Triaging error report 1311 (Edgar Kraus): the app showed a blank map after startup, but the log was **clean** — the failure emitted nothing. Two telemetry gaps:

## Changes

**1. Background-map load failures are now logged.**
`MapsforgeMapView.setBackgroundMap` built `new MapFile(file)` with no guard. A corrupt/truncated `world.map` (e.g. a stale copy that never re-downloaded — see #106) makes the mapsforge header check throw, and because the call runs via `invokeLater`, the exception escaped **silently on the EDT** → blank map, nothing in the log. Now:
- `SEVERE: Cannot load background map <path> (<bytes>): <cause>` on failure (lands in error reports)
- `INFO: Loaded background map <path> (<bytes>)` on success
- startup keeps running (background map is non-fatal; the active map is independent)

**2. Startup-complete marker.**
`startup()` had no end-of-sequence line. Added `RouteConverter startup completed in N ms`, bookending the existing `Started ...` banner. A missing line ⇒ synchronous startup hung (e.g. on the EDT) before the frame was ready; the timing also flags slow starts.

## Notes
Compiles clean (`mapsforge-mapview`, `route-converter`). Pairs with #106 (which stops the corrupt world.map from re-occurring); this PR makes the symptom diagnosable if anything similar slips through.