### PR TITLE
Bridge Log4j 2 API to SLF4J in RouteConverterCmdLine

### DIFF
--- a/RouteConverterLinux/pom.xml
+++ b/RouteConverterLinux/pom.xml
@@ -83,5 +83,11 @@
             <artifactId>route-converter</artifactId>
             <version>${project.version}</version>
         </dependency>
+        <dependency>
+            <groupId>org.apache.logging.log4j</groupId>
+            <artifactId>log4j-to-slf4j</artifactId>
+            <version>2.24.3</version>
+            <scope>runtime</scope>
+        </dependency>
     </dependencies>
 </project>

--- a/RouteConverterMac/pom.xml
+++ b/RouteConverterMac/pom.xml
@@ -115,5 +115,11 @@
             <artifactId>route-converter</artifactId>
             <version>${project.version}</version>
         </dependency>
+        <dependency>
+            <groupId>org.apache.logging.log4j</groupId>
+            <artifactId>log4j-to-slf4j</artifactId>
+            <version>2.24.3</version>
+            <scope>runtime</scope>
+        </dependency>
     </dependencies>
 </project>

--- a/RouteConverterWindows/pom.xml
+++ b/RouteConverterWindows/pom.xml
@@ -103,5 +103,11 @@
             <artifactId>route-converter</artifactId>
             <version>${project.version}</version>
         </dependency>
+        <dependency>
+            <groupId>org.apache.logging.log4j</groupId>
+            <artifactId>log4j-to-slf4j</artifactId>
+            <version>2.24.3</version>
+            <scope>runtime</scope>
+        </dependency>
     </dependencies>
 </project>

--- a/TimeAlbumProLinux/pom.xml
+++ b/TimeAlbumProLinux/pom.xml
@@ -86,5 +86,11 @@
             <artifactId>time-album-pro</artifactId>
             <version>${project.version}</version>
         </dependency>
+        <dependency>
+            <groupId>org.apache.logging.log4j</groupId>
+            <artifactId>log4j-to-slf4j</artifactId>
+            <version>2.24.3</version>
+            <scope>runtime</scope>
+        </dependency>
     </dependencies>
 </project>

--- a/TimeAlbumProMac/pom.xml
+++ b/TimeAlbumProMac/pom.xml
@@ -118,5 +118,11 @@
             <artifactId>time-album-pro</artifactId>
             <version>${project.version}</version>
         </dependency>
+        <dependency>
+            <groupId>org.apache.logging.log4j</groupId>
+            <artifactId>log4j-to-slf4j</artifactId>
+            <version>2.24.3</version>
+            <scope>runtime</scope>
+        </dependency>
     </dependencies>
 </project>

--- a/TimeAlbumProWindows/pom.xml
+++ b/TimeAlbumProWindows/pom.xml
@@ -104,5 +104,11 @@
             <artifactId>time-album-pro</artifactId>
             <version>${project.version}</version>
         </dependency>
+        <dependency>
+            <groupId>org.apache.logging.log4j</groupId>
+            <artifactId>log4j-to-slf4j</artifactId>
+            <version>2.24.3</version>
+            <scope>runtime</scope>
+        </dependency>
     </dependencies>
 </project>

--- a/route-converter-cmdline/pom.xml
+++ b/route-converter-cmdline/pom.xml
@@ -16,5 +16,10 @@
             <artifactId>navigation-formats</artifactId>
             <version>${project.version}</version>
         </dependency>
+        <dependency>
+            <groupId>org.apache.logging.log4j</groupId>
+            <artifactId>log4j-to-slf4j</artifactId>
+            <version>2.24.3</version>
+        </dependency>
     </dependencies>
 </project>

--- a/route-converter-cmdline/pom.xml
+++ b/route-converter-cmdline/pom.xml
@@ -20,6 +20,7 @@
             <groupId>org.apache.logging.log4j</groupId>
             <artifactId>log4j-to-slf4j</artifactId>
             <version>2.24.3</version>
+            <scope>runtime</scope>
         </dependency>
     </dependencies>
 </project>


### PR DESCRIPTION
Closes #113.

## Summary

- Add the `log4j-to-slf4j` runtime bridge so Log4j 2 API calls route through SLF4J, suppressing the standalone Log4j `ERROR StatusLogger` output in `RouteConverterCmdLine`.
- Extend the same runtime bridge to the RouteConverter and TimeAlbumPro shaded artifacts (Linux / Mac / Windows).

## Why

`RouteConverterCmdLine` printed a Log4j `ERROR` because no Log4j 2 binding/bridge was on the runtime classpath. Routing the Log4j 2 API to SLF4J resolves it without adding a full Log4j backend.

## Risk

Low — runtime-scoped dependency only; no source or behaviour change.

🤖 Builder.
