### PR TITLE
Wire BRouter into analyze mode for routed lengths (spec 00055 P2b)

### DIFF
--- a/route-converter-cmdline/pom.xml
+++ b/route-converter-cmdline/pom.xml
@@ -10,6 +10,11 @@
         <relativePath>../pom.xml</relativePath>
     </parent>
 
+    <properties>
+        <!-- keep in sync with brouter/pom.xml: the analyze BRouter length seam reuses these -->
+        <brouter.version>1.7.8</brouter.version>
+    </properties>
+
     <dependencies>
         <dependency>
             <groupId>${project.groupId}</groupId>
@@ -21,6 +26,34 @@
             <artifactId>log4j-to-slf4j</artifactId>
             <version>2.24.3</version>
             <scope>runtime</scope>
+        </dependency>
+        <!-- BRouter offline routing for the analyze routed-length seam (specs/00055 P2b).
+             RoutingContext/RoutingEngine are used directly, matching the calling
+             convention in slash.navigation.brouter.BRouter#getRouteBetween. -->
+        <dependency>
+            <groupId>org.btools</groupId>
+            <artifactId>brouter-core</artifactId>
+            <version>${brouter.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.btools</groupId>
+            <artifactId>brouter-expressions</artifactId>
+            <version>${brouter.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.btools</groupId>
+            <artifactId>brouter-mapaccess</artifactId>
+            <version>${brouter.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.btools</groupId>
+            <artifactId>brouter-codec</artifactId>
+            <version>${brouter.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.btools</groupId>
+            <artifactId>brouter-util</artifactId>
+            <version>${brouter.version}</version>
         </dependency>
     </dependencies>
 </project>

--- a/route-converter-cmdline/src/main/doc/analyze-json.md
+++ b/route-converter-cmdline/src/main/doc/analyze-json.md
@@ -49,15 +49,40 @@ them from `bbox` centre via point-in-polygon (keeps geo data out of Java).
 
 ## `lengthKind` semantics
 
-Each position list is measured point-to-point (recorded geometry):
+- **Track** characteristic → `track` (recorded GPS track length, measured
+  point-to-point along the recorded geometry).
+- **Waypoints** characteristic → `beeline` (straight-line length between the
+  points; never routed).
+- **Route** characteristic (planned routes) → depends on `--brouter-segments`:
+  - **routed** when `--brouter-segments <dir>` is given, the list falls inside
+    the BRouter `.rd5` segment coverage in that directory, and every leg
+    routes successfully. The reported length is the sum of the on-road leg
+    distances between consecutive route points.
+  - **beeline** otherwise — no `--brouter-segments` given, the directory does
+    not exist, the list is outside coverage, or any single leg fails to route
+    (routing error, timeout, no segment). A partially-covered route is reported
+    wholly as `beeline`, never as a mix, so the label never over-promises.
 
-- **Track** characteristic → `track` (recorded GPS track length).
-- **Route** / **Waypoints** characteristic → `beeline` (straight-line length
-  between planned points; not a routed distance).
-- `routed` is reserved: when a `RouteLengthComputer` backed by BRouter is wired
-  in (spec 00055 P3, host infra), Route-type lists inside coverage report
-  `routed` with the on-road distance. The seam is `RouteLengthComputer`; the
-  default `PointToPointLengthComputer` never returns `routed`.
+Routing is best-effort and never aborts the run: any BRouter failure degrades
+that list to `beeline` and the JSON is still emitted.
+
+### BRouter profile
+
+Routed lengths use the **`trekking`** profile (BRouter's general-purpose
+bike/foot profile), bundled with the command-line tool. Planned catalog routes
+are predominantly cycling and hiking tours; trekking follows both roads and
+paths, giving a plausible on-road length across the widest range of routes,
+whereas a car-only profile would refuse footpaths and fall back to beeline on
+exactly those tours. The profile and its `lookups.dat` must match the lookup
+version of the `.rd5` segments on disk; a mismatch makes routing fail and the
+list falls back to `beeline`.
+
+### Routing vs. the client
+
+The number is a BRouter estimate, not a promise of equality with the client's
+Convert tab (which may use map-rendered routing such as GraphHopper or Google
+Maps for Route lists). `lengthKind=routed` labels the method, not a specific
+router.
 
 File-level aggregation of a mixed file reports the least-certain kind present:
 `beeline` if any list is beeline, else `routed` if any list is routed, else

--- a/route-converter-cmdline/src/main/java/slash/navigation/converter/cmdline/BRouterLegRouter.java
+++ b/route-converter-cmdline/src/main/java/slash/navigation/converter/cmdline/BRouterLegRouter.java
@@ -1,0 +1,166 @@
+/*
+    This file is part of RouteConverter.
+
+    RouteConverter is free software; you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation; either version 2 of the License, or
+    (at your option) any later version.
+
+    RouteConverter is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with RouteConverter; if not, write to the Free Software
+    Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
+
+    Copyright (C) 2007 Christian Pesch. All Rights Reserved.
+*/
+
+package slash.navigation.converter.cmdline;
+
+import btools.router.OsmNodeNamed;
+import btools.router.OsmTrack;
+import btools.router.RoutingContext;
+import btools.router.RoutingEngine;
+import slash.navigation.converter.cmdline.BRouterRouteLengthComputer.LegRouter;
+
+import java.io.File;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.OutputStream;
+import java.nio.file.Files;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.logging.Logger;
+
+import static java.lang.String.format;
+
+/**
+ * Production {@link LegRouter}: routes a single leg with BRouter's offline
+ * engine against a directory of {@code .rd5} segment files, using a default
+ * profile bundled with this module. This mirrors the calling convention of
+ * {@code slash.navigation.brouter.BRouter#getRouteBetween} (build a
+ * {@code RoutingContext} pointing at the profile, run a {@code RoutingEngine}
+ * over the segments directory, read distance from the found track) but without
+ * the GUI download/DataSource machinery — the analyzer runs against segments
+ * that already exist on disk (specs/00055 P3 host infra).
+ * <p>
+ * Profile choice: {@code trekking} — BRouter's general-purpose bike/foot
+ * profile. Planned routes in the RouteConverter catalog are predominantly
+ * cycling and hiking tours; trekking follows both roads and paths, so it yields
+ * a plausible on-road length across the widest range of catalog routes. A
+ * car-only profile would refuse footpaths and fail (fall back to beeline) on
+ * exactly those tours. The profile and its {@code lookups.dat} ship as
+ * resources under {@code slash/navigation/converter/cmdline/brouter/} and are
+ * extracted to a temporary directory on first use.
+ * <p>
+ * Memory stays bounded: {@code RoutingContext.memoryclass} defaults to 64 MB
+ * for the node cache and a fresh engine is used per leg, well within the
+ * {@code -Xmx1g} the analyzer runs with.
+ *
+ * @author Christian Pesch
+ */
+class BRouterLegRouter implements LegRouter {
+    private static final Logger log = Logger.getLogger(BRouterLegRouter.class.getName());
+    private static final String PROFILE_NAME = "trekking.brf";
+    private static final String LOOKUPS_NAME = "lookups.dat";
+    private static final String RESOURCE_PREFIX = "brouter/";
+    private static final long MINIMUM_TIMEOUT = 10000L;
+    private static final long MAXIMUM_TIMEOUT = 60000L;
+
+    private final File segmentsDirectory;
+    private File profileFile;
+    private boolean profileExtractionAttempted;
+
+    BRouterLegRouter(File segmentsDirectory) {
+        this.segmentsDirectory = segmentsDirectory;
+    }
+
+    public Double routeLeg(double fromLongitude, double fromLatitude, double toLongitude, double toLatitude) {
+        if (segmentsDirectory == null || !segmentsDirectory.isDirectory()) {
+            log.warning(format("BRouter segments directory %s does not exist; cannot route", segmentsDirectory));
+            return null;
+        }
+
+        File profile = getProfileFile();
+        if (profile == null)
+            return null;
+
+        RoutingContext routingContext = new RoutingContext();
+        routingContext.localFunction = profile.getPath();
+
+        List<OsmNodeNamed> waypoints = new ArrayList<>();
+        waypoints.add(asOsmNodeNamed(fromLongitude, fromLatitude));
+        waypoints.add(asOsmNodeNamed(toLongitude, toLatitude));
+
+        RoutingEngine routingEngine = new RoutingEngine(null, null, segmentsDirectory, waypoints, routingContext);
+        routingEngine.quite = true;
+        routingEngine.doRun(timeoutFor(fromLongitude, fromLatitude, toLongitude, toLatitude));
+
+        if (routingEngine.getErrorMessage() != null) {
+            log.info(format("BRouter routing error: %s", routingEngine.getErrorMessage()));
+            return null;
+        }
+        OsmTrack track = routingEngine.getFoundTrack();
+        if (track == null)
+            return null;
+        return (double) routingEngine.getDistance();
+    }
+
+    /**
+     * Larger legs get a longer budget, matching the heuristic in
+     * {@code BRouter#getRouteBetween}, but capped so a single hostile leg can
+     * never wedge a batch of analyze runs.
+     */
+    private long timeoutFor(double fromLongitude, double fromLatitude, double toLongitude, double toLatitude) {
+        double meanLatitude = Math.toRadians((fromLatitude + toLatitude) / 2);
+        double deltaLongitude = (toLongitude - fromLongitude) * Math.cos(meanLatitude);
+        double deltaLatitude = toLatitude - fromLatitude;
+        double beelineMeters = Math.sqrt(deltaLongitude * deltaLongitude + deltaLatitude * deltaLatitude) * 111320.0;
+        long timeout = (long) (MINIMUM_TIMEOUT + beelineMeters / 15.0);
+        return Math.min(timeout, MAXIMUM_TIMEOUT);
+    }
+
+    private synchronized File getProfileFile() {
+        if (profileExtractionAttempted)
+            return profileFile;
+        profileExtractionAttempted = true;
+        try {
+            File directory = Files.createTempDirectory("brouter-analyze").toFile();
+            directory.deleteOnExit();
+            File extractedLookups = extractResource(LOOKUPS_NAME, directory);
+            extractedLookups.deleteOnExit();
+            File extractedProfile = extractResource(PROFILE_NAME, directory);
+            extractedProfile.deleteOnExit();
+            profileFile = extractedProfile;
+        } catch (IOException e) {
+            log.warning(format("Cannot extract BRouter profile; routed lengths disabled: %s", e));
+            profileFile = null;
+        }
+        return profileFile;
+    }
+
+    private File extractResource(String name, File directory) throws IOException {
+        File target = new File(directory, name);
+        try (InputStream in = BRouterLegRouter.class.getResourceAsStream(RESOURCE_PREFIX + name)) {
+            if (in == null)
+                throw new IOException("Resource " + RESOURCE_PREFIX + name + " not found on classpath");
+            try (OutputStream out = Files.newOutputStream(target.toPath())) {
+                byte[] buffer = new byte[8192];
+                int read;
+                while ((read = in.read(buffer)) != -1)
+                    out.write(buffer, 0, read);
+            }
+        }
+        return target;
+    }
+
+    private OsmNodeNamed asOsmNodeNamed(double longitude, double latitude) {
+        OsmNodeNamed result = new OsmNodeNamed();
+        result.ilon = (int) ((longitude + 180.0) * 1000000.0 + 0.5);
+        result.ilat = (int) ((latitude + 90.0) * 1000000.0 + 0.5);
+        return result;
+    }
+}

--- a/route-converter-cmdline/src/main/java/slash/navigation/converter/cmdline/BRouterLegRouter.java
+++ b/route-converter-cmdline/src/main/java/slash/navigation/converter/cmdline/BRouterLegRouter.java
@@ -71,8 +71,10 @@ class BRouterLegRouter implements LegRouter {
     private static final long MAXIMUM_TIMEOUT = 60000L;
 
     private final File segmentsDirectory;
-    private File profileFile;
-    private boolean profileExtractionAttempted;
+    // static: one extraction per JVM, not per file — a batch-reused analyzer
+    // JVM would otherwise accumulate temp directories until exit
+    private static File profileFile;
+    private static boolean profileExtractionAttempted;
 
     BRouterLegRouter(File segmentsDirectory) {
         this.segmentsDirectory = segmentsDirectory;
@@ -123,7 +125,7 @@ class BRouterLegRouter implements LegRouter {
         return Math.min(timeout, MAXIMUM_TIMEOUT);
     }
 
-    private synchronized File getProfileFile() {
+    private static synchronized File getProfileFile() {
         if (profileExtractionAttempted)
             return profileFile;
         profileExtractionAttempted = true;
@@ -142,7 +144,7 @@ class BRouterLegRouter implements LegRouter {
         return profileFile;
     }
 
-    private File extractResource(String name, File directory) throws IOException {
+    private static File extractResource(String name, File directory) throws IOException {
         File target = new File(directory, name);
         try (InputStream in = BRouterLegRouter.class.getResourceAsStream(RESOURCE_PREFIX + name)) {
             if (in == null)

--- a/route-converter-cmdline/src/main/java/slash/navigation/converter/cmdline/BRouterRouteLengthComputer.java
+++ b/route-converter-cmdline/src/main/java/slash/navigation/converter/cmdline/BRouterRouteLengthComputer.java
@@ -1,0 +1,125 @@
+/*
+    This file is part of RouteConverter.
+
+    RouteConverter is free software; you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation; either version 2 of the License, or
+    (at your option) any later version.
+
+    RouteConverter is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with RouteConverter; if not, write to the Free Software
+    Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
+
+    Copyright (C) 2007 Christian Pesch. All Rights Reserved.
+*/
+
+package slash.navigation.converter.cmdline;
+
+import slash.navigation.base.BaseNavigationPosition;
+import slash.navigation.base.BaseRoute;
+import slash.navigation.common.NavigationPosition;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.logging.Logger;
+
+import static slash.navigation.base.RouteCharacteristics.Route;
+
+/**
+ * BRouter-backed {@link RouteLengthComputer} for the {@code analyze} command
+ * (specs/00055 P2b). Route-characteristic position lists (planned routes) are
+ * routed on-road with BRouter and reported as {@code routed}; every other list
+ * (recorded tracks, loose waypoints) is delegated to the point-to-point
+ * {@link PointToPointLengthComputer}.
+ * <p>
+ * A Route list is routed leg by leg between consecutive positions that carry
+ * coordinates, and the leg distances are summed. If <em>any</em> leg cannot be
+ * routed (no segment coverage, routing error, timeout, missing profile) the
+ * whole list falls back to the straight-line {@code beeline} length, so the
+ * label never over-promises and a partially-covered route is never reported as
+ * a mix. Routing failures never propagate: {@link #computeLength} never throws
+ * for a routing problem, so the analyzer always emits its JSON.
+ * <p>
+ * The actual leg routing is behind the {@link LegRouter} seam. The production
+ * seam is {@link BRouterLegRouter}, which drives BRouter's
+ * {@code RoutingContext}/{@code RoutingEngine} exactly like
+ * {@code slash.navigation.brouter.BRouter#getRouteBetween}. Tests inject a fake
+ * {@link LegRouter} to exercise the summation and fallback logic without real
+ * {@code .rd5} segments.
+ *
+ * @author Christian Pesch
+ */
+public class BRouterRouteLengthComputer implements RouteLengthComputer {
+    private static final Logger log = Logger.getLogger(BRouterRouteLengthComputer.class.getName());
+
+    private final RouteLengthComputer fallback = new PointToPointLengthComputer();
+    private final LegRouter legRouter;
+
+    /**
+     * Routes a single leg between two coordinates.
+     */
+    interface LegRouter {
+        /**
+         * @return the on-road distance in metres, or {@code null} if the leg
+         *         cannot be routed (no coverage, error, timeout)
+         */
+        Double routeLeg(double fromLongitude, double fromLatitude, double toLongitude, double toLatitude);
+    }
+
+    /**
+     * Production constructor: routes with BRouter against the given {@code .rd5}
+     * segments directory using the bundled default profile.
+     */
+    public BRouterRouteLengthComputer(java.io.File segmentsDirectory) {
+        this(new BRouterLegRouter(segmentsDirectory));
+    }
+
+    BRouterRouteLengthComputer(LegRouter legRouter) {
+        this.legRouter = legRouter;
+    }
+
+    public LengthResult computeLength(BaseRoute<?, ?> route) {
+        if (route.getCharacteristics() != Route)
+            return fallback.computeLength(route);
+        if (route.getPositionCount() < 2)
+            return null;
+
+        @SuppressWarnings("unchecked")
+        List<BaseNavigationPosition> positions = ((BaseRoute<BaseNavigationPosition, ?>) route).getPositions();
+        List<NavigationPosition> withCoordinates = new ArrayList<>();
+        for (NavigationPosition position : positions) {
+            if (position.getLongitude() != null && position.getLatitude() != null)
+                withCoordinates.add(position);
+        }
+        if (withCoordinates.size() < 2)
+            return fallback.computeLength(route);
+
+        double routedMeters = 0;
+        for (int i = 1; i < withCoordinates.size(); i++) {
+            NavigationPosition from = withCoordinates.get(i - 1);
+            NavigationPosition to = withCoordinates.get(i);
+            Double legMeters = safeRouteLeg(from, to);
+            if (legMeters == null) {
+                log.info("BRouter could not route a leg; falling back to beeline for this list");
+                return fallback.computeLength(route);
+            }
+            routedMeters += legMeters;
+        }
+        return new LengthResult(routedMeters, "routed");
+    }
+
+    private Double safeRouteLeg(NavigationPosition from, NavigationPosition to) {
+        try {
+            return legRouter.routeLeg(from.getLongitude(), from.getLatitude(), to.getLongitude(), to.getLatitude());
+        } catch (Throwable t) {
+            // never let a routing error crash the analyze run
+            log.warning("BRouter leg routing failed: " + t);
+            return null;
+        }
+    }
+}

--- a/route-converter-cmdline/src/main/java/slash/navigation/converter/cmdline/RouteConverterCmdLine.java
+++ b/route-converter-cmdline/src/main/java/slash/navigation/converter/cmdline/RouteConverterCmdLine.java
@@ -119,9 +119,12 @@ public class RouteConverterCmdLine {
     /**
      * {@code analyze <source file> [--brouter-segments <dir>]} — writes one line
      * of metadata JSON (see src/main/doc/analyze-json.md, specs/00055) to stdout.
-     * The {@code --brouter-segments} option is reserved for the BRouter length
-     * seam (see {@link RouteLengthComputer}); it is accepted but currently unused,
-     * so Route-type lists are measured as beeline.
+     * When {@code --brouter-segments <dir>} points at a directory of BRouter
+     * {@code .rd5} segments, Route-characteristic (planned) position lists inside
+     * coverage are routed on-road and reported as {@code routed}; without the
+     * option, or for lists outside coverage / that fail to route, they fall back
+     * to {@code beeline} (see {@link BRouterRouteLengthComputer}). Tracks and
+     * waypoint lists are always measured point-to-point.
      */
     private int analyze(String[] args) {
         if (args.length < 2) {
@@ -135,8 +138,10 @@ public class RouteConverterCmdLine {
             return 10;
         }
 
+        RouteLengthComputer lengthComputer = createLengthComputer(args);
+
         try {
-            FileAnalyzer analyzer = new FileAnalyzer(registry, new PointToPointLengthComputer());
+            FileAnalyzer analyzer = new FileAnalyzer(registry, lengthComputer);
             String json = analyzer.analyze(source);
             System.out.println(json);
             return 0;
@@ -144,6 +149,27 @@ public class RouteConverterCmdLine {
             log.severe("Error while analyzing '" + source.getAbsolutePath() + "': " + e);
             return 25;
         }
+    }
+
+    /**
+     * Picks the BRouter-backed computer when {@code --brouter-segments <dir>}
+     * names an existing directory, otherwise the point-to-point default. A
+     * missing or non-existent directory is not fatal: everything is measured as
+     * beeline/track so the analyze run still emits JSON.
+     */
+    private RouteLengthComputer createLengthComputer(String[] args) {
+        for (int i = 2; i < args.length - 1; i++) {
+            if ("--brouter-segments".equals(args[i])) {
+                File segments = absolutize(new File(args[i + 1]));
+                if (segments.isDirectory()) {
+                    log.info("Using BRouter segments from " + segments.getAbsolutePath() + " for routed lengths");
+                    return new BRouterRouteLengthComputer(segments);
+                }
+                log.warning("BRouter segments directory '" + segments.getAbsolutePath() + "' does not exist; using beeline lengths");
+                break;
+            }
+        }
+        return new PointToPointLengthComputer();
     }
 
     private void convert(File source, NavigationFormat format, File target) throws IOException {

--- a/route-converter-cmdline/src/main/java/slash/navigation/converter/cmdline/RouteConverterCmdLine.java
+++ b/route-converter-cmdline/src/main/java/slash/navigation/converter/cmdline/RouteConverterCmdLine.java
@@ -158,8 +158,12 @@ public class RouteConverterCmdLine {
      * beeline/track so the analyze run still emits JSON.
      */
     private RouteLengthComputer createLengthComputer(String[] args) {
-        for (int i = 2; i < args.length - 1; i++) {
+        for (int i = 2; i < args.length; i++) {
             if ("--brouter-segments".equals(args[i])) {
+                if (i == args.length - 1) {
+                    log.warning("--brouter-segments requires a directory argument; using beeline lengths");
+                    break;
+                }
                 File segments = absolutize(new File(args[i + 1]));
                 if (segments.isDirectory()) {
                     log.info("Using BRouter segments from " + segments.getAbsolutePath() + " for routed lengths");

--- a/route-converter-cmdline/src/main/resources/slash/navigation/converter/cmdline/brouter/lookups.dat
+++ b/route-converter-cmdline/src/main/resources/slash/navigation/converter/cmdline/brouter/lookups.dat
@@ -1,0 +1,1082 @@
+---lookupversion:11
+---minorversion:2
+
+---context:way
+
+highway;0029035962 residential
+highway;0010319731 service
+highway;0007688809 track
+highway;0007656124 unclassified
+highway;0004141444 footway
+highway;0003493551 tertiary
+highway;0002852601 path
+highway;0002185240 secondary
+highway;0001447719 primary
+highway;0000699577 cycleway
+highway;0000608469 trunk
+highway;0000568118 living_street
+highway;0000515044 motorway
+highway;0000451760 motorway_link
+highway;0000442502 steps
+highway;0000360177 road yes
+highway;0000318426 pedestrian
+highway;0000210535 trunk_link
+highway;0000192461 primary_link
+highway;0000120758 secondary_link
+highway;0000079637 tertiary_link
+highway;0000070238 construction
+highway;0000058257 bridleway
+highway;0000039003 platform
+highway;0000037192 proposed planned virtual
+highway;0000010307 raceway
+highway;0000003152 rest_area
+highway;0000002942 abandoned disused razed demolished dismantled no
+highway;0000002631 services
+highway;0000002133 corridor
+highway;0000001440 bus_stop
+highway;0000000001 busway
+highway;0000000001 elevator
+highway;0000000001 via_ferrata
+
+surface;0002497676 asphalt
+surface;0001568957 paved bricks brick chipseal
+surface;0001562253 unpaved unpaved_minor
+surface;0000727427 gravel
+surface;0000560191 ground soil
+surface;0000350378 dirt dirt/sand
+surface;0000237226 grass artificial_turf
+surface;0000212587 concrete concrete:plates concrete:lanes cement
+surface;0000188743 paving_stones paving_stones:30 paving_stones:20
+surface;0000113800 cobblestone cobblestone:flattened unhewn_cobblestone
+surface;0000093164 compacted
+surface;0000091171 sand dirt/sand
+surface;0000023293 wood
+surface;0000019915 pebblestone
+surface;0000012866 fine_gravel
+surface;0000010681 earth
+surface;0000007331 sett
+surface;0000005778 mud
+surface;0000004549 grass_paver
+surface;0000004398 clay
+surface;0000003760 metal
+surface;0000000001 rock rocks rocky
+surface;0000000001 stone
+
+lit;0000809223 yes
+lit;0000000001 no
+lit;0000800001 sunset-sunrise dusk-dawn
+lit;0000800001 24/7
+lit;0000800001 automatic
+
+estimated_forest_class;0000000001 1
+estimated_forest_class;0000000001 2
+estimated_forest_class;0000000001 3
+estimated_forest_class;0000000001 4
+estimated_forest_class;0000000001 5
+estimated_forest_class;0000000001 6
+
+estimated_noise_class;0000000001 1
+estimated_noise_class;0000000001 2
+estimated_noise_class;0000000001 3
+estimated_noise_class;0000000001 4
+estimated_noise_class;0000000001 5
+estimated_noise_class;0000000001 6
+
+estimated_river_class;0000000001 1
+estimated_river_class;0000000001 2
+estimated_river_class;0000000001 3
+estimated_river_class;0000000001 4
+estimated_river_class;0000000001 5
+estimated_river_class;0000000001 6
+
+estimated_town_class;0000000001 1
+estimated_town_class;0000000001 2
+estimated_town_class;0000000001 3
+estimated_town_class;0000000001 4
+estimated_town_class;0000000001 5
+estimated_town_class;0000000001 6
+
+maxspeed;0001058313 50 55 56 30_mph 30mph
+maxspeed;0000860780 30 35 20_mph 20mph
+maxspeed;0000025232 10 15 5 6 8 5_mph 6_mph
+maxspeed;0000083989 20 25 10_mph 10mph 15_mph 15mph
+maxspeed;0000195097 40 45 25_mph 25mph
+maxspeed;0000204646 60 65 35_mph 35mph 40_mph 40mph
+maxspeed;0000130108 70 75 45_mph 45mph
+maxspeed;0000225071 80 85 50_mph 50mph
+maxspeed;0000106719 90 95 55_mph 55mph
+maxspeed;0000134522 100 60_mph 60mph 65_mph 65mph
+maxspeed;0000025242 110 70_mph 70mph
+maxspeed;0000038763 120 75_mph 75mph
+maxspeed;0000026953 130 80_mph 79_mph
+maxspeed;0000138654 urban RO:urban RU:urban FR:urban IT:urban AT:urban DE:urban UA:urban
+maxspeed;0000138654 rural RO:rural RU:rural FR:rural IT:rural AT:rural DE:rural UA:rural
+
+service;0001433919 parking_aisle
+service;0001305879 driveway driveway2
+service;0000382788 alley
+service;0000018777 drive-through drive_through
+service;0000008290 emergency_access
+service;0000003138 bus
+service;0000001250 parking
+service;0000001159 logging
+service;0000000001 yard
+service;0000000001 spur
+service;0000000001 siding
+service;0000000001 crossover
+
+tracktype;0000887965 grade2
+tracktype;0000868414 grade3
+tracktype;0000595882 grade1
+tracktype;0000568372 grade4 grade3-5
+tracktype;0000405959 grade5
+
+access;0002688349 private restricted residents employees
+access;0000319927 yes public
+access;0000144799 no
+access;0000140215 permissive
+access;0000108802 destination visitors
+access;0000099899 agricultural forestry agricultural;forestry
+access;0000039934 designated official
+access;0000011813 customers
+access;0000004007 delivery
+access;0000000100 psv
+access;0000000100 hov
+access;0000000001 permit
+access;0000000001 military
+
+estimated_traffic_class;0000000001 1
+estimated_traffic_class;0000000001 2
+estimated_traffic_class;0000000001 3
+estimated_traffic_class;0000000001 4
+estimated_traffic_class;0000000001 5
+estimated_traffic_class;0000000001 6
+estimated_traffic_class;0000000001 7
+
+
+lanes;0002838405 2
+lanes;0000718138 1
+lanes;0000259502 3
+lanes;0000141651 4
+lanes;0000017934 5
+lanes;0000008241 6
+lanes;0000003643 1.5
+lanes;0000001087 7
+lanes;0000000001 8 9 10 11 12 13 14 15 16 17 18 19 20 21 22 23 24 25
+
+foot;0001659694 yes allowed
+foot;0000424847 designated official
+foot;0000202364 no
+foot;0000053031 permissive
+foot;0000011661 destination customers
+foot;0000007289 private
+foot;0000000167 use_sidepath sidewalk
+foot;0000000001 permit
+
+bicycle;0001245560 yes allowed
+bicycle;0000452059 no
+bicycle;0000324902 designated official
+bicycle;0000025707 dismount
+bicycle;0000020440 permissive
+bicycle;0000008286 private
+bicycle;0000001553 destination customers delivery
+bicycle;0000000719 use_sidepath use_cycleway
+bicycle;0000000385 mtb
+bicycle;0000000001 permit
+
+smoothness;0000068136 good
+smoothness;0000042124 bad Bad
+smoothness;0000040763 intermediate
+smoothness;0000033941 excellent
+smoothness;0000012683 very_bad
+smoothness;0000009837 horrible terrible
+smoothness;0000003515 very_horrible
+smoothness;0000000919 impassable
+smoothness;0000000251 robust_wheels
+smoothness;0000000221 high_clearance
+smoothness;0000000132 very_good
+smoothness;0000000083 off_road_wheels
+smoothness;0000000057 medium Medium average
+smoothness;0000000048 poor
+smoothness;0000000039 rough
+
+tunnel;0000247305 yes
+tunnel;0000016890 building_passage
+tunnel;0000004237 no
+tunnel;0000000265 passage
+tunnel;0000000241 culvert
+tunnel;0000000122 avalanche_protector
+tunnel;0000000114 covered
+
+sidewalk;0000194579 none
+sidewalk;0000111468 both
+sidewalk;0000052950 right
+sidewalk;0000024489 left
+sidewalk;0000012916 no
+sidewalk;0000005725 separate
+sidewalk;0000001950 yes
+
+bridge;0001842517 yes viaduct true suspension
+bridge;0000000001 boardwalk
+bridge;0000000001 aqueduct
+bridge;0000000001 movable
+
+footway;0000104998 sidewalk
+footway;0000065943 crossing
+footway;0000012342 both
+footway;0000008363 none
+footway;0000005903 right
+footway;0000004159 left
+footway;0000003966 no
+footway;0000001093 yes
+footway;0000000558 separate
+
+railway;0000157547 rail
+railway;0000019316 abandoned disused razed
+railway;0000016982 tram
+railway;0000014387 platform
+railway;0000004623 light_rail
+railway;0000002982 subway
+railway;0000002422 narrow_gauge
+railway;0000001859 preserved
+railway;0000000001 funicular
+railway;0000000001 monorail
+
+motor_vehicle;0000212692 no
+motor_vehicle;0000184982 yes
+motor_vehicle;0000045128 private
+motor_vehicle;0000032622 agricultural forestry agricultural;forestry forestry;agricultural agricultural;destination
+motor_vehicle;0000025396 designated official
+motor_vehicle;0000025092 destination customers delivery
+motor_vehicle;0000010895 permissive
+motor_vehicle;0000000175 emergency Emergency
+motor_vehicle;0000000001 permit
+motor_vehicle;0000000001 psv
+motor_vehicle;0000000001 hov
+
+motorcar;0000135124 no
+motorcar;0000045407 yes
+motorcar;0000021494 agricultural forestry agricultural;forestry
+motorcar;0000012090 destination delivery
+motorcar;0000008733 private
+motorcar;0000005757 designated official
+motorcar;0000004116 permissive
+motorcar;0000000979 restricted
+motorcar;0000000001 permit
+motorcar;0000000001 psv
+motorcar;0000000001 hov
+
+motorcycle;0000092079 no
+motorcycle;0000027978 yes
+motorcycle;0000014652 agricultural forestry agricultural;forestry
+motorcycle;0000008862 destination delivery
+motorcycle;0000004877 designated official
+motorcycle;0000003936 private
+motorcycle;0000002209 permissive
+motorcycle;0000000001 permit
+
+moped;0000000001 no
+moped;0000000001 yes
+moped;0000000001 designated
+moped;0000000001 use_sidepath
+
+mofa;0000000001 no
+mofa;0000000001 yes
+mofa;0000000001 designated
+mofa;0000000001 use_sidepath
+
+atv;0000000001 no
+atv;0000000001 yes
+atv;0000000001 designated official
+atv;0000000001 private
+atv;0000000001 permissive
+
+vehicle;0000030218 no
+vehicle;0000013333 destination delivery customers
+vehicle;0000011692 yes
+vehicle;0000007147 agricultural forestry agricultural;forestry
+vehicle;0000006305 private
+vehicle;0000001294 permissive
+vehicle;0000000105 designated
+vehicle;0000000100 psv
+vehicle;0000000001 permit
+vehicle;0000000001 military
+vehicle;0000000001 emergency
+vehicle;0000000001 hov
+
+horse;0000227398 no
+horse;0000144432 yes permissive
+horse;0000014566 designated official
+horse;0000004755 private
+horse;0000000968 unknown
+horse;0000000205 destination
+
+wheelchair;0000036603 no
+wheelchair;0000028451 yes
+wheelchair;0000002713 limited
+wheelchair;0000001043 unknown
+wheelchair;0000000439 designated official
+wheelchair;0000000184 destination
+
+hgv;0000206836 designated
+hgv;0000071222 yes
+hgv;0000043783 no
+hgv;0000019115 destination
+hgv;0000005273 delivery
+hgv;0000003055 local
+hgv;0000001088 agricultural forestry agricultural;forestry
+hgv;0000000461 private
+hgv;0000000320 unsuitable
+hgv;0000000306 permissive
+
+agricultural;0000000001 no
+agricultural;0000000001 yes
+agricultural;0000000001 designated official
+agricultural;0000000001 permissive
+agricultural;0000000001 private
+agricultural;0000000001 destination delivery
+
+cycleway:both;0000000001 lane
+cycleway:both;0000000001 shared_lane
+cycleway:both;0000000001 no none
+cycleway:both;0000000001 track
+cycleway:both;0000000001 separate
+cycleway:both;0000000001 share_busway
+cycleway:both;0000000001 shared
+cycleway:both;0000000001 yes
+cycleway:both;0000000001 shoulder
+
+cycleway;0000137526 no
+cycleway;0000001883 none
+cycleway;0000124777 lane
+cycleway;0000106948 track path
+cycleway;0000044652 opposite
+cycleway;0000011237 shared
+cycleway;0000007312 opposite_lane
+cycleway;0000005737 shared_lane
+cycleway;0000002533 yes
+cycleway;0000002356 opposite_track
+cycleway;0000001945 share_busway
+cycleway;0000001705 crossing
+cycleway;0000001560 unmarked_lane
+cycleway;0000001542 right
+cycleway;0000001291 segregated
+cycleway;0000001065 both
+cycleway;0000000892 left
+cycleway;0000000344 shoulder
+cycleway;0000000326 designated
+cycleway;0000000247 proposed planned virtual
+cycleway;0000000154 sidewalk
+
+conveying;0000000001 yes reversible
+conveying;0000000001 backward
+conveying;0000000001 forward
+
+path;0000000001 crossing
+
+segregated;0000224960 no
+segregated;0000051124 yes
+
+mtb:scale;0000114272 0
+mtb:scale;0000068284 1
+mtb:scale;0000027311 2
+mtb:scale;0000011529 3
+mtb:scale;0000003666 4
+mtb:scale;0000001957 0+
+mtb:scale;0000001472 5
+mtb:scale;0000000498 1+
+mtb:scale;0000000478 1-
+mtb:scale;0000000268 0-
+mtb:scale;0000000177 2-
+mtb:scale;0000000131 2+
+mtb:scale;0000000115 6
+
+sac_scale;0000150704 hiking
+sac_scale;0000070463 mountain_hiking
+sac_scale;0000010993 demanding_mountain_hiking
+sac_scale;0000004549 alpine_hiking
+sac_scale;0000001620 demanding_alpine_hiking
+sac_scale;0000000831 yes
+sac_scale;0000000712 difficult_alpine_hiking
+sac_scale;0000000001 T1-hiking
+
+noexit;0000118665 yes
+
+motorroad;0000056844 yes
+
+oneway;0005387257 yes
+oneway;0001455407 no
+oneway;0000139188 -1
+oneway;0000000892 reversible
+oneway;0000000756 1
+oneway;0000000481 true
+
+junction;0000321066 roundabout
+junction;0000002828 spui
+junction;0000002134 jughandle
+junction;0000001493 approach
+junction;0000000100 circular
+
+man_made;0000000001 pier
+
+public_transport;0000000001 platform
+
+lcn;0000073956 yes
+lcn;0000002631 proposed
+
+oneway:bicycle;0000012034 no
+oneway:bicycle;0000005217 yes
+
+cycleway:right;0000012522 lane Lane
+cycleway:right;0000006644 track
+cycleway:right;0000000971 share_busway
+cycleway:right;0000000686 sidepath
+cycleway:right;0000000410 shared_lane
+cycleway:right;0000000104 opposite_lane
+cycleway:right;0000000058 opposite_track
+cycleway:right;0000000045 no none
+cycleway:right;0000000037 yes
+cycleway:right;0000000004 opposite
+
+cycleway:left;0000005134 lane Lane
+cycleway:left;0000003169 track
+cycleway:left;0000000656 share_busway
+cycleway:left;0000000608 opposite_lane
+cycleway:left;0000000475 sidepath
+cycleway:left;0000000257 shared_lane
+cycleway:left;0000000246 no none
+cycleway:left;0000000130 opposite_track
+cycleway:left;0000000053 opposite
+cycleway:left;0000000014 yes
+
+shoulder;0000000001 yes
+shoulder;0000000001 no
+shoulder;0000000001 right
+shoulder;0000000001 left
+shoulder;0000000001 both
+
+shoulder:right;0000000001 yes
+
+cycleway:lane;0000000001 advisory
+cycleway:lane;0000000001 exclusive
+cycleway:lane;0000000001 pictogram
+
+cycleway:both:lane;0000000001 advisory
+cycleway:both:lane;0000000001 exclusive
+cycleway:both:lane;0000000001 pictogram
+
+cycleway:right:lane;0000000001 advisory
+cycleway:right:lane;0000000001 exclusive
+cycleway:right:lane;0000000001 pictogram
+
+cycleway:left:lane;0000000001 advisory
+cycleway:left:lane;0000000001 exclusive
+cycleway:left:lane;0000000001 pictogram
+
+incline;0000052784 up
+incline;0000035413 down
+incline;0000001628 yes
+incline;0000000779 steep
+incline;0000000861 3% 0 1 2 3 0% 1% 2% 3%
+incline;0000000724 5% 4 5 4%
+incline;0000000530 8% 6 7 8 6% 7%
+incline;0000003109 10% 9 10 9% 10°
+incline;0000001297 15% 11 12 13 14 15 11% 12% 13% 14%
+incline;0000000997 20% 16 17 18 19 20 16% 17% 18% 19% 10°
+incline;0000000409 25% 21 22 23 24 25 21% 22% 23% 24%
+incline;0000000263 30% 30 40 50 40% 50% 35%
+incline;0000000861 -3% -1 -2 -3 -1% -2% -3%
+incline;0000000724 -5% -4 -5 -4%
+incline;0000000530 -8% -6 -7 -8 -6% -7%
+incline;0000001515 -10% -9 -10 -9% -10°
+incline;0000001297 -15% -11 -12 -13 -14 -15 -11% -12% -13% -14%
+incline;0000000997 -20% -16 -17 -18 -19 -20 -16% -17% -18% -19%
+incline;0000000409 -25% -21 -22 -23 -24 -25 -21% -22% -23% -24%
+incline;0000000172 -30% -30 -40 -50 -40% -50%
+
+toll;0000090536 yes true
+toll:motorcycle;0000000001 no
+
+seamark:type;0001564 recommended_track
+seamark:type;0000522 fairway
+
+waterway;0000016046 river
+waterway;0000009496 canal
+waterway;0000007876 riverbank
+waterway;0000002202 weir
+waterway;0000001364 dam
+waterway;0000000386 lock
+waterway;0000000179 wadi
+waterway;0000000126 dock
+waterway;0000000113 fish_pass
+waterway;0000000086 boatyard
+waterway;0000000071 fairway
+waterway;0000000059 lock_gate
+
+boat;0000019888 no
+boat;0000002718 yes
+boat;0000000232 private
+boat;0000000064 permissive
+boat;0000000045 designated
+
+motorboat;0000001077 yes
+motorboat;0000000808 no
+motorboat;0000000025 private privat
+
+route;0000000850 ferry
+route;0000000539 hiking foot
+route;0000000505 bicycle
+route;0000000454 ski piste
+route;0000000413 mtb
+route;0000000194 canoe
+route;0000000151 road
+route;0000000104 bus
+
+obstacle;0000000001 vegetation
+obstacle;0000000001 fallen_tree
+obstacle;0000000001 bridge
+
+rcn;0000014518 yes
+rcn;0000002862 proposed
+
+ncn;0000002941 yes
+ncn;0000001036 proposed
+
+ford;0000020552 yes
+ford;0000000289 stepping_stones
+
+trail_visibility;0000067438 good
+trail_visibility;0000041280 intermediate
+trail_visibility;0000039801 excellent
+trail_visibility;0000023482 bad poor
+trail_visibility;0000005853 horrible very_bad
+trail_visibility;0000002222 no
+
+class:bicycle:mtb;0000002079 1 +1
+class:bicycle:mtb;0000001191 0
+class:bicycle:mtb;0000001089 2 +2
+class:bicycle:mtb;0000000703 -1
+class:bicycle:mtb;0000000234 -2
+class:bicycle:mtb;0000000140 3 +3
+class:bicycle:mtb;0000000068 -3
+
+class:bicycle;0000002842 1 +1
+class:bicycle;0000000595 -1
+class:bicycle;0000000533 2 +2
+class:bicycle;0000000516 -2
+class:bicycle;0000000245 -3
+class:bicycle;0000000170 0
+class:bicycle;0000000108 3 +3
+
+bicycle:forward;0000000001 yes
+bicycle:forward;0000000001 designated
+bicycle:forward;0000000001 use_sidepath
+bicycle:forward;0000000001 no
+
+bicycle:backward;0000000001 yes
+bicycle:backward;0000000001 designated
+bicycle:backward;0000000001 use_sidepath
+bicycle:backward;0000000001 no
+
+speed_pedelec;0000000001 yes
+speed_pedelec;0000000001 designated
+speed_pedelec;0000000001 use_sidepath
+speed_pedelec;0000000001 no
+
+
+route_bicycle_icn;0000088753 yes
+route_bicycle_icn;0000000001 proposed
+route_bicycle_ncn;0000268180 yes
+route_bicycle_ncn;00000000001 proposed
+route_bicycle_rcn;0000718163 yes
+route_bicycle_rcn;00000000001 proposed
+route_bicycle_lcn;0000469215 yes
+route_bicycle_lcn;00000000001 proposed
+
+route_bicycle_;0000024662 yes
+route_bicycle_radweit;0000004604 yes
+
+route_hiking_iwn;0000056005 yes
+route_hiking_nwn;0000315813 yes
+route_hiking_rwn;0000343219 yes
+route_hiking_lwn;0000359332 yes
+route_hiking_;0000103733 yes
+
+route_foot_nwn;0000047923 yes
+route_foot_lwn;0000135371 yes
+route_foot_rwn;0000115325 yes
+route_foot_;0000070583 yes
+
+route_mtb_;0000066263 yes
+route_mtb_lcn;0000023718 yes
+route_mtb_ncn;0000004853 yes
+route_mtb_rcn;0000013321 yes
+route_mtb_mtb;0000006853 yes
+route_bicycle_mtb;0000002240 yes
+
+ramp:bicycle;0000001305 yes both permissive right left
+ramp:bicycle;0000000385 no
+
+ramp:stroller;0000001099 yes
+ramp:stroller;0000000326 no
+
+ramp:wheelchair;0000000610 yes
+ramp:wheelchair;0000000439 no
+
+ramp:luggage;0000000162 no
+ramp:luggage;0000000054 yes automatic manual
+
+
+mtb:scale:uphill;0000018869 0 0+ 0-
+mtb:scale:uphill;0000015578 1 1+ 1-
+mtb:scale:uphill;0000012338 2 2+ 2-
+mtb:scale:uphill;0000009099 3 3+ 3-
+mtb:scale:uphill;0000005825 4 4+ 4-
+mtb:scale:uphill;0000004628 5 5+ 5-
+
+crossing;0000101049 zebra
+crossing;0000017509 unmarked
+crossing;0000013817 traffic_signals
+crossing;0000011062 uncontrolled
+crossing;0000001722 yes
+crossing;0000001678 island
+crossing;0000000457 marked
+crossing;0000000131 pedestrian_signals
+crossing;0000000122 no
+
+informal;0000002424 yes true
+
+4wd_only;0000008129 yes Yes
+4wd_only;0000000487 recommended
+4wd_only;0000000041 no
+
+concrete;0000000043 plates
+concrete;0000000013 lanes
+
+bus;0001178365 yes
+bus;0000006419 designated
+bus;0000005602 no
+bus;0000005602 urban
+
+psv;0000072077 yes
+psv;0000007456 no
+psv;0000007428 designated official
+
+piste:type;0000000001 downhill
+piste:type;0000000001 nordic
+piste:type;0000000001 skitour
+piste:type;0000000001 sled
+piste:type;0000000001 hiking
+piste:type;0000000001 sleigh
+piste:type;0000000001 connection
+
+piste:grooming;0000000001 classic skating classic;skating classic+skating
+piste:grooming;0000000001 backcountry
+piste:grooming;0000000001 scooter
+piste:grooming;0000000001 mogul
+
+piste:difficulty;0000000001 novice
+piste:difficulty;0000000001 easy
+piste:difficulty;0000000001 intermediate
+piste:difficulty;0000000001 advanced
+piste:difficulty;0000000001 expert
+piste:difficulty;0000000001 freeride
+
+hov;0000006684 lane
+hov;0000003258 designated
+hov;0000002162 no
+hov;0000001512 yes
+
+busway;0000000000 opposite opposite_lane opposite_track
+busway;0000000001 lane
+busway;0000000001 yes track
+busway:left;0000000000 opposite opposite_lane opposite_track
+busway:left;0000000001 lane
+busway:right;0000000000 opposite opposite_lane opposite_track
+busway:right;0000000001 lane
+
+cycleway:left:oneway;0000000769 yes
+cycleway:left:oneway;0000001595 no
+cycleway:left:oneway;0000000927 -1
+cycleway:right:oneway;0000000001 -1
+
+cycleway:right:oneway;0000003084 yes
+cycleway:right:oneway;0000002499 no
+cycleway:right:oneway;0000000017 -1
+
+zone:maxspeed;0000001616 20 DE:20 FR:20
+zone:maxspeed;0000063721 30 DE:30 FR:30 BE:30 HU:30 NO:30 AT:30 ES:30 NL:30 IT:30 CZ:30
+
+cycleway:surface;0000002609 asphalt
+cycleway:surface;0000000150 paved
+cycleway:surface;0000000012 unpaved
+cycleway:surface;0000000010 gravel
+cycleway:surface;0000000157 concrete concrete:plates concrete:lanes
+cycleway:surface;0000002239 paving_stones paving_stones:30 paving_stones:20
+cycleway:surface;0000000011 cobblestone cobblestone:flattened unhewn_cobblestone
+cycleway:surface;0000000013 compacted
+cycleway:surface;0000000006 fine_gravel
+cycleway:surface;0000000011 sett
+
+footway:surface;0000000001 asphalt
+footway:surface;0000000001 paved
+footway:surface;0000000001 unpaved
+footway:surface;0000000001 gravel
+footway:surface;0000000001 concrete concrete:plates concrete:lanes
+footway:surface;0000000001 paving_stones paving_stones:30
+footway:surface;0000000001 cobblestone unhewn_cobblestone
+footway:surface;0000000001 compacted
+footway:surface;0000000001 fine_gravel
+footway:surface;0000000001 sett
+footway:surface;0000000001 wood
+
+maxspeed:backward;0001058313 50 55 56 30_mph 30mph
+maxspeed:backward;0000860780 30 35 20_mph 20mph
+maxspeed:backward;0000025232 10 15 5 6 8 5_mph 6_mph
+maxspeed:backward;0000083989 20 25 10_mph 10mph 15_mph 15mph
+maxspeed:backward;0000195097 40 45 25_mph 25mph
+maxspeed:backward;0000204646 60 65 35_mph 35mph 40_mph 40mph
+maxspeed:backward;0000130108 70 75 45_mph 45mph
+maxspeed:backward;0000225071 80 85 50_mph 50mph
+maxspeed:backward;0000106719 90 95 55_mph 55mph
+maxspeed:backward;0000134522 100 60_mph 60mph 65_mph 65mph
+maxspeed:backward;0000025242 110 70_mph 70mph
+maxspeed:backward;0000038763 120 75_mph 75mph
+maxspeed:backward;0000026953 130 80_mph 79_mph
+maxspeed:backward;0000138654 urban RO:urban RU:urban FR:urban IT:urban AT:urban DE:urban UA:urban
+maxspeed:backward;0000138654 rural RO:rural RU:rural FR:rural IT:rural AT:rural DE:rural UA:rural
+
+maxspeed:forward;0001058313 50 55 56 30_mph 30mph
+maxspeed:forward;0000860780 30 35 20_mph 20mph
+maxspeed:forward;0000025232 10 15 5 6 8 5_mph 6_mph
+maxspeed:forward;0000083989 20 25 10_mph 10mph 15_mph 15mph
+maxspeed:forward;0000195097 40 45 25_mph 25mph
+maxspeed:forward;0000204646 60 65 35_mph 35mph 40_mph 40mph
+maxspeed:forward;0000130108 70 75 45_mph 45mph
+maxspeed:forward;0000225071 80 85 50_mph 50mph
+maxspeed:forward;0000106719 90 95 55_mph 55mph
+maxspeed:forward;0000134522 100 60_mph 60mph 65_mph 65mph
+maxspeed:forward;0000025242 110 70_mph 70mph
+maxspeed:forward;0000038763 120 75_mph 75mph
+maxspeed:forward;0000026953 130 80_mph 79_mph
+maxspeed:forward;0000138654 urban RO:urban RU:urban FR:urban IT:urban AT:urban DE:urban UA:urban
+maxspeed:forward;0000138654 rural RO:rural RU:rural FR:rural IT:rural AT:rural DE:rural UA:rural
+
+embedded_rails;0000000928 tram
+embedded_rails;0000000007 yes
+embedded_rails;0000000003 rail
+
+living_street;0000000404 yes
+
+sidewalk:bicycle;0000000439 yes
+sidewalk:bicycle;0000000439 designated
+
+sidewalk:left:bicycle;0000001722 yes
+sidewalk:left:bicycle;0000001722 designated
+sidewalk:right:bicycle;0000002667 yes
+sidewalk:right:bicycle;0000002667 designated
+
+sidewalk:left;0000000001 no
+sidewalk:left;0000000001 separate
+sidewalk:left;0000000001 yes
+sidewalk:left;0000000001 designated
+sidewalk:right;0000000001 no
+sidewalk:right;0000000001 separate
+sidewalk:right;0000000001 yes
+sidewalk:right;0000000001 designated
+sidewalk:both;0000000001 no
+sidewalk:both;0000000001 yes
+sidewalk:both;0000000001 separate
+
+bicycle_road;0000006521 yes
+bicycle_road;0000006521 designated
+
+cyclestreet;0000000001 yes
+cyclestreet;0000000001 designated
+
+traffic_calming;0000000001 bump
+traffic_calming;0000000001 hump
+traffic_calming;0000000001 table
+traffic_calming;0000000001 yes
+traffic_calming;0000000001 cushion
+traffic_calming;0000000001 rumble_strip
+traffic_calming;0000000001 choker
+traffic_calming;0000000001 chicane
+traffic_calming;0000000001 choked_table
+
+construction;0000144871 yes
+construction;0000008214 minor
+construction;0029035962 residential
+construction;0010319731 service
+construction;0007688809 track
+construction;0007656124 unclassified
+construction;0004141444 footway pedestrian
+construction;0003493551 tertiary tertiary_link
+construction;0002852601 path
+construction;0002185240 secondary secondary_link
+construction;0001447719 primary primary_link
+construction;0000699577 cycleway
+construction;0000608469 trunk trunk_link
+construction;0000568118 living_street
+construction;0000515044 motorway motorway_link
+construction;0000442502 steps
+construction;0000360177 road highway
+construction;0000000049 bridleway
+
+
+---context:node
+
+highway;0001314954 bus_stop
+highway;0001130090 crossing
+highway;0001031274 turning_circle
+highway;0000609262 traffic_signals traffic_signals;crossing
+highway;0000306900 street_lamp
+highway;0000136339 stop
+highway;0000105097 motorway_junction
+highway;0000058076 give_way
+highway;0000049111 mini_roundabout
+highway;0000030072 milestone
+highway;0000017567 speed_camera
+highway;0000013806 emergency_access_point
+highway;0000009721 platform
+highway;0000007369 passing_place
+highway;0000005939 ford
+highway;0000004831 rest_area
+highway;0000003535 elevator
+highway;0000002572 turning_loop
+highway;0000002540 steps
+highway;0000002493 services
+highway;0000002133 emergency_bay
+highway;0000000244 construction
+highway;0000000213 proposed
+highway;0000000155 unknown
+highway;0000000134 traffic_sign
+highway;0000000115 trailhead
+
+highway;0000000046 toll_bridge
+highway;0000000037 city_entry
+highway;0000002967 traffic_mirror
+highway;0000001724 priority
+highway;0000000001 toll_gantry
+
+estimated_crossing_class;0000000001 0
+estimated_crossing_class;0000000001 1
+estimated_crossing_class;0000000001 2
+estimated_crossing_class;0000000001 3
+estimated_crossing_class;0000000001 4
+estimated_crossing_class;0000000001 5
+estimated_crossing_class;0000000001 6
+
+barrier;0000606512 gate wicket_gate
+barrier;0000164120 bollard
+barrier;0000112184 lift_gate
+barrier;0000046779 stile
+barrier;0000046255 cycle_barrier
+barrier;0000038597 entrance
+barrier;0000027579 block stone rock
+barrier;0000023074 toll_booth
+barrier;0000016782 cattle_grid
+barrier;0000016154 kissing_gate
+barrier;0000003182 turnstile
+barrier;0000003160 fence
+barrier;0000002701 border_control
+barrier;0000002536 sally_port
+barrier;0000002504 chain
+barrier;0000002470 door
+barrier;0000002089 swing_gate
+barrier;0000001912 bump_gate
+barrier;0000001856 yes
+barrier;0000001683 hampshire_gate
+barrier;0000000445 wall
+barrier;0000000440 bus_trap sump_buster
+barrier;0000000435 ditch
+barrier;0000000420 debris
+barrier;0000000381 log
+barrier;0000000336 chicane
+barrier;0000000316 kerb
+barrier;0000000268 obstacle
+barrier;0000000223 no
+barrier;0000000213 horse_stile
+barrier;0000000210 full-height_turnstile
+barrier;0000000176 windfall
+barrier;0000000168 spikes
+barrier;0000000168 checkpoint
+barrier;0000000166 hedge
+barrier;0000000164 footgate
+barrier;0000000141 tree
+barrier;0000000133 guard_rail
+barrier;0000000129 bar
+barrier;0000000124 fallen_tree
+barrier;0000000118 jersey_barrier
+barrier;0000000114 motorcycle_barrier
+barrier;0000000114 barrier
+barrier;0000000108 rope
+barrier;0000000001 height_restrictor
+barrier;0000000001 sliding_gate slide_gate
+
+entrance;0000301732 yes entrance
+entrance;0000159853 main main_entrance
+entrance;0000025621 staircase
+entrance;0000006666 home residence
+entrance;0000005428 service
+entrance;0000001853 emergency
+entrance;0000001144 exit
+entrance;0000000620 garage
+entrance;0000000285 shop
+entrance;0000000001 secondary
+
+crossing;0000251032 uncontrolled
+crossing;0000200387 traffic_signals traffic_signals;marked
+crossing;0000029717 unmarked
+crossing;0000022119 island
+crossing;0000006981 zebra
+crossing;0000003897 no
+crossing;0000002166 yes
+crossing;0000000001 marked
+
+
+access;0000078544 private
+access;0000014933 yes public
+access;0000014456 no
+access;0000008670 permissive
+access;0000006316 destination customers delivery
+access;0000000973 agricultural forestry
+access;0000000942 designated official
+access;0000000001 permit
+
+bicycle;0000267569 yes
+bicycle;0000067796 no
+bicycle;0000004075 designated official
+bicycle;0000002596 dismount
+bicycle;0000000498 permissive
+bicycle;0000000359 private
+bicycle;0000000075 destination
+
+foot;0000272169 yes
+foot;0000036271 no
+foot;0000001118 designated official
+foot;0000000960 private
+foot;0000000833 permissive
+foot;0000000127 destination customers
+
+noexit;0000195286 yes
+
+traffic_signals:direction;0000062645 forward
+traffic_signals:direction;0000033961 backward
+traffic_signals:direction;0000007309 both forward;backward backward;forward
+
+traffic_calming;0000045987 bump bump;choker mini_bumps
+traffic_calming;0000040022 hump hump;choker
+traffic_calming;0000012499 table table;choker
+traffic_calming;0000006808 yes
+traffic_calming;0000005754 cushion cushion;choker
+traffic_calming;0000005466 choker choker;cushion choker;hump choker;table choker;bump
+traffic_calming;0000005305 island
+traffic_calming;0000004686 chicane
+traffic_calming;0000004032 rumble_strip
+traffic_calming;0000000186 dip double_dip
+traffic_calming;0000000001 choked_table
+
+traffic_signals;0000000001 signal traffic_lights pedestrian_crossing yes crossing junction level_crossing crossing_only pedestrian normal signals on_demand crossing_on_demand
+traffic_signals;0000000001 blinker emergency no blink_mode continuous_green blink emergency_priority
+traffic_signals;0000000001 tram_priority bus_priority stop tram_priority;blinker
+traffic_signals;0000000001 ramp_meter
+
+motorcar;0000038901 yes
+motorcar;0000009323 no
+motorcar;0000000895 private
+motorcar;0000000216 destination
+motorcar;0000000214 permissive
+motorcar;0000000093 agricultural forestry
+motorcar;0000000084 designated official
+
+motor_vehicle;0000000066 yes
+motor_vehicle;0000000001 permissive
+motor_vehicle;0000000000 designated official
+motor_vehicle;0000000030 destination customers delivery
+motor_vehicle;0000000073 agricultural forestry
+motor_vehicle;0000000136 private
+motor_vehicle;0000000469 no
+motor_vehicle;0000000001 permit
+
+motorcycle;0000028697 yes
+motorcycle;0000007061 no
+motorcycle;0000000243 private
+motorcycle;0000000237 designated
+motorcycle;0000000117 destination
+motorcycle;0000000029 agricultural forestry
+motorcycle;0000000001 permissive
+
+vehicle;0000002176 no
+vehicle;0000000576 yes
+vehicle;0000000556 private
+vehicle;0000000262 destination
+vehicle;0000000138 agricultural forestry
+vehicle;0000000105 permissive
+vehicle;0000000003 designated official
+
+horse;0000021837 yes permissive
+horse;0000010811 no
+horse;0000000105 private
+horse;0000000053 designated official
+horse;0000000007 destination
+
+wheelchair;0000203478 yes true
+wheelchair;0000100082 no false
+wheelchair;0000080430 limited
+wheelchair;0000002769 designated official
+wheelchair;0000000005 private
+wheelchair;0000000139 bad
+wheelchair;0000000031 half
+wheelchair;0000000005 partial
+
+kerb;0000000001 lowered
+kerb;0000000001 flush no
+kerb;0000000001 raised
+kerb;0000000001 rolled
+
+hgv;0000001141 no
+hgv;0000000359 yes true permissive
+hgv;0000000111 destination delivery
+hgv;0000000108 designated official
+hgv;0000000065 private
+hgv;0000000016 agricultural forestry
+
+railway;0000312710 level_crossing
+railway;0000078746 station
+railway;0000067876 buffer_stop
+railway;0000056184 switch
+railway;0000049600 crossing
+railway;0000037871 tram_stop
+railway;0000024038 halt stop
+railway;0000014285 subway_entrance
+railway;0000010890 signal
+railway;0000000001 funicular
+
+waterway;0000004698 weir
+waterway;0000001647 lock_gate
+waterway;0000000425 waterfall
+waterway;0000000170 lock
+
+surface;0000000001 asphalt
+surface;0000000001 paved paving_stones sett cobblestone
+surface;0000000001 unpaved compacted gravel grass ground
+
+ford;0000037927 yes
+ford;0000000310 stepping_stones
+
+direction;0000274642 forward
+direction;0000249637 backward
+direction;0000021634 both forward;backward backward;forward
+
+traffic_sign:direction;0000000001 forward
+traffic_sign:direction;0000000001 backward
+traffic_sign:direction;0000000001 both forward;backward backward;forward
+
+give_way:direction;0000000001 forward
+give_way:direction;0000000001 backward
+
+stop:direction;0000000001 forward
+stop:direction;0000000001 backward
+
+monitoring:bicycle;0000000001 yes induction_loop

--- a/route-converter-cmdline/src/main/resources/slash/navigation/converter/cmdline/brouter/trekking.brf
+++ b/route-converter-cmdline/src/main/resources/slash/navigation/converter/cmdline/brouter/trekking.brf
@@ -1,0 +1,436 @@
+# *** The trekking profile is for slow travel
+# *** and avoiding car traffic, but still with
+# *** a focus on approaching your destination
+# *** efficiently.
+
+---context:global   # following code refers to global config
+
+# Bike profile
+assign validForBikes = true
+
+# Use the following switches to change behaviour
+assign   allow_steps              = true   # %allow_steps% | Set false to disallow steps | boolean
+assign   allow_ferries            = true   # %allow_ferries% | Set false to disallow ferries | boolean
+assign   ignore_cycleroutes       = false  # %ignore_cycleroutes% | Set true for better elevation results | boolean
+assign   stick_to_cycleroutes     = false  # %stick_to_cycleroutes% | Set true to just follow cycleroutes | boolean
+assign   use_proposed_cycleroutes = false  # %use_proposed_cycleroutes% | Set to true to consider proposed and regular cycleroutes as equals | boolean
+assign   avoid_unsafe             = false  # %avoid_unsafe% | Set true to avoid standard highways | boolean
+
+assign   add_beeline              = false  # %add_beeline% | Enable beeline on distant start/end points | boolean
+
+assign   consider_noise           = false  # %consider_noise% | Activate to prefer a low-noise route | boolean
+assign   consider_river           = false  # %consider_river% | Activate to prefer a route along rivers, lakes, etc. | boolean
+assign   consider_forest          = false  # %consider_forest% | Activate to prefer a route in forest or parks | boolean
+assign   consider_town            = false  # %consider_town% | Activate to bypass cities / big towns as far as possible | boolean
+assign   consider_traffic         = false  # %consider_traffic% | Activate to consider traffic estimates | boolean
+
+
+
+# Change elevation parameters
+assign   consider_elevation       = true   # %consider_elevation% | Set true to favor a route with few elevation meters | boolean
+
+assign downhillcost       = 60    # %downhillcost% | Cost for going downhill | number
+assign downhillcutoff     = 1.5   # %downhillcutoff% | Gradients below this value in percents are not counted. | number
+assign uphillcost         = 0     # %uphillcost% | Cost for going uphill | number
+assign uphillcutoff       = 1.5   # %uphillcutoff% | Gradients below this value in percents are not counted.  | number
+
+assign downhillcost       = if consider_elevation then downhillcost else 0
+assign uphillcost         = if consider_elevation then uphillcost else 0
+
+# Kinematic model parameters (travel time computation)
+assign totalMass  = 90     # %totalMass% | Mass (in kg) of the bike + biker, for travel time computation | number
+assign maxSpeed   = 45     # %maxSpeed% | Absolute maximum speed (in km/h), for travel time computation | number
+assign S_C_x      = 0.225  # %S_C_x% | Drag coefficient times the reference area (in m^2), for travel time computation | number
+assign C_r        = 0.01   # %C_r% | Rolling resistance coefficient (dimensionless), for travel time computation | number
+assign bikerPower = 100    # %bikerPower% | Average power (in W) provided by the biker, for travel time computation | number
+
+# Turn instructions settings
+assign turnInstructionMode          = 1     # %turnInstructionMode% | Mode for the generated turn instructions | [0=none, 1=auto-choose, 2=locus-style, 3=osmand-style, 4=comment-style, 5=gpsies-style, 6=orux-style, 7=locus-old-style]
+assign turnInstructionCatchingRange = 40    # %turnInstructionCatchingRange% | Within this distance (in m) several turning instructions are combined into one and the turning angles are better approximated to the general direction | number
+assign turnInstructionRoundabouts   = true  # %turnInstructionRoundabouts% | Set "false" to avoid generating special turning instructions for roundabouts | boolean
+assign considerTurnRestrictions     = true  # %considerTurnRestrictions% | Set true to take turn restrictions into account | boolean
+
+# with engine defaults, long parts of routing to via points may be removed
+assign correctMisplacedViaPoints = false # %correctMisplacedViaPoints% | Set to true to remove detours due to via points (going back and forth on the same route) | boolean
+assign correctMisplacedViaPointsDistance = 400 # %correctMisplacedViaPointsDistance% | Only remove detours shorter than this (one-way) distance (in m) (engine defaults to 0 which removes detours whatever their length) | number
+
+assign processUnusedTags            = false # %processUnusedTags% | Set true to output unused tags in data tab | boolean
+
+---context:way   # following code refers to way-tags
+
+# classifier constants
+assign classifier_none  = 1
+assign classifier_ferry = 2
+
+#
+# pre-calculate some logical expressions
+#
+
+assign any_cycleroute =
+  if not use_proposed_cycleroutes then
+     if      route_bicycle_icn=yes then true
+     else if route_bicycle_ncn=yes then true
+     else if route_bicycle_rcn=yes then true
+     else if route_bicycle_lcn=yes then true
+     else false
+  else
+     if      route_bicycle_icn=yes|proposed then true
+     else if route_bicycle_ncn=yes|proposed then true
+     else if route_bicycle_rcn=yes|proposed then true
+     else if route_bicycle_lcn=yes|proposed then true
+     else false
+
+assign nodeaccessgranted =
+     if any_cycleroute then true
+     else lcn=yes
+
+assign is_ldcr =
+     if ignore_cycleroutes then false
+     else any_cycleroute
+
+# set isbike considering access, local cycle route or the presence of a cycleway on the highway
+assign hasbikerouteoraccess =
+       or bicycle_road=yes or cyclestreet=yes or bicycle=yes|permissive|designated lcn=yes
+
+assign hascycleway = not
+  and ( or cycleway= cycleway=no|none ) and ( or cycleway:left= cycleway:left=no ) and ( or cycleway:right= cycleway:right=no ) ( or cycleway:both= cycleway:both=no )
+
+assign isbike = or hasbikerouteoraccess hascycleway
+
+assign ispaved = or surface=paved|asphalt|concrete|paving_stones|sett smoothness=excellent|good
+assign isunpaved = not or ispaved or ( and surface= smoothness= ) or surface=fine_gravel|cobblestone smoothness=intermediate|bad
+assign probablyGood = or ispaved and ( or isbike highway=footway ) not isunpaved
+
+
+#
+# this is the cost (in Meter) for a 90-degree turn
+# The actual cost is calculated as turncost*cos(angle)
+# (Suppressing turncost while following longdistance-cycleways
+# makes them a little bit more magnetic)
+#
+assign turncost = if is_ldcr then 0
+                  else if junction=roundabout then 0
+                  else 90
+
+
+#
+# for any change in initialclassifier, initialcost is added once
+#
+assign initialclassifier =
+     if route=ferry then classifier_ferry
+     else classifier_none
+
+
+#
+# calculate the initial cost
+# this is added to the total cost each time the costfactor
+# changed
+#
+assign initialcost =
+     if ( equal initialclassifier classifier_ferry ) then 10000
+     else 0
+
+#
+# implicit access here just from the motorroad tag
+# (implicit access rules from highway tag handled elsewhere)
+#
+assign defaultaccess =
+       if access= then not motorroad=yes
+       else if access=private|no then false
+       else true
+
+#
+# calculate logical bike access
+#
+assign bikeaccess =
+       if bicycle= then
+       (
+         if bicycle_road=yes then true
+         else if vehicle= then ( if highway=footway then false else defaultaccess )
+         else not vehicle=private|no
+       )
+       else not bicycle=private|no|dismount|use_sidepath
+
+#
+# calculate logical foot access
+#
+assign footaccess =
+       if bicycle=dismount then true
+       else if foot= then defaultaccess
+       else not foot=private|no|use_sidepath
+
+#
+# if not bike-, but foot-access, just a moderate penalty,
+# otherwise access is forbidden
+#
+assign accesspenalty =
+       if bikeaccess then 0
+       else if footaccess then 4
+       else if any_cycleroute then 15
+       else if bicycle=use_sidepath then 25
+       else 10000
+
+#
+# handle one-ways. On primary roads, wrong-oneways should
+# be close to forbidden, while on other ways we just add
+# 4 to the costfactor (making it at least 5 - you are allowed
+# to push your bike)
+
+# are we against legal direction on a oneway?
+assign badoneway =
+       if reversedirection=yes then
+         if oneway:bicycle=yes then true
+         else if oneway= then junction=roundabout
+         else oneway=yes|true|1
+       else oneway=-1
+
+assign onewaypenalty =
+       if ( badoneway ) then
+       (
+         if (
+           and hascycleway
+           or and cycleway:left=lane|track|shared_lane|share_busway
+                  cycleway:left:oneway=no|-1
+           or and cycleway:right=lane|track|shared_lane|share_busway
+                  cycleway:right:oneway=no|-1
+           or and cycleway:both=lane|track|shared_lane|share_busway
+                  #or cycleway:both:oneway=no|-1
+                  or cycleway:left:oneway=no|-1
+                     cycleway:right:oneway=no|-1
+           or cycleway=opposite|opposite_lane|opposite_track
+           or cycleway:left=opposite|opposite_lane|opposite_track
+              cycleway:right=opposite|opposite_lane|opposite_track
+                                                             ) then 0
+         else if ( oneway:bicycle=no                         ) then 0
+         else if ( not footaccess                            ) then 100
+         else if ( junction=roundabout|circular              ) then 60
+         else if ( highway=primary|primary_link              ) then 50
+         else if ( highway=secondary|secondary_link          ) then 30
+         else if ( highway=tertiary|tertiary_link            ) then 20
+         else 4.0
+       )
+       else 0.0
+
+# add estimate tags
+assign traffic_penalty
+   switch consider_traffic
+      switch estimated_traffic_class=       0
+      switch estimated_traffic_class=1|2    0.2
+      switch estimated_traffic_class=3      0.4
+      switch estimated_traffic_class=4      0.6
+      switch estimated_traffic_class=5      0.8
+      switch estimated_traffic_class=6|7    1 99 0
+
+
+assign noise_penalty
+   switch consider_noise
+     switch estimated_noise_class=  0
+     switch estimated_noise_class=1  0.3
+     switch estimated_noise_class=2  0.5
+     switch estimated_noise_class=3  0.8
+     switch estimated_noise_class=4  1.4
+     switch estimated_noise_class=5  1.7
+     switch estimated_noise_class=6  2 0 0
+
+assign no_river_penalty
+   switch consider_river
+     switch estimated_river_class=  2
+     switch estimated_river_class=1  1.3
+     switch estimated_river_class=2  1
+     switch estimated_river_class=3  0.7
+     switch estimated_river_class=4  0.4
+     switch estimated_river_class=5  0.1
+     switch estimated_river_class=6  0 99 0
+
+assign no_forest_penalty
+   switch consider_forest
+     switch estimated_forest_class=  1
+     switch estimated_forest_class=1  0.5
+     switch estimated_forest_class=2  0.4
+     switch estimated_forest_class=3  0.25
+     switch estimated_forest_class=4  0.15
+     switch estimated_forest_class=5  0.1
+     switch estimated_forest_class=6  0 99 0
+
+assign town_penalty
+   switch consider_town
+     switch estimated_town_class=  0
+     switch estimated_town_class=1  0.5
+     switch estimated_town_class=2  0.9
+     switch estimated_town_class=3  1.2
+     switch estimated_town_class=4  1.3
+     switch estimated_town_class=5  1.4
+     switch estimated_town_class=6  1.6 99 0
+
+#
+# calculate the cost-factor, which is the factor
+# by which the distance of a way-segment is multiplied
+# to calculate the cost of that segment. The costfactor
+# must be >=1 and it's supposed to be close to 1 for
+# the type of way the routing profile is searching for
+#
+assign isresidentialorliving = or highway=residential|living_street living_street=yes
+assign costfactor
+
+  #
+  # exclude rivers, rails etc.
+  #
+  if ( and highway= not route=ferry ) then 10000
+
+  #
+  # exclude motorways and proposed, abandoned under construction roads
+  #
+  else if ( highway=motorway|motorway_link          ) then   10000
+  else if ( highway=proposed|abandoned|construction ) then   10000
+
+  #
+  # all other exclusions below (access, steps, ferries,..)
+  # should not be deleted by the decoder, to be available
+  # in voice-hint-processing
+  #
+  else min 9999
+
+  add town_penalty
+  add no_forest_penalty
+  add no_river_penalty
+  add noise_penalty
+  add traffic_penalty
+
+  #
+  # apply oneway-and access-penalties
+  #
+  add max onewaypenalty accesspenalty
+
+  #
+  # steps and ferries are special. Note this is handled
+  # before the cycleroute-switch, to be able
+  # to really exclude them be setting cost to infinity
+  #
+  if ( highway=steps ) then ( if allow_steps then 40 else 10000 )
+  else if ( route=ferry   ) then ( if allow_ferries then 5.67 else 10000 )
+
+  #
+  # handle long-distance cycle-routes.
+  #
+  else if ( is_ldcr ) then 1                   # always treated as perfect (=1)
+  else
+  add ( if stick_to_cycleroutes then 0.5 else 0.05 )  # everything else somewhat up
+
+  #
+  # some other highway types
+  #
+  if      ( highway=pedestrian                ) then ( if isbike then ( if hascycleway then 1.1 else 2.2 ) else 3 )
+  else if ( highway=bridleway                 ) then 5
+  else if ( highway=cycleway                  ) then 1
+  else if ( isresidentialorliving             ) then ( if isunpaved then 1.5 else 1.1 )
+  else if ( highway=service                   ) then ( if isunpaved then 1.6 else 1.3 )
+
+  #
+  # tracks and track-like ways are rated mainly be tracktype/grade
+  # But note that if no tracktype is given (mainly for road/path/footway)
+  # it can be o.k. if there's any other hint for quality
+  #
+  else if ( highway=track|road|path|footway ) then
+  (
+    if      ( tracktype=grade1 ) then ( if probablyGood then 1.0 else 1.3 )
+    else if ( tracktype=grade2 ) then ( if probablyGood then 1.1 else 2.0 )
+    else if ( tracktype=grade3 ) then ( if probablyGood then 1.5 else 3.0 )
+    else if ( tracktype=grade4 ) then ( if probablyGood then 2.0 else 5.0 )
+    else if ( tracktype=grade5 ) then ( if probablyGood then 3.0 else 5.0 )
+    else                              ( if probablyGood then 1.0 else 5.0 )
+  )
+
+  #
+  # When avoiding unsafe ways, avoid highways without a bike hint
+  #
+  else add ( if ( and avoid_unsafe not isbike ) then 2 else 0 )
+
+  #
+  # actuals roads are o.k. if we have a bike hint
+  #
+       if ( highway=trunk|trunk_link         ) then ( if isbike then 1.5 else 10  )
+  else if ( highway=primary|primary_link     ) then ( if isbike then 1.2 else  3  )
+  else if ( highway=secondary|secondary_link ) then ( if isbike then 1.1 else 1.6 )
+  else if ( highway=tertiary|tertiary_link   ) then ( if isbike then 1.0 else 1.4 )
+  else if ( highway=unclassified             ) then ( if isbike then 1.0 else 1.3 )
+
+  #
+  # default for any other highway type not handled above
+  #
+  else 2.0
+
+
+# way priorities used for voice hint generation
+
+assign priorityclassifier =
+
+  if      ( highway=motorway                          ) then  30
+  else if ( highway=motorway_link                     ) then  29
+  else if ( highway=trunk                             ) then  28
+  else if ( highway=trunk_link                        ) then  27
+  else if ( highway=primary                           ) then  26
+  else if ( highway=primary_link                      ) then  25
+  else if ( highway=secondary                         ) then  24
+  else if ( highway=secondary_link                    ) then  23
+  else if ( highway=tertiary                          ) then  22
+  else if ( highway=tertiary_link                     ) then  21
+  else if ( highway=unclassified                      ) then  20
+  else if ( isresidentialorliving                     ) then  6
+  else if ( highway=service                           ) then  6
+  else if ( highway=cycleway                          ) then  6
+  else if ( or bicycle=designated bicycle_road=yes    ) then  6
+  else if ( highway=track                             ) then if tracktype=grade1 then 6 else 4
+  else if ( highway=bridleway|road|path|footway       ) then  4
+  else if ( highway=steps                             ) then  2
+  else if ( highway=pedestrian                        ) then  2
+  else 0
+
+# some more classifying bits used for voice hint generation...
+
+assign isbadoneway = not equal onewaypenalty 0
+assign isgoodoneway = if reversedirection=yes then oneway=-1
+                      else if oneway= then junction=roundabout else oneway=yes|true|1
+assign isroundabout = junction=roundabout
+assign islinktype = highway=motorway_link|trunk_link|primary_link|secondary_link|tertiary_link
+assign isgoodforcars = if greater priorityclassifier 6 then true
+                  else if ( or isresidentialorliving highway=service ) then true
+                  else if ( and highway=track tracktype=grade1 ) then true
+                  else false
+
+# ... encoded into a bitmask
+
+assign classifiermask add          isbadoneway
+                      add multiply isgoodoneway   2
+                      add multiply isroundabout   4
+                      add multiply islinktype     8
+                          multiply isgoodforcars 16
+
+# include `smoothness=` tags in the response's WayTags for track analysis
+assign dummyUsage = smoothness=
+
+---context:node  # following code refers to node tags
+
+assign defaultaccess =
+       if ( access= ) then true # add default barrier restrictions here!
+       else if ( access=private|no ) then false
+       else true
+
+assign bikeaccess =
+       if nodeaccessgranted=yes then true
+       else if bicycle= then
+       (
+         if vehicle= then defaultaccess
+         else not vehicle=private|no
+       )
+       else not bicycle=private|no|dismount
+
+assign footaccess =
+       if bicycle=dismount then true
+       else if foot= then defaultaccess
+       else not foot=private|no
+
+assign initialcost =
+       if or highway=traffic_signals and highway=crossing crossing=traffic_signals then 20
+       else
+       if bikeaccess then 0
+       else ( if footaccess then 100 else 1000000 )

--- a/route-converter-cmdline/src/test/java/slash/navigation/converter/cmdline/BRouterRouteLengthComputerTest.java
+++ b/route-converter-cmdline/src/test/java/slash/navigation/converter/cmdline/BRouterRouteLengthComputerTest.java
@@ -1,0 +1,141 @@
+/*
+    This file is part of RouteConverter.
+
+    RouteConverter is free software; you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation; either version 2 of the License, or
+    (at your option) any later version.
+
+    RouteConverter is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with RouteConverter; if not, write to the Free Software
+    Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
+
+    Copyright (C) 2007 Christian Pesch. All Rights Reserved.
+*/
+
+package slash.navigation.converter.cmdline;
+
+import org.junit.Test;
+import slash.navigation.base.BaseRoute;
+import slash.navigation.base.CmdLineNavigationFormatRegistry;
+import slash.navigation.base.NavigationFormatParser;
+import slash.navigation.base.ParserResult;
+import slash.navigation.base.RouteCharacteristics;
+
+import java.io.File;
+import java.io.IOException;
+import java.net.URISyntaxException;
+import java.util.ArrayList;
+import java.util.List;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
+
+/**
+ * Exercises {@link BRouterRouteLengthComputer} through the {@code LegRouter}
+ * seam so the routed-summation and beeline-fallback logic are covered without
+ * real {@code .rd5} segments (specs/00055 P2b). One case drives the production
+ * {@link BRouterLegRouter} against a non-existent segments directory to prove
+ * the real path degrades to beeline rather than crashing.
+ */
+public class BRouterRouteLengthComputerTest {
+
+    private BaseRoute<?, ?> firstRoute(String resource) throws IOException, URISyntaxException {
+        File source = new File(getClass().getResource(resource).toURI());
+        NavigationFormatParser parser = new NavigationFormatParser(new CmdLineNavigationFormatRegistry());
+        ParserResult result = parser.read(source);
+        assertTrue(result.isSuccessful());
+        return result.getAllRoutes().get(0);
+    }
+
+    @Test
+    public void routeTypeSumsRoutedLegDistancesAndReportsRouted() throws IOException, URISyntaxException {
+        BaseRoute<?, ?> route = firstRoute("analyze-route.gpx");
+        assertEquals(RouteCharacteristics.Route, route.getCharacteristics());
+
+        List<Object[]> legs = new ArrayList<>();
+        BRouterRouteLengthComputer.LegRouter fake = (fromLon, fromLat, toLon, toLat) -> {
+            legs.add(new Object[]{fromLon, fromLat, toLon, toLat});
+            return 1234.0;
+        };
+        RouteLengthComputer computer = new BRouterRouteLengthComputer(fake);
+
+        RouteLengthComputer.LengthResult result = computer.computeLength(route);
+        assertEquals("routed", result.kind());
+        // three route points -> two routed legs -> 2 * 1234
+        assertEquals(2, legs.size());
+        assertEquals(2468.0, result.meters(), 0.0001);
+    }
+
+    @Test
+    public void routeTypeFallsBackToBeelineWhenALegCannotBeRouted() throws IOException, URISyntaxException {
+        BaseRoute<?, ?> route = firstRoute("analyze-route.gpx");
+
+        // fail the second leg only
+        int[] calls = {0};
+        BRouterRouteLengthComputer.LegRouter fake = (fromLon, fromLat, toLon, toLat) ->
+                (++calls[0] == 1) ? 1000.0 : null;
+        RouteLengthComputer computer = new BRouterRouteLengthComputer(fake);
+
+        RouteLengthComputer.LengthResult result = computer.computeLength(route);
+        assertEquals("beeline", result.kind());
+        assertEquals(route.getDistance(), result.meters(), 0.0001);
+    }
+
+    @Test
+    public void routeTypeTreatsRoutingExceptionAsLegFailureAndFallsBackToBeeline() throws IOException, URISyntaxException {
+        BaseRoute<?, ?> route = firstRoute("analyze-route.gpx");
+
+        BRouterRouteLengthComputer.LegRouter throwing = (fromLon, fromLat, toLon, toLat) -> {
+            throw new RuntimeException("simulated routing crash");
+        };
+        RouteLengthComputer computer = new BRouterRouteLengthComputer(throwing);
+
+        RouteLengthComputer.LengthResult result = computer.computeLength(route);
+        assertEquals("beeline", result.kind());
+        assertEquals(route.getDistance(), result.meters(), 0.0001);
+    }
+
+    @Test
+    public void trackListIsDelegatedToPointToPointAndReportsTrack() throws IOException, URISyntaxException {
+        BaseRoute<?, ?> track = firstRoute("analyze-two-tracks.gpx");
+        assertEquals(RouteCharacteristics.Track, track.getCharacteristics());
+
+        // a LegRouter that must never be consulted for a non-Route list
+        BRouterRouteLengthComputer.LegRouter forbidden = (fromLon, fromLat, toLon, toLat) -> {
+            throw new AssertionError("routing must not be attempted for a Track list");
+        };
+        RouteLengthComputer computer = new BRouterRouteLengthComputer(forbidden);
+
+        RouteLengthComputer.LengthResult result = computer.computeLength(track);
+        assertEquals("track", result.kind());
+    }
+
+    @Test
+    public void realBRouterWithoutSegmentsFallsBackToBeeline() throws IOException, URISyntaxException {
+        BaseRoute<?, ?> route = firstRoute("analyze-route.gpx");
+
+        File missing = new File(System.getProperty("java.io.tmpdir"), "no-such-brouter-segments-dir");
+        RouteLengthComputer computer = new BRouterRouteLengthComputer(missing);
+
+        RouteLengthComputer.LengthResult result = computer.computeLength(route);
+        assertEquals("beeline", result.kind());
+        assertEquals(route.getDistance(), result.meters(), 0.0001);
+    }
+
+    @Test
+    public void shortRouteWithFewerThanTwoCoordinatesReturnsNull() {
+        BRouterRouteLengthComputer.LegRouter fake = (fromLon, fromLat, toLon, toLat) -> 1.0;
+        RouteLengthComputer computer = new BRouterRouteLengthComputer(fake);
+
+        BaseRoute<?, ?> empty = new slash.navigation.gpx.GpxRoute(new slash.navigation.gpx.Gpx11Format(),
+                RouteCharacteristics.Route, "empty", new ArrayList<>(), new ArrayList<>());
+        assertNull(computer.computeLength(empty));
+    }
+}

--- a/route-converter-cmdline/src/test/java/slash/navigation/converter/cmdline/FileAnalyzerTest.java
+++ b/route-converter-cmdline/src/test/java/slash/navigation/converter/cmdline/FileAnalyzerTest.java
@@ -84,6 +84,20 @@ public class FileAnalyzerTest {
     }
 
     @Test
+    public void routeFileWithBRouterButNoSegmentsStillEmitsBeelineJson() throws IOException, URISyntaxException {
+        // wiring the BRouter computer at a non-existent segments directory must
+        // never crash the analyze run: JSON is still produced, kind is beeline
+        File missing = new File(System.getProperty("java.io.tmpdir"), "no-such-brouter-segments-dir");
+        FileAnalyzer brouterAnalyzer = new FileAnalyzer(new CmdLineNavigationFormatRegistry(),
+                new BRouterRouteLengthComputer(missing));
+
+        File source = resource("analyze-route.gpx");
+        String json = brouterAnalyzer.analyze(source);
+        assertTrue(json, json.contains("\"lengthKind\":\"beeline\""));
+        assertTrue(json, json.contains("\"positionLists\":1"));
+    }
+
+    @Test
     public void corruptZipFails() throws URISyntaxException {
         // a hostile/corrupt zip must fail the analysis, not produce metadata
         File source = resource("analyze-corrupt.zip");

--- a/route-converter-cmdline/src/test/resources/slash/navigation/converter/cmdline/analyze-route.gpx
+++ b/route-converter-cmdline/src/test/resources/slash/navigation/converter/cmdline/analyze-route.gpx
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<gpx version="1.1" creator="RouteConverter" xmlns="http://www.topografix.com/GPX/1/1">
+    <rte>
+        <name>Planned Tour</name>
+        <rtept lat="53.40451" lon="10.18587"/>
+        <rtept lat="53.44000" lon="10.12000"/>
+        <rtept lat="53.49249" lon="10.06767"/>
+    </rte>
+</gpx>


### PR DESCRIPTION
Route-type (planned) position lists get realistic road lengths via BRouter-as-library instead of beeline; `--brouter-segments <dir>` now activates routing.

- Dependency: `org.btools:brouter-{core,expressions,mapaccess,codec,util}:1.7.8` — same coordinates/version the existing `brouter` module uses.
- `BRouterLegRouter` mirrors `slash.navigation.brouter.BRouter#getRouteBetween` (RoutingContext + RoutingEngine per leg), without the GUI DownloadManager machinery — routes against segments already on disk.
- Profile: `trekking` (bundled with its `lookups.dat` as module resources) — catalog routes are mostly cycling/hiking; documented in `analyze-json.md`.
- Fallback: all legs must route, else the whole list reports beeline (`lengthKind=beeline`); never a mix, never a crash — JSON always emitted. Track/Waypoint lists unchanged.
- Memory bounded (64 MB node cache, fresh engine per leg, per-leg timeout capped 60s) — fits the prod `-Xmx1g` analyzer.

Tests: 6 new in `BRouterRouteLengthComputerTest` + 1 end-to-end in `FileAnalyzerTest`; `mvn -pl route-converter-cmdline -am test` green.

Prod note: after merge the analyzer jar on vc612 gets rebuilt (`mvn -pl RouteConverterCmdLine -am package`) and re-shipped; Europe rd5 segments already at `/var/lib/brouter/segments` (87 tiles, 3 GB).