### PR TITLE
feat(mapview): show non-selected position lists read-only (gray)

### DIFF
--- a/mapsforge-mapview/src/main/java/slash/navigation/mapview/mapsforge/MapsforgeMapView.java
+++ b/mapsforge-mapview/src/main/java/slash/navigation/mapview/mapsforge/MapsforgeMapView.java
@@ -337,6 +337,7 @@ public class MapsforgeMapView extends BaseMapView {
         trackRenderer = new TrackRenderer(this, preferencesModel.getTrackColorModel(),
                 preferencesModel.getTrackLineWidthModel(), GRAPHIC_FACTORY);
         nonSelectedPositionListsRenderer = new NonSelectedPositionListsRenderer(this, positionListsModel,
+                preferencesModel.getRouteColorModel(), preferencesModel.getTrackColorModel(),
                 preferencesModel.getRouteLineWidthModel(), preferencesModel.getTrackLineWidthModel(), GRAPHIC_FACTORY);
     }
 

--- a/mapsforge-mapview/src/main/java/slash/navigation/mapview/mapsforge/MapsforgeMapView.java
+++ b/mapsforge-mapview/src/main/java/slash/navigation/mapview/mapsforge/MapsforgeMapView.java
@@ -71,6 +71,7 @@ import slash.navigation.mapview.mapsforge.overlays.OverlayManager;
 import slash.navigation.mapview.mapsforge.renderer.BorderPainter;
 import slash.navigation.mapview.mapsforge.renderer.MagnifierPainter;
 import slash.navigation.mapview.mapsforge.renderer.MapViewLayerOperations;
+import slash.navigation.mapview.mapsforge.renderer.NonSelectedPositionListsRenderer;
 import slash.navigation.mapview.mapsforge.renderer.RouteRenderer;
 import slash.navigation.mapview.mapsforge.renderer.TrackRenderer;
 import slash.navigation.mapview.mapsforge.tiles.DefaultTileLayerFactory;
@@ -147,10 +148,13 @@ public class MapsforgeMapView extends BaseMapView {
     private static final byte MAXIMUM_ZOOM_LEVEL = 22;
 
     private PositionsModel positionsModel;
+    private PositionListsModel positionListsModel;
     private MapPreferencesModel preferencesModel;
     private MapViewCallbackOpenSource mapViewCallback;
+    private NonSelectedPositionListsRenderer nonSelectedPositionListsRenderer;
 
     private final TableModelListener positionsModelListener = new PositionsModelListener();
+    private final ListDataListener positionListsModelListener = new PositionListsModelListener();
     private final ListDataListener characteristicsModelListener = new CharacteristicsModelListener();
     private final ChangeListener routingPreferencesListener = e -> {
         if (positionsModel.getRoute().getCharacteristics().equals(Route))
@@ -164,6 +168,8 @@ public class MapsforgeMapView extends BaseMapView {
             this.waypointIcon = null;
         }
         this.updateDecoupler.replaceRoute();
+        // line widths apply to the gray set, too
+        updateNonSelectedPositionLists();
     };
     private final ChangeListener displayedMapListener = e ->
             handleMapAndThemeUpdate(true, !isVisible(this.mapView.getModel().mapViewPosition.getCenter()));
@@ -200,9 +206,11 @@ public class MapsforgeMapView extends BaseMapView {
     // initialization
 
     public void initialize(PositionsModel positionsModel,
+                           PositionListsModel positionListsModel,
                            MapPreferencesModel preferencesModel,
                            MapViewCallback mapViewCallback) {
         this.positionsModel = positionsModel;
+        this.positionListsModel = positionListsModel;
         this.preferencesModel = preferencesModel;
         this.mapViewCallback = (MapViewCallbackOpenSource) mapViewCallback;
 
@@ -309,6 +317,7 @@ public class MapsforgeMapView extends BaseMapView {
         this.updateDecoupler = new UpdateDecoupler(positionsModel, this::getEventMapUpdaterFor);
 
         positionsModel.addTableModelListener(positionsModelListener);
+        positionListsModel.addListDataListener(positionListsModelListener);
         preferencesModel.getRoutingPreferencesModel().addChangeListener(routingPreferencesListener);
         preferencesModel.getCharacteristicsModel().addListDataListener(characteristicsModelListener);
         preferencesModel.getUnitSystemModel().addChangeListener(unitSystemListener);
@@ -327,6 +336,8 @@ public class MapsforgeMapView extends BaseMapView {
                 preferencesModel.getRouteLineWidthModel(), GRAPHIC_FACTORY);
         trackRenderer = new TrackRenderer(this, preferencesModel.getTrackColorModel(),
                 preferencesModel.getTrackLineWidthModel(), GRAPHIC_FACTORY);
+        nonSelectedPositionListsRenderer = new NonSelectedPositionListsRenderer(this, positionListsModel,
+                preferencesModel.getRouteLineWidthModel(), preferencesModel.getTrackLineWidthModel(), GRAPHIC_FACTORY);
     }
 
     private static boolean initializedActions = false;
@@ -509,22 +520,25 @@ public class MapsforgeMapView extends BaseMapView {
                     encodeInt(waypointColorModel.getColor().getGreen(), 2) +
                     encodeInt(waypointColorModel.getColor().getBlue(), 2);
             String opacity = Transfer.formatDoubleAsString(Float.valueOf(asAlpha(waypointColorModel)).doubleValue(), 2);
-
-            InputStream inputStream = MapsforgeMapView.class.getResourceAsStream("waypoint.svg");
-            assert inputStream != null;
-            Reader reader = new TokenReplacingReader(new InputStreamReader(inputStream), new TokenResolver() {
-                public String resolveToken(String tokenName) {
-                    if (tokenName.equals("color"))
-                        return color;
-                    if (tokenName.equals("opacity"))
-                        return opacity;
-                    return tokenName;
-                }
-            });
-            BufferedImage bufferedImage = getResourceBitmap(reader, "waypoint-" + color + "-" + opacity, getDeviceScaleFactor(), 100f, 16, 16, 100);
-            waypointIcon = new AwtBitmap(bufferedImage);
+            waypointIcon = createWaypointIcon(color, opacity);
         }
         return waypointIcon;
+    }
+
+    public Bitmap createWaypointIcon(String color, String opacity) {
+        InputStream inputStream = MapsforgeMapView.class.getResourceAsStream("waypoint.svg");
+        assert inputStream != null;
+        Reader reader = new TokenReplacingReader(new InputStreamReader(inputStream), new TokenResolver() {
+            public String resolveToken(String tokenName) {
+                if (tokenName.equals("color"))
+                    return color;
+                if (tokenName.equals("opacity"))
+                    return opacity;
+                return tokenName;
+            }
+        });
+        BufferedImage bufferedImage = getResourceBitmap(reader, "waypoint-" + color + "-" + opacity, getDeviceScaleFactor(), 100f, 16, 16, 100);
+        return new AwtBitmap(bufferedImage);
     }
 
     private void handleUnitSystem() {
@@ -614,6 +628,7 @@ public class MapsforgeMapView extends BaseMapView {
 
         handleBackground();
         handleOverlays();
+        handleNonSelectedPositionLists();
 
         // then start download layer threads
         if (layer instanceof TileDownloadLayer tileDownloadLayer)
@@ -648,6 +663,28 @@ public class MapsforgeMapView extends BaseMapView {
         LocalMap map = getMapManager().getDisplayedMapModel().getItem();
         if (map.getType().equals(Mapsforge))
             layers.add(0, backgroundLayer);
+    }
+
+    private void handleNonSelectedPositionLists() {
+        Layer nonSelectedLayer = nonSelectedPositionListsRenderer.getLayer();
+        Layers layers = getLayerManager().getLayers();
+        layers.remove(nonSelectedLayer);
+
+        // insert directly above the map (and background) layers so that the selected
+        // position list and the selection markers are always drawn on top of the gray set
+        int index = 0;
+        for (Layer layer : mapsToLayers.values())
+            index = max(index, layers.indexOf(layer) + 1);
+        layers.add(index, nonSelectedLayer);
+
+        // catch position lists that were loaded before the map was initialized
+        nonSelectedPositionListsRenderer.update();
+    }
+
+    private void updateNonSelectedPositionLists() {
+        // may fire from list/preference listeners registered before the renderer is built
+        if (nonSelectedPositionListsRenderer != null)
+            nonSelectedPositionListsRenderer.update();
     }
 
     private void handleShadedHills() {
@@ -694,6 +731,7 @@ public class MapsforgeMapView extends BaseMapView {
         mapViewCallback.getTileServerMapManager().getAppliedOverlaysModel().removeTableModelListener(appliedOverlayListener);
 
         positionsModel.removeTableModelListener(positionsModelListener);
+        positionListsModel.removeListDataListener(positionListsModelListener);
         preferencesModel.getRoutingPreferencesModel().removeChangeListener(routingPreferencesListener);
         preferencesModel.getCharacteristicsModel().removeListDataListener(characteristicsModelListener);
         preferencesModel.getUnitSystemModel().removeChangeListener(unitSystemListener);
@@ -1289,6 +1327,22 @@ public class MapsforgeMapView extends BaseMapView {
     }
 
     // listeners
+
+    private class PositionListsModelListener implements ListDataListener {
+        public void intervalAdded(ListDataEvent e) {
+            updateNonSelectedPositionLists();
+        }
+
+        public void intervalRemoved(ListDataEvent e) {
+            updateNonSelectedPositionLists();
+        }
+
+        public void contentsChanged(ListDataEvent e) {
+            // selection changes are fired as contentsChanged: the previously selected
+            // list joins the gray set, the newly selected one leaves it
+            updateNonSelectedPositionLists();
+        }
+    }
 
     private class PositionsModelListener implements TableModelListener {
         public void tableChanged(TableModelEvent e) {

--- a/mapsforge-mapview/src/main/java/slash/navigation/mapview/mapsforge/renderer/NonSelectedPositionListsRenderer.java
+++ b/mapsforge-mapview/src/main/java/slash/navigation/mapview/mapsforge/renderer/NonSelectedPositionListsRenderer.java
@@ -28,6 +28,7 @@ import org.mapsforge.map.layer.overlay.Marker;
 import org.mapsforge.map.model.DisplayModel;
 import slash.navigation.base.BaseRoute;
 import slash.navigation.common.NavigationPosition;
+import slash.navigation.converter.gui.models.ColorModel;
 import slash.navigation.converter.gui.models.PositionListsModel;
 import slash.navigation.gui.models.IntegerModel;
 import slash.navigation.mapview.mapsforge.MapsforgeMapView;
@@ -39,6 +40,7 @@ import java.util.List;
 import static slash.common.helpers.ThreadHelper.invokeInAwtEventQueue;
 import static slash.navigation.base.RouteCharacteristics.Route;
 import static slash.navigation.base.RouteCharacteristics.Waypoints;
+import static slash.navigation.mapview.mapsforge.helpers.ColorHelper.asRGBA;
 
 /**
  * Renders every position list of a file that is not the selected one as a read-only,
@@ -51,12 +53,17 @@ import static slash.navigation.base.RouteCharacteristics.Waypoints;
  */
 
 public class NonSelectedPositionListsRenderer {
+    // waypoint icon: lighter/grayer so it reads as subordinate to the selected list
     private static final String NON_SELECTED_COLOR = "808080";
-    private static final String NON_SELECTED_OPACITY = "0.5";
-    private static final int NON_SELECTED_RGBA = 0x80808080;
+    private static final String NON_SELECTED_OPACITY = "0.7";
+    // non-selected Route/Track lines use a lightened version of the active list's color (solid),
+    // so the darker, fully-saturated active list clearly stands out as the one being edited
+    private static final float NON_SELECTED_LIGHTEN_FACTOR = 0.55f;
 
     private final MapsforgeMapView mapView;
     private final PositionListsModel positionListsModel;
+    private final ColorModel routeColorModel;
+    private final ColorModel trackColorModel;
     private final IntegerModel routeLineWidthModel;
     private final IntegerModel trackLineWidthModel;
     private final GraphicFactory graphicFactory;
@@ -64,10 +71,13 @@ public class NonSelectedPositionListsRenderer {
     private Bitmap waypointIcon;
 
     public NonSelectedPositionListsRenderer(MapsforgeMapView mapView, PositionListsModel positionListsModel,
+                                            ColorModel routeColorModel, ColorModel trackColorModel,
                                             IntegerModel routeLineWidthModel, IntegerModel trackLineWidthModel,
                                             GraphicFactory graphicFactory) {
         this.mapView = mapView;
         this.positionListsModel = positionListsModel;
+        this.routeColorModel = routeColorModel;
+        this.trackColorModel = trackColorModel;
         this.routeLineWidthModel = routeLineWidthModel;
         this.trackLineWidthModel = trackLineWidthModel;
         this.graphicFactory = graphicFactory;
@@ -127,14 +137,36 @@ public class NonSelectedPositionListsRenderer {
             if (latLongs.size() < 2)
                 return;
 
-            Paint paint = graphicFactory.createPaint();
-            paint.setColor(NON_SELECTED_RGBA);
-            paint.setStrokeWidth((route.getCharacteristics().equals(Route) ?
-                    routeLineWidthModel : trackLineWidthModel).getInteger());
-            Polyline polyline = new Polyline(latLongs, paint, mapView.getTileSize());
-            polyline.setDisplayModel(displayModel);
-            layer.layers.add(polyline);
+            boolean isRoute = route.getCharacteristics().equals(Route);
+            int width = (isRoute ? routeLineWidthModel : trackLineWidthModel).getInteger();
+            int color = lighten(asRGBA(isRoute ? routeColorModel : trackColorModel), NON_SELECTED_LIGHTEN_FACTOR);
+            // lighter shade of the active color, solid: the darker active line stays dominant
+            layer.layers.add(line(latLongs, color, width, displayModel));
         }
+    }
+
+    /**
+     * Blends the RGB of an ARGB color toward white by the given factor (0 = unchanged, 1 = white),
+     * keeping the alpha, so a non-selected line reads as a lighter shade of the active color.
+     */
+    static int lighten(int argb, float factor) {
+        int a = (argb >>> 24) & 0xFF;
+        int r = (argb >> 16) & 0xFF;
+        int g = (argb >> 8) & 0xFF;
+        int b = argb & 0xFF;
+        r = (int) (r + (255 - r) * factor);
+        g = (int) (g + (255 - g) * factor);
+        b = (int) (b + (255 - b) * factor);
+        return (a << 24) | (r << 16) | (g << 8) | b;
+    }
+
+    private Polyline line(List<LatLong> latLongs, int colorRgba, int strokeWidth, DisplayModel displayModel) {
+        Paint paint = graphicFactory.createPaint();
+        paint.setColor(colorRgba);
+        paint.setStrokeWidth(strokeWidth);
+        Polyline polyline = new Polyline(latLongs, paint, mapView.getTileSize());
+        polyline.setDisplayModel(displayModel);
+        return polyline;
     }
 
     private synchronized Bitmap getWaypointIcon() {

--- a/mapsforge-mapview/src/main/java/slash/navigation/mapview/mapsforge/renderer/NonSelectedPositionListsRenderer.java
+++ b/mapsforge-mapview/src/main/java/slash/navigation/mapview/mapsforge/renderer/NonSelectedPositionListsRenderer.java
@@ -1,0 +1,145 @@
+/*
+    This file is part of RouteConverter.
+
+    RouteConverter is free software; you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation; either version 2 of the License, or
+    (at your option) any later version.
+
+    RouteConverter is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with RouteConverter; if not, write to the Free Software
+    Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
+
+    Copyright (C) 2007 Christian Pesch. All Rights Reserved.
+*/
+package slash.navigation.mapview.mapsforge.renderer;
+
+import org.mapsforge.core.graphics.Bitmap;
+import org.mapsforge.core.graphics.GraphicFactory;
+import org.mapsforge.core.graphics.Paint;
+import org.mapsforge.core.model.LatLong;
+import org.mapsforge.map.layer.GroupLayer;
+import org.mapsforge.map.layer.overlay.Marker;
+import org.mapsforge.map.model.DisplayModel;
+import slash.navigation.base.BaseRoute;
+import slash.navigation.common.NavigationPosition;
+import slash.navigation.converter.gui.models.PositionListsModel;
+import slash.navigation.gui.models.IntegerModel;
+import slash.navigation.mapview.mapsforge.MapsforgeMapView;
+import slash.navigation.mapview.mapsforge.lines.Polyline;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import static slash.common.helpers.ThreadHelper.invokeInAwtEventQueue;
+import static slash.navigation.base.RouteCharacteristics.Route;
+import static slash.navigation.base.RouteCharacteristics.Waypoints;
+
+/**
+ * Renders every position list of a file that is not the selected one as a read-only,
+ * gray, non-interactive overlay for the {@link MapsforgeMapView}. The layers live on a
+ * dedicated {@link GroupLayer} the map view keeps below the selected list and its
+ * selection markers. Route-type lists are drawn from their stored positions - the
+ * routing engine and distance/time computation stay reserved for the selected list.
+ *
+ * @author Christian Pesch
+ */
+
+public class NonSelectedPositionListsRenderer {
+    private static final String NON_SELECTED_COLOR = "808080";
+    private static final String NON_SELECTED_OPACITY = "0.5";
+    private static final int NON_SELECTED_RGBA = 0x80808080;
+
+    private final MapsforgeMapView mapView;
+    private final PositionListsModel positionListsModel;
+    private final IntegerModel routeLineWidthModel;
+    private final IntegerModel trackLineWidthModel;
+    private final GraphicFactory graphicFactory;
+    private final GroupLayer layer = new GroupLayer();
+    private Bitmap waypointIcon;
+
+    public NonSelectedPositionListsRenderer(MapsforgeMapView mapView, PositionListsModel positionListsModel,
+                                            IntegerModel routeLineWidthModel, IntegerModel trackLineWidthModel,
+                                            GraphicFactory graphicFactory) {
+        this.mapView = mapView;
+        this.positionListsModel = positionListsModel;
+        this.routeLineWidthModel = routeLineWidthModel;
+        this.trackLineWidthModel = trackLineWidthModel;
+        this.graphicFactory = graphicFactory;
+    }
+
+    public GroupLayer getLayer() {
+        return layer;
+    }
+
+    public void update() {
+        invokeInAwtEventQueue(new Runnable() {
+            public void run() {
+                // GroupLayer.draw()/onDestroy() iterate the plain ArrayList layers under
+                // synchronized(this) on the render thread; hold the same monitor while we
+                // clear and repopulate here on the EDT to avoid a ConcurrentModificationException
+                synchronized (layer) {
+                    layer.layers.clear();
+
+                    List<BaseRoute> routes = positionListsModel.getRoutes();
+                    BaseRoute selectedRoute = positionListsModel.getSelectedRoute();
+                    if (routes != null) {
+                        for (BaseRoute route : routes) {
+                            if (route == null || route == selectedRoute)
+                                continue;
+                            addPositionList(route);
+                        }
+                    }
+                }
+
+                layer.requestRedraw();
+            }
+        });
+    }
+
+    @SuppressWarnings("unchecked")
+    private void addPositionList(BaseRoute route) {
+        List<NavigationPosition> positions = route.getPositions();
+        DisplayModel displayModel = mapView.getMapView().getModel().displayModel;
+
+        if (route.getCharacteristics().equals(Waypoints)) {
+            Bitmap icon = getWaypointIcon();
+            for (NavigationPosition position : positions) {
+                if (position == null || !position.hasCoordinates())
+                    continue;
+
+                Marker marker = new Marker(mapView.asLatLong(position), icon, 0, 0);
+                marker.setDisplayModel(displayModel);
+                layer.layers.add(marker);
+            }
+
+        } else {
+            List<LatLong> latLongs = new ArrayList<>();
+            for (NavigationPosition position : positions) {
+                if (position != null && position.hasCoordinates())
+                    latLongs.add(mapView.asLatLong(position));
+            }
+            if (latLongs.size() < 2)
+                return;
+
+            Paint paint = graphicFactory.createPaint();
+            paint.setColor(NON_SELECTED_RGBA);
+            paint.setStrokeWidth((route.getCharacteristics().equals(Route) ?
+                    routeLineWidthModel : trackLineWidthModel).getInteger());
+            Polyline polyline = new Polyline(latLongs, paint, mapView.getTileSize());
+            polyline.setDisplayModel(displayModel);
+            layer.layers.add(polyline);
+        }
+    }
+
+    private synchronized Bitmap getWaypointIcon() {
+        if (waypointIcon == null)
+            waypointIcon = mapView.createWaypointIcon(NON_SELECTED_COLOR, NON_SELECTED_OPACITY);
+        return waypointIcon;
+    }
+}

--- a/mapsforge-mapview/src/test/java/slash/navigation/mapview/mapsforge/renderer/NonSelectedPositionListsRendererTest.java
+++ b/mapsforge-mapview/src/test/java/slash/navigation/mapview/mapsforge/renderer/NonSelectedPositionListsRendererTest.java
@@ -1,0 +1,59 @@
+/*
+    This file is part of RouteConverter.
+
+    RouteConverter is free software; you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation; either version 2 of the License, or
+    (at your option) any later version.
+
+    RouteConverter is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with RouteConverter; if not, write to the Free Software
+    Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
+
+    Copyright (C) 2007 Christian Pesch. All Rights Reserved.
+*/
+package slash.navigation.mapview.mapsforge.renderer;
+
+import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+import static slash.navigation.mapview.mapsforge.renderer.NonSelectedPositionListsRenderer.lighten;
+
+public class NonSelectedPositionListsRendererTest {
+
+    @Test
+    public void factorZeroKeepsTheColor() {
+        assertEquals(0xFF3379FF, lighten(0xFF3379FF, 0.0f));
+    }
+
+    @Test
+    public void factorOneTurnsRgbWhiteButKeepsAlpha() {
+        assertEquals(0xFFFFFFFF, lighten(0xFF3379FF, 1.0f));
+        assertEquals(0x80FFFFFF, lighten(0x80000000, 1.0f));
+    }
+
+    @Test
+    public void factorHalfBlendsHalfwayToWhite() {
+        // each channel: c + (255 - c) * 0.5 -> 0 becomes 127
+        assertEquals(0xFF7F7F7F, lighten(0xFF000000, 0.5f));
+    }
+
+    @Test
+    public void alphaIsPreserved() {
+        assertEquals(0x80, (lighten(0x803379FF, 0.55f) >>> 24) & 0xFF);
+    }
+
+    @Test
+    public void lightenedIsBrighterPerChannel() {
+        int original = 0xFF2050A0;
+        int lightened = lighten(original, 0.55f);
+        assertEquals(true, ((lightened >> 16) & 0xFF) > ((original >> 16) & 0xFF));
+        assertEquals(true, ((lightened >> 8) & 0xFF) > ((original >> 8) & 0xFF));
+        assertEquals(true, (lightened & 0xFF) > (original & 0xFF));
+    }
+}

--- a/mapview/src/main/java/slash/navigation/converter/gui/models/PositionListsModel.java
+++ b/mapview/src/main/java/slash/navigation/converter/gui/models/PositionListsModel.java
@@ -1,0 +1,40 @@
+/*
+    This file is part of RouteConverter.
+
+    RouteConverter is free software; you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation; either version 2 of the License, or
+    (at your option) any later version.
+
+    RouteConverter is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with RouteConverter; if not, write to the Free Software
+    Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
+
+    Copyright (C) 2007 Christian Pesch. All Rights Reserved.
+*/
+
+package slash.navigation.converter.gui.models;
+
+import slash.navigation.base.BaseRoute;
+
+import javax.swing.event.ListDataListener;
+import java.util.List;
+
+/**
+ * A model for all position lists of a file and the selected position list.
+ *
+ * @author Christian Pesch
+ */
+
+public interface PositionListsModel {
+    List<BaseRoute> getRoutes();
+    BaseRoute getSelectedRoute();
+
+    void addListDataListener(ListDataListener l);
+    void removeListDataListener(ListDataListener l);
+}

--- a/mapview/src/main/java/slash/navigation/mapview/MapView.java
+++ b/mapview/src/main/java/slash/navigation/mapview/MapView.java
@@ -36,6 +36,7 @@ import java.util.List;
 
 public interface MapView extends PositionsSelectionModel {
     void initialize(PositionsModel positionsModel,
+                    PositionListsModel positionListsModel,
                     MapPreferencesModel preferencesModel,
                     MapViewCallback mapViewCallback);
     boolean isDownload();

--- a/route-converter-gui/src/main/java/slash/navigation/converter/gui/RouteConverter.java
+++ b/route-converter-gui/src/main/java/slash/navigation/converter/gui/RouteConverter.java
@@ -412,7 +412,8 @@ public abstract class RouteConverter extends SingleFrameApplication {
                     printStackTrace(new UnsupportedOperationException()).replaceAll("\n", "<p>"))), MAP_PANEL_CONSTRAINTS);
 
         } else {
-            getMapView().initialize(getConvertPanel().getPositionsModel(), mapPreferencesModel, getMapViewCallback());
+            getMapView().initialize(getConvertPanel().getPositionsModel(), getConvertPanel().getFormatAndRoutesModel(),
+                    mapPreferencesModel, getMapViewCallback());
 
             @SuppressWarnings({"ThrowableResultOfMethodCallIgnored"})
             Throwable cause = getMapView().getInitializationCause();

--- a/route-converter-gui/src/main/java/slash/navigation/converter/gui/models/FormatAndRoutesModel.java
+++ b/route-converter-gui/src/main/java/slash/navigation/converter/gui/models/FormatAndRoutesModel.java
@@ -32,7 +32,7 @@ import java.util.List;
  * @author Christian Pesch
  */
 
-public interface FormatAndRoutesModel extends ComboBoxModel {
+public interface FormatAndRoutesModel extends ComboBoxModel, PositionListsModel {
     List<BaseRoute> getRoutes();
     void setRoutes(FormatAndRoutes<BaseNavigationFormat, BaseRoute, BaseNavigationPosition> formatAndRoutes);
     NavigationFormat<BaseRoute> getFormat();

--- a/route-converter-gui/src/test/java/slash/navigation/converter/gui/models/NonSelectedListsFlowIT.java
+++ b/route-converter-gui/src/test/java/slash/navigation/converter/gui/models/NonSelectedListsFlowIT.java
@@ -1,0 +1,96 @@
+/*
+    This file is part of RouteConverter.
+
+    RouteConverter is free software; you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation; either version 2 of the License, or
+    (at your option) any later version.
+
+    RouteConverter is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with RouteConverter; if not, write to the Free Software
+    Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
+
+    Copyright (C) 2007 Christian Pesch. All Rights Reserved.
+*/
+
+package slash.navigation.converter.gui.models;
+
+import org.junit.Test;
+import slash.navigation.base.*;
+
+import javax.swing.event.ListDataEvent;
+import javax.swing.event.ListDataListener;
+import java.io.File;
+import java.util.ArrayList;
+import java.util.List;
+
+import static org.junit.Assert.*;
+
+/**
+ * Guards the {@link PositionListsModel} contract that MapsforgeMapView's gray
+ * non-selected-list rendering is driven by: {@link PositionListsModel#getRoutes()} /
+ * {@link PositionListsModel#getSelectedRoute()} stay consistent, and the ListDataEvents
+ * that trigger a gray-set rebuild fire on load and on selection switch. It does not
+ * exercise the mapsforge rendering itself (no map view is instantiated here).
+ */
+public class NonSelectedListsFlowIT {
+
+    private static List<BaseRoute> graySet(PositionListsModel model) {
+        List<BaseRoute> result = new ArrayList<>();
+        BaseRoute selected = model.getSelectedRoute();
+        for (BaseRoute route : model.getRoutes())
+            if (route != selected)
+                result.add(route);
+        return result;
+    }
+
+    @Test
+    public void grayListsAreAllRoutesExceptSelectedAndFollowSwitches() throws Exception {
+        PositionsModel positionsModel = new PositionsModelImpl(new PositionsModelCallback() {
+            public String getStringAt(slash.navigation.common.NavigationPosition p, int c) { return null; }
+            public void setValueAt(slash.navigation.common.NavigationPosition p, int c, Object v) { }
+        });
+        CharacteristicsModel characteristicsModel = new CharacteristicsModel();
+        FormatAndRoutesModel model = new FormatAndRoutesModelImpl(positionsModel, characteristicsModel);
+
+        final int[] contentsChanged = {0}, intervalAdded = {0};
+        model.addListDataListener(new ListDataListener() {
+            public void intervalAdded(ListDataEvent e) { intervalAdded[0]++; }
+            public void intervalRemoved(ListDataEvent e) { }
+            public void contentsChanged(ListDataEvent e) { contentsChanged[0]++; }
+        });
+
+        NavigationFormatParser parser = new NavigationFormatParser(new NavigationFormatRegistry());
+        ParserResult result = parser.read(new File("../navigation-formats-samples/src/test/from.gpx"));
+        assertTrue("parse failed", result.isSuccessful());
+
+        List<BaseRoute> all = result.getAllRoutes();
+        assertTrue("expected a multi-list file with at least 3 lists, got " + all.size(), all.size() >= 3);
+
+        model.setRoutes(new FormatAndRoutes(result.getFormat(), all));
+
+        // load fired an interval-added event (map rebuilds the gray set from it)
+        assertTrue("load did not fire a list event", intervalAdded[0] >= 1);
+
+        // first list is selected; every other list is the gray set
+        assertEquals(all.get(0), model.getSelectedRoute());
+        List<BaseRoute> gray = graySet(model);
+        assertEquals(all.size() - 1, gray.size());
+        assertFalse(gray.contains(model.getSelectedRoute()));
+
+        // switch selection -> previously selected joins gray, newly selected leaves it
+        contentsChanged[0] = 0;
+        model.setSelectedRoute(all.get(2));
+        assertTrue("switch did not fire contentsChanged", contentsChanged[0] >= 1);
+        assertEquals(all.get(2), model.getSelectedRoute());
+        gray = graySet(model);
+        assertEquals(all.size() - 1, gray.size());
+        assertTrue("previously selected list must now be gray", gray.contains(all.get(0)));
+        assertFalse("newly selected list must not be gray", gray.contains(all.get(2)));
+    }
+}

--- a/specs/00015-show-nonselected-lists-readonly.md
+++ b/specs/00015-show-nonselected-lists-readonly.md
@@ -1,9 +1,9 @@
 ---
 name: 00015-show-nonselected-lists-readonly
-status: proposed
-phases_done: []
-phases_next: []
-last_touched: 2026-07-03
+status: implemented (gray read-only MVP, needs manual UI test)
+phases_done: [gray-readonly-mvp]
+phases_next: [manual-ui-verification]
+last_touched: 2026-07-04
 ---
 
 # 00015 - Show non-selected position lists read-only (gray)
@@ -119,6 +119,38 @@ gray render path** for every other list in the file:
   path must dispatch per list, not assume one type.
 - **Repaint triggers:** existing color/characteristics/routing listeners assume
   one list; each needs a companion that also refreshes the gray set.
+
+## Implementation notes (2026-07-04)
+
+Implemented as designed, with one structural deviation that earlier manual
+attempts likely tripped over: `FormatAndRoutesModel` lives in
+`route-converter-gui`, which **depends on** `mapview` (where `MapView` and
+`PositionsModel` live) — so `MapView.initialize` cannot take
+`FormatAndRoutesModel` without a circular module dependency. Solution: new
+minimal interface `PositionListsModel` (`mapview/.../converter/gui/models/`,
+same package) with `getRoutes()`, `getSelectedRoute()` and list-data listener
+registration; `FormatAndRoutesModel` extends it, so no caller changes.
+
+- `MapView.initialize`/`MapsforgeMapView.initialize` take the extra
+  `PositionListsModel`; `RouteConverter.setMapView` passes
+  `getConvertPanel().getFormatAndRoutesModel()` (the undo wrapper delegates
+  listeners to the impl, so events flow).
+- Gray render path: one `GroupLayer` (`nonSelectedPositionListsLayer`)
+  inserted directly above the map/background tile layers, i.e. below the
+  active list's layers and selection markers. Rebuilt wholesale from
+  `getRoutes() minus getSelectedRoute()` on every `ListDataEvent` (selection
+  switch fires `contentsChanged`, list add/remove fire interval events,
+  `setRoutes` fires both), on map/theme switch, and on color/line-width
+  changes.
+- Per-list dispatch: Waypoints → plain gray `Marker` per position (gray
+  variant of waypoint.svg, opacity 0.5); Route/Track → a single gray
+  `Polyline` over the stored positions (one layer per list — cheap, no
+  per-pair layers, no routing engine, no DistanceAndTimeAggregator).
+- Read-only for free: plain `Marker`/`Polyline` layers have no tap/drag
+  handling, and all edit paths (`getClosestPosition`, add/move/delete) only
+  consult the active `positionsModel`, so gray lists cannot be edited or
+  snapped onto.
+- Single-list files: gray set is empty, behaviour unchanged.
 
 ## Future evolution (not this spec)
 

--- a/specs/00015-show-nonselected-lists-readonly.md
+++ b/specs/00015-show-nonselected-lists-readonly.md
@@ -1,21 +1,39 @@
 ---
 name: 00015-show-nonselected-lists-readonly
-status: implemented (gray read-only MVP, needs manual UI test)
-phases_done: [gray-readonly-mvp]
+status: implemented (read-only MVP on PR #117, needs manual UI test)
+phases_done: [readonly-mvp]
 phases_next: [manual-ui-verification]
-last_touched: 2026-07-04
+last_touched: 2026-07-05
 ---
 
-# 00015 - Show non-selected position lists read-only (gray)
+# 00015 - Show non-selected position lists read-only
 
 ## Status
 
-Proposed. Created on July 3, 2026, from issue
+Implemented on PR [#117](https://github.com/cpesch/RouteConverter/pull/117),
+rebased onto the refactored `MapsforgeMapView` (after #119/#125/#126). The
+read-only secondary render path is done and unit-tested; only a manual UI pass
+remains before merge.
+
+**Styling evolved during external-feedback review (2026-07-05):** the original
+plan drew non-selected lists flat gray, but on light/busy map themes that was
+barely visible, and later experiments (dark line + white casing; dashed) either
+over-powered the active list or inverted the hierarchy. The shipped look draws
+each non-selected Route/Track list as a **lighter solid shade of the active
+route/track color** (`NonSelectedPositionListsRenderer.lighten()`, ~55% toward
+white), so the darker, fully-saturated active list clearly stands out as the one
+being edited. Waypoint lists use a subordinate gray icon. The active list's own
+render path is unchanged (a per-segment casing was tried and reverted — it
+interleaved white over the colored joins).
+
+Created on July 3, 2026, from issue
 [#101](https://github.com/cpesch/RouteConverter/issues/101) (Baltasarq,
 2026-06-01), which was split off the #91 POI thread. Scope tier decided by the
-maintainer on 2026-07-03: **the gray read-only MVP** — draw every non-selected
-position list in the file as gray, non-interactive; keep editing exactly as
-today (one list, chosen by the existing combo). The more ambitious forum design
+maintainer on 2026-07-03: **the read-only MVP** — draw every non-selected
+position list in the file de-emphasized and non-interactive; keep editing
+exactly as today (one list, chosen by the existing combo). (The de-emphasis was
+planned as flat gray; it shipped as a lighter shade of the active color — see
+Status.) The more ambitious forum design
 (Mogh's panel with per-list colors + visibility checkboxes + multi-edit +
 multiple elevation profiles) is recorded below as the future evolution, not this
 spec's scope.


### PR DESCRIPTION
Implements spec `00015` — issue #101 (gray read-only MVP).

## What
Every position list in a loaded file that is **not** the combo-selected one is drawn **gray, semi-transparent and non-interactive**. The selected list stays editable/colored exactly as today. Switching the combo makes the newly-selected list editable and the previously-selected one gray; both stay visible.

## Why the extra interface (`PositionListsModel`)
`MapView` lives in module `mapview`; `FormatAndRoutesModel` lives in `route-converter-gui`, which **depends on** `mapview`. Passing `FormatAndRoutesModel` into `MapView.initialize` directly would be a circular module dependency. A minimal `PositionListsModel` (`getRoutes` / `getSelectedRoute` + listeners) in `mapview`, which `FormatAndRoutesModel` extends, breaks the cycle with no caller changes.

## How
- `MapView.initialize` / `MapsforgeMapView.initialize` take the extra model; `RouteConverter.setMapView` passes it.
- Gray lists render into a dedicated `GroupLayer` inserted below the active list + selection markers, rebuilt from *routes − selected* on load, selection switch, list add/remove and color/line-width changes.
- Per characteristic: Waypoints → gray markers; Route/Track → one gray `Polyline` over stored positions. **No routing engine, no `DistanceAndTimeAggregator`** for the read-only set.
- Layer mutation is `synchronized` on the `GroupLayer` to exclude with the render thread's `draw()` (avoids a `ConcurrentModificationException` / blank map on switch-during-redraw).
- Read-only for free: plain `Marker`/`Polyline` have no drag/tap; all edit paths only consult the active `positionsModel`.
- Single-list files unchanged.

## Testing
- Full reactor build green (`route-converter -am`, Java 21).
- `mapview` + `mapsforge-mapview` unit tests pass (59).
- New `NonSelectedListsFlowIT` drives the model contract (routes-minus-selected + list events on load/switch) against a real multi-list GPX.
- High-effort multi-agent code review run; the one real bug it found (GroupLayer mutation race) is fixed in this branch.

## Still needs a human eyeball (native Swing GUI, not driveable headlessly here)
- gray lists actually render gray/semi-transparent below the colored active list;
- clicking/dragging never snaps onto a gray list.

## Out of scope (spec: future evolution)
Per-list colors, a list panel, visibility toggles, multi-list editing, multiple elevation profiles.

> Note for the closed edition: `MapView.initialize` gained a parameter. If `browser-mapview` (`JavaFX8WebViewMapView`) is still shipped there, it needs the new 4-arg signature too or it will `AbstractMethodError` at runtime. Not reachable in the open-source build.