### PR TITLE
test: raise coverage across 5 weak spots tied to recent bugs

### DIFF
--- a/download/src/test/java/slash/navigation/download/DownloadManagerStateMachineTest.java
+++ b/download/src/test/java/slash/navigation/download/DownloadManagerStateMachineTest.java
@@ -1,0 +1,262 @@
+/*
+    This file is part of RouteConverter.
+
+    RouteConverter is free software; you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation; either version 2 of the License, or
+    (at your option) any later version.
+
+    RouteConverter is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with RouteConverter; if not, write to the Free Software
+    Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
+
+    Copyright (C) 2007 Christian Pesch. All Rights Reserved.
+*/
+package slash.navigation.download;
+
+import com.sun.net.httpserver.HttpServer;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.io.File;
+import java.io.IOException;
+import java.io.OutputStream;
+import java.net.InetSocketAddress;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.util.EnumSet;
+import java.util.Set;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.zip.ZipEntry;
+import java.util.zip.ZipOutputStream;
+
+import static java.io.File.createTempFile;
+import static java.util.Collections.singletonList;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
+import static slash.common.io.Files.generateChecksum;
+import static slash.common.io.InputOutput.readFileToString;
+import static slash.navigation.download.Action.Copy;
+import static slash.navigation.download.Action.Extract;
+import static slash.navigation.download.State.Outdated;
+import static slash.navigation.download.State.Succeeded;
+
+/**
+ * Hermetic (no external network) tests of the download state machine, covering the paths that
+ * recently broke: ETag/304 conditional GET with a corrupt local target, Extract with/without
+ * fragments, and resume/partial-content. Uses a local {@link HttpServer} so they run in the
+ * unit (Surefire) phase rather than the network-gated {@link DownloadManagerIT}.
+ *
+ * @author Christian Pesch
+ */
+public class DownloadManagerStateMachineTest {
+    private static final String ENTRY_NAME = "first/second/447bytes.txt";
+    private static final String ENTRY_BODY = "Lorem ipsum dolor sit amet, consectetur adipisicing elit";
+    private static final String PLAIN_BODY = "0123456789ABCDEFGHIJ0123456789ABCDEFGHIJ"; // 40 bytes
+    private static final String ETAG = "\"state-machine\"";
+
+    private HttpServer server;
+    private final AtomicInteger bodiesServed = new AtomicInteger();
+    private final AtomicInteger partialServed = new AtomicInteger();
+    private final AtomicInteger conditional304 = new AtomicInteger();
+    private byte[] zipBytes;
+
+    private DownloadManager manager;
+    private File queueFile, target, targetDirectory;
+
+    @Before
+    public void setUp() throws IOException {
+        zipBytes = buildZip(ENTRY_NAME, ENTRY_BODY.getBytes(StandardCharsets.UTF_8));
+        server = HttpServer.create(new InetSocketAddress("127.0.0.1", 0), 0);
+
+        server.createContext("/archive.zip", exchange -> {
+            String ifNoneMatch = exchange.getRequestHeaders().getFirst("If-None-Match");
+            exchange.getResponseHeaders().add("ETag", ETAG);
+            if (ETAG.equals(ifNoneMatch)) {
+                conditional304.incrementAndGet();
+                exchange.sendResponseHeaders(304, -1);
+            } else {
+                exchange.sendResponseHeaders(200, zipBytes.length);
+                try (OutputStream out = exchange.getResponseBody()) { out.write(zipBytes); }
+                bodiesServed.incrementAndGet();
+            }
+            exchange.close();
+        });
+
+        server.createContext("/plain.txt", exchange -> {
+            byte[] body = PLAIN_BODY.getBytes(StandardCharsets.UTF_8);
+            String range = exchange.getRequestHeaders().getFirst("Range");
+            if (range != null && range.startsWith("bytes=")) {
+                int start = parseRangeStart(range);
+                byte[] remainder = new byte[body.length - start];
+                System.arraycopy(body, start, remainder, 0, remainder.length);
+                exchange.getResponseHeaders().add("Content-Range",
+                        "bytes " + start + "-" + (body.length - 1) + "/" + body.length);
+                exchange.sendResponseHeaders(206, remainder.length);
+                try (OutputStream out = exchange.getResponseBody()) { out.write(remainder); }
+                partialServed.incrementAndGet();
+            } else {
+                exchange.getResponseHeaders().add("ETag", ETAG);
+                exchange.sendResponseHeaders(200, body.length);
+                try (OutputStream out = exchange.getResponseBody()) { out.write(body); }
+                bodiesServed.incrementAndGet();
+            }
+            exchange.close();
+        });
+
+        server.createContext("/conditional.txt", exchange -> {
+            byte[] body = PLAIN_BODY.getBytes(StandardCharsets.UTF_8);
+            String ifNoneMatch = exchange.getRequestHeaders().getFirst("If-None-Match");
+            exchange.getResponseHeaders().add("ETag", ETAG);
+            if (ETAG.equals(ifNoneMatch)) {
+                conditional304.incrementAndGet();
+                exchange.sendResponseHeaders(304, -1);
+            } else {
+                exchange.sendResponseHeaders(200, body.length);
+                try (OutputStream out = exchange.getResponseBody()) { out.write(body); }
+                bodiesServed.incrementAndGet();
+            }
+            exchange.close();
+        });
+
+        server.start();
+
+        queueFile = createTempFile("queueFile", ".xml");
+        manager = new DownloadManager(queueFile);
+        target = createTempFile("local", ".txt");
+        assertTrue(target.delete());
+        targetDirectory = createTempFile("extract", "");
+        assertTrue(targetDirectory.delete());
+        assertTrue(targetDirectory.mkdirs());
+    }
+
+    @After
+    public void tearDown() {
+        manager.dispose();
+        server.stop(0);
+        if (target.exists()) target.delete();
+        deleteRecursively(targetDirectory);
+        if (queueFile.exists() && !queueFile.delete()) queueFile.deleteOnExit();
+    }
+
+    private String url(String path) {
+        return "http://127.0.0.1:" + server.getAddress().getPort() + path;
+    }
+
+    private static int parseRangeStart(String range) {
+        String value = range.substring("bytes=".length());
+        return Integer.parseInt(value.substring(0, value.indexOf('-')));
+    }
+
+    private static byte[] buildZip(String entryName, byte[] content) throws IOException {
+        ByteArrayOutputStream out = new ByteArrayOutputStream();
+        try (ZipOutputStream zip = new ZipOutputStream(out)) {
+            ZipEntry entry = new ZipEntry(entryName);
+            entry.setTime(0); // deterministic
+            zip.putNextEntry(entry);
+            zip.write(content);
+            zip.closeEntry();
+        }
+        return out.toByteArray();
+    }
+
+    private static void deleteRecursively(File file) {
+        if (file == null || !file.exists()) return;
+        File[] children = file.listFiles();
+        if (children != null) for (File child : children) deleteRecursively(child);
+        file.delete();
+    }
+
+    private static String sha1Of(byte[] bytes) throws IOException {
+        return generateChecksum(new ByteArrayInputStream(bytes));
+    }
+
+    @Test
+    public void testExtractWithMatchingFragmentSucceeds() throws IOException {
+        File extracted = new File(targetDirectory, ENTRY_NAME);
+        byte[] entryBytes = ENTRY_BODY.getBytes(StandardCharsets.UTF_8);
+        Checksum fragmentChecksum = new Checksum(null, (long) entryBytes.length, sha1Of(entryBytes));
+        FileAndChecksum fragment = new FileAndChecksum(extracted, fragmentChecksum);
+
+        Download download = manager.queueForDownload("zip with fragment", url("/archive.zip"), Extract,
+                new FileAndChecksum(targetDirectory, null), singletonList(fragment));
+        manager.waitForCompletion(singletonList(download));
+
+        assertEquals(Succeeded, download.getState());
+        assertEquals(1, bodiesServed.get());
+        assertTrue(extracted.exists());
+        assertEquals(ENTRY_BODY, readFileToString(extracted));
+    }
+
+    @Test
+    public void testExtractWithoutFragmentsDoesNotCrashManager() {
+        Download download = manager.queueForDownload("zip without fragments", url("/archive.zip"), Extract,
+                new FileAndChecksum(targetDirectory, null), null);
+        manager.waitForCompletion(singletonList(download));
+
+        Set<State> terminal = EnumSet.of(Succeeded, Outdated, State.Failed, State.NoFileError, State.ChecksumError);
+        assertTrue("expected a terminal state but was " + download.getState(),
+                terminal.contains(download.getState()));
+        assertEquals(1, bodiesServed.get());
+    }
+
+    @Test
+    public void testResumePartialContentCompletesDownload() throws IOException {
+        byte[] full = PLAIN_BODY.getBytes(StandardCharsets.UTF_8);
+        int prefixLength = 16;
+        Checksum expected = new Checksum(null, (long) full.length, sha1Of(full));
+        Download download = new Download("resumable plain", url("/plain.txt"), Copy,
+                new FileAndChecksum(target, expected), null);
+
+        byte[] prefix = new byte[prefixLength];
+        System.arraycopy(full, 0, prefix, 0, prefixLength);
+        Files.write(download.getTempFile().toPath(), prefix);
+
+        Download queued = manager.queue(download, true);
+        manager.waitForCompletion(singletonList(queued));
+
+        assertEquals(Succeeded, queued.getState());
+        assertEquals(1, partialServed.get());
+        assertEquals(0, bodiesServed.get());
+        assertEquals(PLAIN_BODY, readFileToString(target));
+        assertFalse(download.getTempFile().exists());
+    }
+
+    @Test
+    public void test304WithCorruptLocalTargetReFetchesUnconditionally() throws IOException {
+        byte[] body = PLAIN_BODY.getBytes(StandardCharsets.UTF_8);
+        Checksum expected = new Checksum(null, (long) body.length, sha1Of(body));
+
+        Download download = manager.queueForDownload("conditional", url("/conditional.txt"), Copy,
+                new FileAndChecksum(target, expected), null);
+        manager.waitForCompletion(singletonList(download));
+        assertEquals(Succeeded, download.getState());
+        assertNotNull(download.getETag());
+        assertEquals(1, bodiesServed.get());
+        assertEquals(0, conditional304.get());
+
+        Files.writeString(target.toPath(), "short");
+        manager.scanForOutdatedFilesInQueue();
+        assertEquals(Outdated, download.getState());
+        assertNull(download.getETag());
+
+        Download second = manager.queueForDownload("conditional", url("/conditional.txt"), Copy,
+                new FileAndChecksum(target, expected), null);
+        manager.waitForCompletion(singletonList(second));
+        assertEquals(Succeeded, second.getState());
+        assertEquals(2, bodiesServed.get());
+        assertEquals(0, conditional304.get());
+        assertEquals(PLAIN_BODY, readFileToString(target));
+    }
+}

--- a/download/src/test/java/slash/navigation/download/DownloadManagerStateMachineTest.java
+++ b/download/src/test/java/slash/navigation/download/DownloadManagerStateMachineTest.java
@@ -22,7 +22,9 @@ package slash.navigation.download;
 import com.sun.net.httpserver.HttpServer;
 import org.junit.After;
 import org.junit.Before;
+import org.junit.Rule;
 import org.junit.Test;
+import org.junit.rules.Timeout;
 
 import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
@@ -65,6 +67,9 @@ public class DownloadManagerStateMachineTest {
     private static final String ENTRY_BODY = "Lorem ipsum dolor sit amet, consectetur adipisicing elit";
     private static final String PLAIN_BODY = "0123456789ABCDEFGHIJ0123456789ABCDEFGHIJ"; // 40 bytes
     private static final String ETAG = "\"state-machine\"";
+
+    @Rule
+    public final Timeout testTimeout = Timeout.seconds(30);
 
     private HttpServer server;
     private final AtomicInteger bodiesServed = new AtomicInteger();

--- a/graphhopper/src/test/java/slash/navigation/graphhopper/GraphDescriptorComparatorContractTest.java
+++ b/graphhopper/src/test/java/slash/navigation/graphhopper/GraphDescriptorComparatorContractTest.java
@@ -1,0 +1,182 @@
+/*
+    This file is part of RouteConverter.
+
+    RouteConverter is free software; you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation; either version 2 of the License, or
+    (at your option) any later version.
+
+    RouteConverter is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with RouteConverter; if not, write to the Free Software
+    Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
+
+    Copyright (C) 2007 Christian Pesch. All Rights Reserved.
+*/
+package slash.navigation.graphhopper;
+
+import org.junit.Test;
+import slash.navigation.common.BoundingBox;
+
+import java.lang.reflect.Field;
+import java.util.ArrayList;
+import java.util.Comparator;
+import java.util.List;
+import java.util.Random;
+
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+/**
+ * Adversarial total-order (Comparator contract) tests for the graph descriptor comparators.
+ * The {@link slash.navigation.graphhopper.GraphManager.GraphDescriptorComparator} mixes a
+ * partial "bounding box contains" relation with a square-size tie-break, which is the classic
+ * recipe for an intransitive comparator -- it produced a real
+ * "Comparison method violates its general contract!" failure that left routing unconfigured.
+ *
+ * These feed many randomized, adversarial descriptor sets (contained / overlapping / disjoint /
+ * identical / null bounding boxes) through the comparator and assert antisymmetry, transitivity
+ * and that {@link List#sort} (TimSort, which actively detects contract violations) never throws.
+ *
+ * @author Christian Pesch
+ */
+public class GraphDescriptorComparatorContractTest {
+
+    /** Asserts a comparator is a total order over the given elements and survives TimSort on shuffles. */
+    private static <T> void assertTotalOrder(Comparator<T> comparator, List<T> elements) {
+        // antisymmetry: sgn(compare(a, b)) == -sgn(compare(b, a))
+        for (T a : elements)
+            for (T b : elements) {
+                int ab = Integer.signum(comparator.compare(a, b));
+                int ba = Integer.signum(comparator.compare(b, a));
+                if (ab != -ba)
+                    fail("antisymmetry violated: compare(a,b)=" + ab + " compare(b,a)=" + ba + " for " + a + " / " + b);
+            }
+
+        // transitivity: compare(a,b)<=0 && compare(b,c)<=0  =>  compare(a,c)<=0
+        for (T a : elements)
+            for (T b : elements)
+                for (T c : elements)
+                    if (comparator.compare(a, b) <= 0 && comparator.compare(b, c) <= 0 && comparator.compare(a, c) > 0)
+                        fail("transitivity violated: a<=b, b<=c but a>c for " + a + " / " + b + " / " + c);
+
+        // TimSort actively throws IllegalArgumentException on a broken comparator
+        Random shuffle = new Random(1);
+        for (int i = 0; i < 8; i++) {
+            List<T> copy = new ArrayList<>(elements);
+            java.util.Collections.shuffle(copy, shuffle);
+            copy.sort(comparator);
+        }
+    }
+
+    /** Self-test: the harness must actually catch a known-intransitive comparator. */
+    @Test
+    public void testAssertTotalOrderCatchesNonTransitiveComparator() {
+        // rock(0) < scissors(2), scissors(2) < paper(1), paper(1) < rock(0): intransitive
+        Comparator<Integer> rockPaperScissors = (x, y) -> {
+            if (x.equals(y)) return 0;
+            boolean xBeatsY = (x + 1) % 3 == y % 3;
+            return xBeatsY ? -1 : 1;
+        };
+        try {
+            assertTotalOrder(rockPaperScissors, List.of(0, 1, 2));
+            fail("expected the harness to reject the intransitive comparator");
+        } catch (AssertionError | IllegalArgumentException expected) {
+            // good: either the transitivity assertion or TimSort caught it
+        }
+    }
+
+    @Test
+    public void testGraphDescriptorComparatorTotalOrderOnHandPickedBoundingBoxes() {
+        List<GraphDescriptor> descriptors = new ArrayList<>();
+        // identifiers vary so the tie-break branch is exercised deterministically
+        descriptors.add(remote("world.pbf", new BoundingBox(180.0, 90.0, -180.0, -90.0)));
+        descriptors.add(remote("france.pbf", new BoundingBox(8.0, 51.0, -5.0, 42.0)));
+        descriptors.add(remote("paris.pbf", new BoundingBox(2.6, 49.0, 2.0, 48.6)));        // inside france
+        descriptors.add(remote("germany.pbf", new BoundingBox(15.0, 55.0, 5.0, 47.0)));     // overlaps france, neither contains
+        descriptors.add(remote("japan.pbf", new BoundingBox(146.0, 46.0, 129.0, 30.0)));    // disjoint
+        descriptors.add(remote("france-copy.pbf", new BoundingBox(8.0, 51.0, -5.0, 42.0))); // identical box, different id
+        descriptors.add(remote("noBox.pbf", null));
+        descriptors.add(remote("noBox2.pbf", null));
+        descriptors.add(zip("archive.zip", null));
+
+        assertTotalOrder(new GraphManager.GraphDescriptorComparator(), descriptors);
+    }
+
+    @Test
+    public void testGraphDescriptorComparatorTotalOrderRandomizedAdversarial() {
+        Comparator<GraphDescriptor> comparator = new GraphManager.GraphDescriptorComparator();
+        Random random = new Random(42); // fixed seed -> reproducible
+        for (int iteration = 0; iteration < 250; iteration++)
+            assertTotalOrder(comparator, randomDescriptors(random, 4 + random.nextInt(9)));
+    }
+
+    @Test
+    public void testPreferredComparatorTotalOrderRandomizedAdversarial() throws Exception {
+        Field field = DownloadableFinder.class.getDeclaredField("PREFERRED_GRAPH_DESCRIPTOR_COMPARATOR");
+        field.setAccessible(true);
+        @SuppressWarnings("unchecked")
+        Comparator<GraphDescriptor> comparator = (Comparator<GraphDescriptor>) field.get(null);
+        assertTrue(comparator != null);
+
+        Random random = new Random(7);
+        for (int iteration = 0; iteration < 250; iteration++)
+            assertTotalOrder(comparator, randomDescriptors(random, 4 + random.nextInt(9)));
+    }
+
+    // a small pool of boxes with deliberately mixed relations (contained / overlapping /
+    // disjoint / identical) so random sets contain incomparable contains-pairs -- the exact
+    // shape that triggers intransitivity
+    private static final BoundingBox[] BOX_POOL = {
+            null,
+            new BoundingBox(180.0, 90.0, -180.0, -90.0),  // world
+            new BoundingBox(8.0, 51.0, -5.0, 42.0),       // france
+            new BoundingBox(2.6, 49.0, 2.0, 48.6),        // paris (inside france)
+            new BoundingBox(15.0, 55.0, 5.0, 47.0),       // germany (overlaps france)
+            new BoundingBox(8.0, 51.0, -5.0, 42.0),       // france duplicate
+            new BoundingBox(146.0, 46.0, 129.0, 30.0),    // japan (disjoint)
+            new BoundingBox(10.0, 52.0, 6.0, 48.0),       // inside germany
+    };
+
+    private static List<GraphDescriptor> randomDescriptors(Random random, int count) {
+        List<GraphDescriptor> descriptors = new ArrayList<>();
+        for (int i = 0; i < count; i++) {
+            BoundingBox box = random.nextBoolean()
+                    ? BOX_POOL[random.nextInt(BOX_POOL.length)]
+                    : randomBox(random);
+            String uri = "graph-" + i + "-" + random.nextInt(1000) + (random.nextBoolean() ? ".pbf" : ".zip");
+            descriptors.add(uri.endsWith(".zip") ? zip(uri, box) : remote(uri, box));
+        }
+        return descriptors;
+    }
+
+    private static BoundingBox randomBox(Random random) {
+        double minLon = -180 + random.nextInt(300);
+        double minLat = -80 + random.nextInt(140);
+        double width = 1 + random.nextInt(60);
+        double height = 1 + random.nextInt(60);
+        return new BoundingBox(minLon + width, minLat + height, minLon, minLat);
+    }
+
+    private static GraphDescriptor remote(String uri, BoundingBox box) {
+        return new GraphDescriptor(GraphManager.GraphType.PBF, null, file(uri, box));
+    }
+
+    private static GraphDescriptor zip(String uri, BoundingBox box) {
+        return new GraphDescriptor(GraphManager.GraphType.ZIP, null, file(uri, box));
+    }
+
+    private static slash.navigation.datasources.File file(String uri, BoundingBox box) {
+        slash.navigation.datasources.File file = mock(slash.navigation.datasources.File.class);
+        when(file.getUri()).thenReturn(uri);
+        when(file.toString()).thenReturn(uri);
+        when(file.getBoundingBox()).thenReturn(box);
+        return file;
+    }
+}

--- a/graphhopper/src/test/java/slash/navigation/graphhopper/GraphDescriptorComparatorContractTest.java
+++ b/graphhopper/src/test/java/slash/navigation/graphhopper/GraphDescriptorComparatorContractTest.java
@@ -160,7 +160,7 @@ public class GraphDescriptorComparatorContractTest {
         double minLon = -180 + random.nextInt(300);
         double minLat = -80 + random.nextInt(140);
         double width = 1 + random.nextInt(60);
-        double height = 1 + random.nextInt(60);
+        double height = 1 + random.nextInt(Math.max(1, (int) Math.min(60, 90 - minLat)));
         return new BoundingBox(minLon + width, minLat + height, minLon, minLat);
     }
 

--- a/mapsforge-mapview/src/test/java/slash/navigation/mapview/mapsforge/MapsforgeMapViewTest.java
+++ b/mapsforge-mapview/src/test/java/slash/navigation/mapview/mapsforge/MapsforgeMapViewTest.java
@@ -21,6 +21,7 @@ package slash.navigation.mapview.mapsforge;
 
 import org.junit.Before;
 import org.junit.Test;
+import org.mapsforge.map.reader.MapFile;
 import org.mapsforge.map.rendertheme.XmlRenderThemeMenuCallback;
 import org.mapsforge.map.rendertheme.XmlRenderThemeStyleLayer;
 import org.mapsforge.map.rendertheme.XmlRenderThemeStyleMenu;
@@ -30,8 +31,11 @@ import slash.navigation.maps.item.ItemTableModel;
 import slash.navigation.maps.mapsforge.MapsforgeMapManager;
 import slash.navigation.maps.tileserver.TileServerMapManager;
 
+import java.io.File;
+import java.io.IOException;
 import java.lang.reflect.Constructor;
 import java.lang.reflect.Field;
+import java.nio.file.Files;
 import java.util.Collections;
 import java.util.LinkedHashMap;
 import java.util.LinkedHashSet;
@@ -41,6 +45,7 @@ import java.util.Set;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertThrows;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
@@ -165,5 +170,49 @@ public class MapsforgeMapViewTest {
         when(layer.getCategories()).thenReturn(new LinkedHashSet<>(Set.of(categories)));
         when(layer.getOverlays()).thenReturn(Collections.emptyList());
         return layer;
+    }
+
+    // --- background map failure modes ----------------------------------------
+    // setBackgroundMap builds new MapFile(file) first; a corrupt or missing file makes the
+    // mapsforge header check throw before any Swing-heavy code, and the catch must log + null
+    // the layer instead of letting the exception escape on the EDT (which left a blank map with
+    // nothing logged -- error report 1311).
+
+    @Test
+    public void testMapFileRejectsTruncatedGarbage() throws IOException {
+        File corrupt = File.createTempFile("not-a-map", ".map");
+        corrupt.deleteOnExit();
+        Files.write(corrupt.toPath(), "this is not a mapsforge binary map file".getBytes());
+        assertThrows(RuntimeException.class, () -> new MapFile(corrupt));
+    }
+
+    @Test
+    public void testMapFileRejectsMissingFile() {
+        File missing = new File(System.getProperty("java.io.tmpdir"), "missing-" + System.nanoTime() + ".map");
+        assertThrows(RuntimeException.class, () -> new MapFile(missing));
+    }
+
+    @Test
+    public void testSetBackgroundMapWithCorruptFileDoesNotThrowAndClearsLayer() throws Exception {
+        File corrupt = File.createTempFile("not-a-map", ".map");
+        corrupt.deleteOnExit();
+        Files.write(corrupt.toPath(), "this is not a mapsforge binary map file".getBytes());
+
+        mapView.setBackgroundMap(corrupt); // must not throw
+        assertNull(backgroundLayerOf(mapView));
+    }
+
+    @Test
+    public void testSetBackgroundMapWithMissingFileDoesNotThrowAndClearsLayer() throws Exception {
+        File missing = new File(System.getProperty("java.io.tmpdir"), "missing-" + System.nanoTime() + ".map");
+
+        mapView.setBackgroundMap(missing); // must not throw
+        assertNull(backgroundLayerOf(mapView));
+    }
+
+    private static Object backgroundLayerOf(MapsforgeMapView mapView) throws Exception {
+        Field field = MapsforgeMapView.class.getDeclaredField("backgroundLayer");
+        field.setAccessible(true);
+        return field.get(mapView);
     }
 }

--- a/navigation-formats/src/test/java/slash/navigation/gpx/GpxFormatNegativeTest.java
+++ b/navigation-formats/src/test/java/slash/navigation/gpx/GpxFormatNegativeTest.java
@@ -1,0 +1,122 @@
+/*
+    This file is part of RouteConverter.
+
+    RouteConverter is free software; you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation; either version 2 of the License, or
+    (at your option) any later version.
+
+    RouteConverter is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with RouteConverter; if not, write to the Free Software
+    Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
+
+    Copyright (C) 2007 Christian Pesch. All Rights Reserved.
+*/
+package slash.navigation.gpx;
+
+import org.junit.Test;
+import slash.navigation.base.ParserContext;
+import slash.navigation.base.ParserContextImpl;
+
+import java.io.ByteArrayInputStream;
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.util.List;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertThrows;
+
+/**
+ * Negative / malformed-input tests for the GPX readers. GPX is the most-used format, yet was
+ * covered almost entirely by happy-path roundtrips (and the broad roundtrip suite is an *IT*,
+ * excluded from the gated unit build). These assert that bad input fails cleanly with an
+ * {@link IOException} rather than an NPE or a hang, and that the core happy path still parses --
+ * so a parsing regression fails the GATED unit build.
+ *
+ * @author Christian Pesch
+ */
+public class GpxFormatNegativeTest {
+
+    private List<GpxRoute> read(GpxFormat format, String source) throws IOException {
+        ParserContext<GpxRoute> context = new ParserContextImpl<>(null, null);
+        format.read(new ByteArrayInputStream(source.getBytes(StandardCharsets.UTF_8)), context);
+        return context.getRoutes();
+    }
+
+    @Test
+    public void testEmptyInputGpx10() {
+        assertThrows(IOException.class, () -> read(new Gpx10Format(), ""));
+    }
+
+    @Test
+    public void testEmptyInputGpx11() {
+        assertThrows(IOException.class, () -> read(new Gpx11Format(), ""));
+    }
+
+    @Test
+    public void testBlankInputGpx11() {
+        assertThrows(IOException.class, () -> read(new Gpx11Format(), "   \n\t  "));
+    }
+
+    @Test
+    public void testTruncatedGpx11() {
+        assertThrows(IOException.class, () -> read(new Gpx11Format(),
+                "<?xml version=\"1.0\"?><gpx version=\"1.1\"><wpt lat=\"49.0\" lon=\"8."));
+    }
+
+    @Test
+    public void testTruncatedGpx10() {
+        assertThrows(IOException.class, () -> read(new Gpx10Format(),
+                "<?xml version=\"1.0\"?><gpx version=\"1.0\"><wpt lat=\"49"));
+    }
+
+    @Test
+    public void testNonGpxWellFormedXmlGpx11() {
+        assertThrows(IOException.class, () -> read(new Gpx11Format(),
+                "<?xml version=\"1.0\"?><html><body>not gpx</body></html>"));
+    }
+
+    @Test
+    public void testNonGpxWellFormedXmlGpx10() {
+        assertThrows(IOException.class, () -> read(new Gpx10Format(),
+                "<?xml version=\"1.0\"?><kml><Document/></kml>"));
+    }
+
+    @Test
+    public void testMalformedCoordinateGpx11() {
+        assertThrows(IOException.class, () -> read(new Gpx11Format(),
+                "<?xml version=\"1.0\"?><gpx version=\"1.1\"><wpt lat=\"not-a-number\" lon=\"8.0\"/></gpx>"));
+    }
+
+    @Test
+    public void testValidButEmptyGpx11ReturnsNoRoutesWithoutThrowing() throws IOException {
+        List<GpxRoute> routes = read(new Gpx11Format(),
+                "<?xml version=\"1.0\"?><gpx version=\"1.1\" creator=\"test\" xmlns=\"http://www.topografix.com/GPX/1/1\"></gpx>");
+        // no tracks/routes/waypoints -> no usable route, but no exception
+        if (routes != null)
+            for (GpxRoute route : routes)
+                assertEquals(0, route.getPositionCount());
+    }
+
+    @Test
+    public void testReadTinyGpx11Waypoint() throws IOException {
+        List<GpxRoute> routes = read(new Gpx11Format(),
+                "<?xml version=\"1.0\"?>" +
+                        "<gpx version=\"1.1\" creator=\"test\" xmlns=\"http://www.topografix.com/GPX/1/1\">" +
+                        "<wpt lat=\"49.123456\" lon=\"8.654321\"><ele>250.5</ele><name>home</name></wpt>" +
+                        "</gpx>");
+        assertNotNull(routes);
+        assertEquals(1, routes.size());
+        GpxRoute route = routes.get(0);
+        assertEquals(1, route.getPositionCount());
+        assertEquals(49.123456, route.getPosition(0).getLatitude(), 1e-9);
+        assertEquals(8.654321, route.getPosition(0).getLongitude(), 1e-9);
+        assertEquals(250.5, route.getPosition(0).getElevation(), 1e-9);
+    }
+}

--- a/navigation-formats/src/test/java/slash/navigation/gpx/GpxFormatNegativeTest.java
+++ b/navigation-formats/src/test/java/slash/navigation/gpx/GpxFormatNegativeTest.java
@@ -98,10 +98,9 @@ public class GpxFormatNegativeTest {
     public void testValidButEmptyGpx11ReturnsNoRoutesWithoutThrowing() throws IOException {
         List<GpxRoute> routes = read(new Gpx11Format(),
                 "<?xml version=\"1.0\"?><gpx version=\"1.1\" creator=\"test\" xmlns=\"http://www.topografix.com/GPX/1/1\"></gpx>");
-        // no tracks/routes/waypoints -> no usable route, but no exception
-        if (routes != null)
-            for (GpxRoute route : routes)
-                assertEquals(0, route.getPositionCount());
+        assertNotNull(routes);
+        for (GpxRoute route : routes)
+            assertEquals(0, route.getPositionCount());
     }
 
     @Test

--- a/navigation-formats/src/test/java/slash/navigation/kml/KmlFormatNegativeTest.java
+++ b/navigation-formats/src/test/java/slash/navigation/kml/KmlFormatNegativeTest.java
@@ -1,0 +1,80 @@
+/*
+    This file is part of RouteConverter.
+
+    RouteConverter is free software; you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation; either version 2 of the License, or
+    (at your option) any later version.
+
+    RouteConverter is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with RouteConverter; if not, write to the Free Software
+    Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
+
+    Copyright (C) 2007 Christian Pesch. All Rights Reserved.
+*/
+package slash.navigation.kml;
+
+import org.junit.Test;
+import slash.navigation.base.ParserContext;
+import slash.navigation.base.ParserContextImpl;
+
+import java.io.ByteArrayInputStream;
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.util.List;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertThrows;
+
+/**
+ * Negative / malformed-input tests for the KML 2.2 reader: bad input must fail cleanly with an
+ * {@link IOException} (not an NPE or hang), and structurally valid KML with no geometry must
+ * yield no routes without throwing.
+ *
+ * @author Christian Pesch
+ */
+public class KmlFormatNegativeTest {
+    private final Kml22Format format = new Kml22Format();
+
+    private List<KmlRoute> read(String source) throws IOException {
+        ParserContext<KmlRoute> context = new ParserContextImpl<>();
+        format.read(new ByteArrayInputStream(source.getBytes(StandardCharsets.UTF_8)), context);
+        return context.getRoutes();
+    }
+
+    @Test
+    public void testEmptyInput() {
+        assertThrows(IOException.class, () -> read(""));
+    }
+
+    @Test
+    public void testBlankInput() {
+        assertThrows(IOException.class, () -> read("   \n\t  "));
+    }
+
+    @Test
+    public void testTruncatedKml() {
+        assertThrows(IOException.class, () -> read(
+                "<?xml version=\"1.0\"?><kml xmlns=\"http://www.opengis.net/kml/2.2\"><Document><Placemark><Point><coordinates>8.0,49."));
+    }
+
+    @Test
+    public void testNonKmlWellFormedXml() {
+        assertThrows(IOException.class, () -> read(
+                "<?xml version=\"1.0\"?><gpx version=\"1.1\"><wpt lat=\"49.0\" lon=\"8.0\"/></gpx>"));
+    }
+
+    @Test
+    public void testValidButEmptyKmlReturnsNoRoutesWithoutThrowing() throws IOException {
+        List<KmlRoute> routes = read(
+                "<?xml version=\"1.0\"?><kml xmlns=\"http://www.opengis.net/kml/2.2\"><Document/></kml>");
+        if (routes != null)
+            for (KmlRoute route : routes)
+                assertEquals(0, route.getPositionCount());
+    }
+}

--- a/scripts/verify-runtime.sh
+++ b/scripts/verify-runtime.sh
@@ -29,6 +29,10 @@
 #                    (default: third-party library roots; app GUI classes are
 #                    covered by the #3 smoke instead, to avoid opening windows)
 #   STRICT_MISSING   1 = fail on #5 jdeps --missing-deps findings (default warn)
+#   STRICT_MODULES   1 = fail on #2 when the fat jar references a module absent
+#                    from jre-modules.txt (default 0 -- advisory, because jdeps
+#                    over-approximates on a fat jar and reports dead/optional
+#                    references the app never executes; #3/#4 are the real gates)
 #
 set -euo pipefail
 
@@ -41,6 +45,7 @@ sample_gpx="${3:-}"
 mr_version="${MR_VERSION:-17}"
 init_prefixes="${INIT_PREFIXES:-org.apache.,org.sqlite.,com.sun.,jakarta.,net.java.dev.jna.,org.mozilla.,com.fasterxml.,com.google.}"
 strict_missing="${STRICT_MISSING:-0}"
+strict_modules="${STRICT_MODULES:-0}"
 
 [[ -f "$fat_jar" ]]      || { echo "::error::fat jar not found: $fat_jar"; exit 2; }
 [[ -f "$modules_file" ]] || { echo "::error::module list not found: $modules_file"; exit 2; }
@@ -80,7 +85,13 @@ for m in "${req_arr[@]}"; do
   esac
 done
 if ((${#extras[@]})); then
-  echo "::warning::fat jar references module(s) not shipped: ${extras[*]} (dead refs unless #4/#3 fail)"
+  if [[ "$strict_modules" == "1" ]]; then
+    echo "::error::jdeps requires module(s) absent from jre-modules.txt: ${extras[*]}"
+    echo "::error::the shipped stripped JRE lacks them -> runtime NoClassDefFoundError; add them to jre-modules.txt and rebuild the Mac/Windows JREs"
+    fail=1
+  else
+    echo "::warning::fat jar references module(s) not shipped: ${extras[*]} (dead refs unless #4/#3 fail; set STRICT_MODULES=1 to gate)"
+  fi
 else
   echo "    OK: every referenced module is shipped"
 fi


### PR DESCRIPTION
Five focused test additions, each targeting a real recent failure or a thin-coverage hotspot. ~27 new tests; all hermetic (no network/fixtures), run in the gated unit phase.

**1. Comparator total-order contract** (`graphhopper`)
Adversarial fixed-seed sets (contained/overlapping/disjoint/identical/null bounding boxes) through `GraphDescriptorComparator` + the `PREFERRED` comparator; asserts antisymmetry, transitivity, and that `List.sort` (TimSort) never throws. Includes a self-test proving the harness catches a known-intransitive comparator. Guards the "Comparison method violates its general contract" class.

**2. Download state machine** (`download`)
Local-`HttpServer` tests: Extract with/without fragments, resume via HTTP 206, and conditional-GET 304 with a corrupt local target re-fetching unconditionally. Covers the ETag/304 cache-poison (#106) and gpsbabel Extract-fragments paths.

**3. Background-map failure modes** (`mapsforge-mapview`)
`setBackgroundMap` with a corrupt/missing `.map` must log + null the layer, not let the mapsforge header-check throw escape on the EDT (the blank-map-with-clean-log of #107).

**4. Format negative tests** (`navigation-formats`)
GPX and KML are the most-used formats but were covered mostly by happy-path roundtrips (and the broad roundtrip suite is an excluded `*IT`). Empty/truncated/non-format/malformed input → clean `IOException`; valid-but-empty → no routes; a tiny valid GPX 1.1 still parses lat/lon/ele — so a parse regression fails the gated build.

**5. Opt-in `STRICT_MODULES` gate** (`scripts/verify-runtime.sh`)
The jdeps module-superset check is advisory (jdeps over-approximates on a fat jar). `STRICT_MODULES=1` promotes it to a hard gate naming missing modules; default stays advisory (#3/#4 remain the real runtime gates).

All five module suites green locally.