### PR TITLE
Review follow-up: analyze mode hardening + BRouter single-pass routing (spec 00055)

### DIFF
--- a/route-converter-cmdline/src/main/doc/analyze-json.md
+++ b/route-converter-cmdline/src/main/doc/analyze-json.md
@@ -59,9 +59,12 @@ them from `bbox` centre via point-in-polygon (keeps geo data out of Java).
     routes successfully. The reported length is the sum of the on-road leg
     distances between consecutive route points.
   - **beeline** otherwise — no `--brouter-segments` given, the directory does
-    not exist, the list is outside coverage, or any single leg fails to route
-    (routing error, timeout, no segment). A partially-covered route is reported
-    wholly as `beeline`, never as a mix, so the label never over-promises.
+    not exist, the list is outside coverage, the route fails to route (routing
+    error, timeout, no segment), or the routed length comes back materially
+    shorter than the straight-line beeline through the same points (impossible
+    for an on-road route, so the result is distrusted). A partially-covered
+    route is reported wholly as `beeline`, never as a mix, so the label never
+    over-promises.
 
 Routing is best-effort and never aborts the run: any BRouter failure degrades
 that list to `beeline` and the JSON is still emitted.

--- a/route-converter-cmdline/src/main/doc/analyze-json.md
+++ b/route-converter-cmdline/src/main/doc/analyze-json.md
@@ -36,7 +36,7 @@ stdout carries only the JSON payload.
 | `bbox.east`       | number          | maximum longitude |
 | `bbox.west`       | number          | minimum longitude |
 | `lengthM`         | integer or null | total length in metres, summed over all lists; `null` if not computable |
-| `lengthKind`      | string          | `"track"` \| `"beeline"` \| `"routed"` (see below) |
+| `lengthKind`      | string or null  | `"track"` \| `"beeline"` \| `"routed"` (see below); `null` exactly when `lengthM` is `null` (no length computable) |
 | `durationS`       | integer or null | total duration in seconds derived from position timestamps only; `null` if no timestamps |
 | `elevationGainM`  | integer or null | cumulative ascent in metres; `null` if no elevation data |
 | `elevationLossM`  | integer or null | cumulative descent in metres; `null` if no elevation data |
@@ -86,4 +86,5 @@ router.
 
 File-level aggregation of a mixed file reports the least-certain kind present:
 `beeline` if any list is beeline, else `routed` if any list is routed, else
-`track`.
+`track`. If no list has a computable length (`lengthM` is `null`) then
+`lengthKind` is `null` too.

--- a/route-converter-cmdline/src/main/java/slash/navigation/converter/cmdline/BRouterRouteLengthComputer.java
+++ b/route-converter-cmdline/src/main/java/slash/navigation/converter/cmdline/BRouterRouteLengthComputer.java
@@ -37,19 +37,19 @@ import static slash.navigation.base.RouteCharacteristics.Route;
  * (recorded tracks, loose waypoints) is delegated to the point-to-point
  * {@link PointToPointLengthComputer}.
  * <p>
- * A Route list is routed leg by leg between consecutive positions that carry
- * coordinates, and the leg distances are summed. If <em>any</em> leg cannot be
- * routed (no segment coverage, routing error, timeout, missing profile) the
- * whole list falls back to the straight-line {@code beeline} length, so the
- * label never over-promises and a partially-covered route is never reported as
- * a mix. Routing failures never propagate: {@link #computeLength} never throws
- * for a routing problem, so the analyzer always emits its JSON.
+ * A Route list is routed in a single call over all of its coordinates, and the
+ * total on-road distance is reported. If the route cannot be routed (no segment
+ * coverage, routing error, timeout, missing profile) the whole list falls back
+ * to the straight-line {@code beeline} length, so the label never over-promises
+ * and a partially-covered route is never reported as a mix. Routing failures
+ * never propagate: {@link #computeLength} never throws for a routing problem, so
+ * the analyzer always emits its JSON.
  * <p>
- * The actual leg routing is behind the {@link LegRouter} seam. The production
- * seam is {@link BRouterLegRouter}, which drives BRouter's
- * {@code RoutingContext}/{@code RoutingEngine} exactly like
+ * The actual routing is behind the {@link RouteRouter} seam. The production seam
+ * is {@link BRouterRouteRouter}, which drives BRouter's
+ * {@code RoutingContext}/{@code RoutingEngine} over the whole waypoint list like
  * {@code slash.navigation.brouter.BRouter#getRouteBetween}. Tests inject a fake
- * {@link LegRouter} to exercise the summation and fallback logic without real
+ * {@link RouteRouter} to exercise the routed/fallback logic without real
  * {@code .rd5} segments.
  *
  * @author Christian Pesch
@@ -58,17 +58,21 @@ public class BRouterRouteLengthComputer implements RouteLengthComputer {
     private static final Logger log = Logger.getLogger(BRouterRouteLengthComputer.class.getName());
 
     private final RouteLengthComputer fallback = new PointToPointLengthComputer();
-    private final LegRouter legRouter;
+    private final RouteRouter routeRouter;
 
     /**
-     * Routes a single leg between two coordinates.
+     * Routes a whole position list in one call.
      */
-    interface LegRouter {
+    interface RouteRouter {
         /**
-         * @return the on-road distance in metres, or {@code null} if the leg
-         *         cannot be routed (no coverage, error, timeout)
+         * @param longitudes the route's point longitudes, in order
+         * @param latitudes  the route's point latitudes, in order (parallel to
+         *                   {@code longitudes})
+         * @return the total on-road distance in metres through all points, or
+         *         {@code null} if the route cannot be routed (no coverage,
+         *         error, timeout) — routing is all-or-nothing
          */
-        Double routeLeg(double fromLongitude, double fromLatitude, double toLongitude, double toLatitude);
+        Double routeRoute(double[] longitudes, double[] latitudes);
     }
 
     /**
@@ -76,11 +80,11 @@ public class BRouterRouteLengthComputer implements RouteLengthComputer {
      * segments directory using the bundled default profile.
      */
     public BRouterRouteLengthComputer(java.io.File segmentsDirectory) {
-        this(new BRouterLegRouter(segmentsDirectory));
+        this(new BRouterRouteRouter(segmentsDirectory));
     }
 
-    BRouterRouteLengthComputer(LegRouter legRouter) {
-        this.legRouter = legRouter;
+    BRouterRouteLengthComputer(RouteRouter routeRouter) {
+        this.routeRouter = routeRouter;
     }
 
     public LengthResult computeLength(BaseRoute<?, ?> route) {
@@ -99,26 +103,27 @@ public class BRouterRouteLengthComputer implements RouteLengthComputer {
         if (withCoordinates.size() < 2)
             return fallback.computeLength(route);
 
-        double routedMeters = 0;
-        for (int i = 1; i < withCoordinates.size(); i++) {
-            NavigationPosition from = withCoordinates.get(i - 1);
-            NavigationPosition to = withCoordinates.get(i);
-            Double legMeters = safeRouteLeg(from, to);
-            if (legMeters == null) {
-                log.info("BRouter could not route a leg; falling back to beeline for this list");
-                return fallback.computeLength(route);
-            }
-            routedMeters += legMeters;
+        double[] longitudes = new double[withCoordinates.size()];
+        double[] latitudes = new double[withCoordinates.size()];
+        for (int i = 0; i < withCoordinates.size(); i++) {
+            longitudes[i] = withCoordinates.get(i).getLongitude();
+            latitudes[i] = withCoordinates.get(i).getLatitude();
+        }
+
+        Double routedMeters = safeRoute(longitudes, latitudes);
+        if (routedMeters == null) {
+            log.info("BRouter could not route the list; falling back to beeline for this list");
+            return fallback.computeLength(route);
         }
         return new LengthResult(routedMeters, "routed");
     }
 
-    private Double safeRouteLeg(NavigationPosition from, NavigationPosition to) {
+    private Double safeRoute(double[] longitudes, double[] latitudes) {
         try {
-            return legRouter.routeLeg(from.getLongitude(), from.getLatitude(), to.getLongitude(), to.getLatitude());
+            return routeRouter.routeRoute(longitudes, latitudes);
         } catch (Throwable t) {
             // never let a routing error crash the analyze run
-            log.warning("BRouter leg routing failed: " + t);
+            log.warning("BRouter routing failed: " + t);
             return null;
         }
     }

--- a/route-converter-cmdline/src/main/java/slash/navigation/converter/cmdline/BRouterRouteLengthComputer.java
+++ b/route-converter-cmdline/src/main/java/slash/navigation/converter/cmdline/BRouterRouteLengthComputer.java
@@ -28,7 +28,9 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.logging.Logger;
 
+import static java.lang.String.format;
 import static slash.navigation.base.RouteCharacteristics.Route;
+import static slash.navigation.common.Bearing.calculateBearing;
 
 /**
  * BRouter-backed {@link RouteLengthComputer} for the {@code analyze} command
@@ -56,6 +58,10 @@ import static slash.navigation.base.RouteCharacteristics.Route;
  */
 public class BRouterRouteLengthComputer implements RouteLengthComputer {
     private static final Logger log = Logger.getLogger(BRouterRouteLengthComputer.class.getName());
+    // an on-road route can never be shorter than the straight line through the
+    // same points; allow 1% for rounding/projection slack before treating a
+    // "routed" length as impossible and distrusting it
+    private static final double BEELINE_SANITY_EPSILON = 0.01;
 
     private final RouteLengthComputer fallback = new PointToPointLengthComputer();
     private final RouteRouter routeRouter;
@@ -115,7 +121,24 @@ public class BRouterRouteLengthComputer implements RouteLengthComputer {
             log.info("BRouter could not route the list; falling back to beeline for this list");
             return fallback.computeLength(route);
         }
+
+        // Sanity: an on-road route cannot be shorter than the beeline through the
+        // same points. A routed length materially below the beeline signals a
+        // wrong/partial result, so distrust it and fall back to beeline.
+        double beelineMeters = beelineMeters(longitudes, latitudes);
+        if (routedMeters < beelineMeters * (1 - BEELINE_SANITY_EPSILON)) {
+            log.warning(format("BRouter routed length %.0f m is shorter than the %.0f m beeline; falling back to beeline",
+                    routedMeters, beelineMeters));
+            return fallback.computeLength(route);
+        }
         return new LengthResult(routedMeters, "routed");
+    }
+
+    private static double beelineMeters(double[] longitudes, double[] latitudes) {
+        double meters = 0;
+        for (int i = 1; i < longitudes.length; i++)
+            meters += calculateBearing(longitudes[i - 1], latitudes[i - 1], longitudes[i], latitudes[i]).getDistance();
+        return meters;
     }
 
     private Double safeRoute(double[] longitudes, double[] latitudes) {

--- a/route-converter-cmdline/src/main/java/slash/navigation/converter/cmdline/BRouterRouteRouter.java
+++ b/route-converter-cmdline/src/main/java/slash/navigation/converter/cmdline/BRouterRouteRouter.java
@@ -29,13 +29,14 @@ import slash.navigation.converter.cmdline.BRouterRouteLengthComputer.RouteRouter
 import java.io.File;
 import java.io.IOException;
 import java.io.InputStream;
-import java.io.OutputStream;
 import java.nio.file.Files;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.logging.Logger;
 
 import static java.lang.String.format;
+import static slash.common.io.InputOutput.copyAndClose;
+import static slash.navigation.common.Bearing.calculateBearing;
 
 /**
  * Production {@link RouteRouter}: routes an entire position list in a single
@@ -81,6 +82,9 @@ class BRouterRouteRouter implements RouteRouter {
     // accordingly. Five minutes still bounds a hostile route so it can never
     // wedge a batch of analyze runs.
     private static final long MAXIMUM_TIMEOUT = 300000L;
+    // metres of beeline that buy one extra millisecond of routing budget,
+    // matching slash.navigation.brouter.BRouter#getRouteBetween (bearing / 15.0)
+    private static final double METERS_PER_MILLISECOND = 15.0;
 
     private final File segmentsDirectory;
     // static: one extraction per JVM, not per file — a batch-reused analyzer
@@ -131,13 +135,9 @@ class BRouterRouteRouter implements RouteRouter {
      */
     private long timeoutFor(double[] longitudes, double[] latitudes) {
         double beelineMeters = 0;
-        for (int i = 1; i < longitudes.length; i++) {
-            double meanLatitude = Math.toRadians((latitudes[i - 1] + latitudes[i]) / 2);
-            double deltaLongitude = (longitudes[i] - longitudes[i - 1]) * Math.cos(meanLatitude);
-            double deltaLatitude = latitudes[i] - latitudes[i - 1];
-            beelineMeters += Math.sqrt(deltaLongitude * deltaLongitude + deltaLatitude * deltaLatitude) * 111320.0;
-        }
-        long timeout = (long) (MINIMUM_TIMEOUT + beelineMeters / 15.0);
+        for (int i = 1; i < longitudes.length; i++)
+            beelineMeters += calculateBearing(longitudes[i - 1], latitudes[i - 1], longitudes[i], latitudes[i]).getDistance();
+        long timeout = (long) (MINIMUM_TIMEOUT + beelineMeters / METERS_PER_MILLISECOND);
         return Math.min(timeout, MAXIMUM_TIMEOUT);
     }
 
@@ -162,16 +162,10 @@ class BRouterRouteRouter implements RouteRouter {
 
     private static File extractResource(String name, File directory) throws IOException {
         File target = new File(directory, name);
-        try (InputStream in = BRouterRouteRouter.class.getResourceAsStream(RESOURCE_PREFIX + name)) {
-            if (in == null)
-                throw new IOException("Resource " + RESOURCE_PREFIX + name + " not found on classpath");
-            try (OutputStream out = Files.newOutputStream(target.toPath())) {
-                byte[] buffer = new byte[8192];
-                int read;
-                while ((read = in.read(buffer)) != -1)
-                    out.write(buffer, 0, read);
-            }
-        }
+        InputStream in = BRouterRouteRouter.class.getResourceAsStream(RESOURCE_PREFIX + name);
+        if (in == null)
+            throw new IOException("Resource " + RESOURCE_PREFIX + name + " not found on classpath");
+        copyAndClose(in, Files.newOutputStream(target.toPath()));
         return target;
     }
 

--- a/route-converter-cmdline/src/main/java/slash/navigation/converter/cmdline/BRouterRouteRouter.java
+++ b/route-converter-cmdline/src/main/java/slash/navigation/converter/cmdline/BRouterRouteRouter.java
@@ -24,7 +24,7 @@ import btools.router.OsmNodeNamed;
 import btools.router.OsmTrack;
 import btools.router.RoutingContext;
 import btools.router.RoutingEngine;
-import slash.navigation.converter.cmdline.BRouterRouteLengthComputer.LegRouter;
+import slash.navigation.converter.cmdline.BRouterRouteLengthComputer.RouteRouter;
 
 import java.io.File;
 import java.io.IOException;
@@ -38,14 +38,22 @@ import java.util.logging.Logger;
 import static java.lang.String.format;
 
 /**
- * Production {@link LegRouter}: routes a single leg with BRouter's offline
- * engine against a directory of {@code .rd5} segment files, using a default
- * profile bundled with this module. This mirrors the calling convention of
- * {@code slash.navigation.brouter.BRouter#getRouteBetween} (build a
- * {@code RoutingContext} pointing at the profile, run a {@code RoutingEngine}
- * over the segments directory, read distance from the found track) but without
- * the GUI download/DataSource machinery — the analyzer runs against segments
- * that already exist on disk (specs/00055 P3 host infra).
+ * Production {@link RouteRouter}: routes an entire position list in a single
+ * BRouter run against a directory of {@code .rd5} segment files, using a default
+ * profile bundled with this module. BRouter's {@code RoutingEngine} accepts an
+ * ordered waypoint list and routes through all of them in sequence, appending
+ * the sections into one track, so the whole list is one engine call rather than
+ * one per leg. {@code getDistance()} then returns the total on-road distance
+ * through every waypoint (compare {@code slash.navigation.brouter.BRouter#getRouteBetween},
+ * which drives the same {@code RoutingContext}/{@code RoutingEngine} for its
+ * two-point case) but without the GUI download/DataSource machinery — the
+ * analyzer runs against segments that already exist on disk (specs/00055 P3
+ * host infra).
+ * <p>
+ * Routing is all-or-nothing: if the engine reports an error or finds no track
+ * (no segment coverage, timeout, missing profile) the method returns {@code null}
+ * and the caller falls the whole list back to a straight-line beeline length, so
+ * the label never over-promises (specs/00055).
  * <p>
  * Profile choice: {@code trekking} — BRouter's general-purpose bike/foot
  * profile. Planned routes in the RouteConverter catalog are predominantly
@@ -57,18 +65,22 @@ import static java.lang.String.format;
  * extracted to a temporary directory on first use.
  * <p>
  * Memory stays bounded: {@code RoutingContext.memoryclass} defaults to 64 MB
- * for the node cache and a fresh engine is used per leg, well within the
+ * for the node cache and a fresh engine is used per list, well within the
  * {@code -Xmx1g} the analyzer runs with.
  *
  * @author Christian Pesch
  */
-class BRouterLegRouter implements LegRouter {
-    private static final Logger log = Logger.getLogger(BRouterLegRouter.class.getName());
+class BRouterRouteRouter implements RouteRouter {
+    private static final Logger log = Logger.getLogger(BRouterRouteRouter.class.getName());
     private static final String PROFILE_NAME = "trekking.brf";
     private static final String LOOKUPS_NAME = "lookups.dat";
     private static final String RESOURCE_PREFIX = "brouter/";
     private static final long MINIMUM_TIMEOUT = 10000L;
-    private static final long MAXIMUM_TIMEOUT = 60000L;
+    // whole-route budget (was a per-leg cap): a route routed in one engine call
+    // gets a single timeout scaled with its total beeline, so raise the cap
+    // accordingly. Five minutes still bounds a hostile route so it can never
+    // wedge a batch of analyze runs.
+    private static final long MAXIMUM_TIMEOUT = 300000L;
 
     private final File segmentsDirectory;
     // static: one extraction per JVM, not per file — a batch-reused analyzer
@@ -76,11 +88,11 @@ class BRouterLegRouter implements LegRouter {
     private static File profileFile;
     private static boolean profileExtractionAttempted;
 
-    BRouterLegRouter(File segmentsDirectory) {
+    BRouterRouteRouter(File segmentsDirectory) {
         this.segmentsDirectory = segmentsDirectory;
     }
 
-    public Double routeLeg(double fromLongitude, double fromLatitude, double toLongitude, double toLatitude) {
+    public Double routeRoute(double[] longitudes, double[] latitudes) {
         if (segmentsDirectory == null || !segmentsDirectory.isDirectory()) {
             log.warning(format("BRouter segments directory %s does not exist; cannot route", segmentsDirectory));
             return null;
@@ -94,12 +106,12 @@ class BRouterLegRouter implements LegRouter {
         routingContext.localFunction = profile.getPath();
 
         List<OsmNodeNamed> waypoints = new ArrayList<>();
-        waypoints.add(asOsmNodeNamed(fromLongitude, fromLatitude));
-        waypoints.add(asOsmNodeNamed(toLongitude, toLatitude));
+        for (int i = 0; i < longitudes.length; i++)
+            waypoints.add(asOsmNodeNamed(longitudes[i], latitudes[i]));
 
         RoutingEngine routingEngine = new RoutingEngine(null, null, segmentsDirectory, waypoints, routingContext);
         routingEngine.quite = true;
-        routingEngine.doRun(timeoutFor(fromLongitude, fromLatitude, toLongitude, toLatitude));
+        routingEngine.doRun(timeoutFor(longitudes, latitudes));
 
         if (routingEngine.getErrorMessage() != null) {
             log.info(format("BRouter routing error: %s", routingEngine.getErrorMessage()));
@@ -112,15 +124,19 @@ class BRouterLegRouter implements LegRouter {
     }
 
     /**
-     * Larger legs get a longer budget, matching the heuristic in
-     * {@code BRouter#getRouteBetween}, but capped so a single hostile leg can
-     * never wedge a batch of analyze runs.
+     * A longer route gets a longer budget, matching the heuristic in
+     * {@code BRouter#getRouteBetween}, summed over the whole list and capped at
+     * {@link #MAXIMUM_TIMEOUT} so a single hostile route can never wedge a batch
+     * of analyze runs.
      */
-    private long timeoutFor(double fromLongitude, double fromLatitude, double toLongitude, double toLatitude) {
-        double meanLatitude = Math.toRadians((fromLatitude + toLatitude) / 2);
-        double deltaLongitude = (toLongitude - fromLongitude) * Math.cos(meanLatitude);
-        double deltaLatitude = toLatitude - fromLatitude;
-        double beelineMeters = Math.sqrt(deltaLongitude * deltaLongitude + deltaLatitude * deltaLatitude) * 111320.0;
+    private long timeoutFor(double[] longitudes, double[] latitudes) {
+        double beelineMeters = 0;
+        for (int i = 1; i < longitudes.length; i++) {
+            double meanLatitude = Math.toRadians((latitudes[i - 1] + latitudes[i]) / 2);
+            double deltaLongitude = (longitudes[i] - longitudes[i - 1]) * Math.cos(meanLatitude);
+            double deltaLatitude = latitudes[i] - latitudes[i - 1];
+            beelineMeters += Math.sqrt(deltaLongitude * deltaLongitude + deltaLatitude * deltaLatitude) * 111320.0;
+        }
         long timeout = (long) (MINIMUM_TIMEOUT + beelineMeters / 15.0);
         return Math.min(timeout, MAXIMUM_TIMEOUT);
     }
@@ -146,7 +162,7 @@ class BRouterLegRouter implements LegRouter {
 
     private static File extractResource(String name, File directory) throws IOException {
         File target = new File(directory, name);
-        try (InputStream in = BRouterLegRouter.class.getResourceAsStream(RESOURCE_PREFIX + name)) {
+        try (InputStream in = BRouterRouteRouter.class.getResourceAsStream(RESOURCE_PREFIX + name)) {
             if (in == null)
                 throw new IOException("Resource " + RESOURCE_PREFIX + name + " not found on classpath");
             try (OutputStream out = Files.newOutputStream(target.toPath())) {

--- a/route-converter-cmdline/src/main/java/slash/navigation/converter/cmdline/FileAnalyzer.java
+++ b/route-converter-cmdline/src/main/java/slash/navigation/converter/cmdline/FileAnalyzer.java
@@ -20,6 +20,8 @@
 
 package slash.navigation.converter.cmdline;
 
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
 import slash.common.type.CompactCalendar;
 import slash.navigation.base.BaseNavigationPosition;
 import slash.navigation.base.BaseRoute;
@@ -32,7 +34,9 @@ import java.io.File;
 import java.io.IOException;
 import java.time.Instant;
 import java.time.format.DateTimeFormatter;
+import java.util.LinkedHashMap;
 import java.util.List;
+import java.util.Map;
 
 import static java.lang.Math.round;
 
@@ -46,6 +50,8 @@ import static java.lang.Math.round;
  * @author Christian Pesch
  */
 public class FileAnalyzer {
+    private static final ObjectMapper OBJECT_MAPPER = new ObjectMapper();
+
     private final NavigationFormatRegistry registry;
     private final RouteLengthComputer lengthComputer;
 
@@ -87,7 +93,7 @@ public class FileAnalyzer {
      * null handling) can be unit-tested with crafted routes (specs/00055).
      */
     static String toJson(List<BaseRoute> routes, long size, String format, String extension,
-                         RouteLengthComputer lengthComputer) {
+                         RouteLengthComputer lengthComputer) throws JsonProcessingException {
         int positions = 0;
         double lengthMeters = 0;
         boolean anyLength = false;
@@ -157,81 +163,37 @@ public class FileAnalyzer {
             }
         }
 
-        StringBuilder json = new StringBuilder();
-        json.append('{');
-        appendNumber(json, "size", size);
-        json.append(',');
-        appendString(json, "format", format);
-        json.append(',');
-        appendNumber(json, "positionLists", routes.size());
-        json.append(',');
-        appendNumber(json, "positions", positions);
-        json.append(',');
-        json.append("\"bbox\":");
+        // Insertion order defines the JSON field order (LinkedHashMap); the
+        // single-line, no-whitespace layout and null emission are ObjectMapper
+        // defaults, so the output matches the analyze-json.md contract.
+        Map<String, Object> payload = new LinkedHashMap<>();
+        payload.put("size", size);
+        payload.put("format", format);
+        payload.put("positionLists", routes.size());
+        payload.put("positions", positions);
         if (anyCoordinate) {
-            json.append('{');
-            appendRawNumber(json, "north", north);
-            json.append(',');
-            appendRawNumber(json, "south", south);
-            json.append(',');
-            appendRawNumber(json, "east", east);
-            json.append(',');
-            appendRawNumber(json, "west", west);
-            json.append('}');
+            Map<String, Object> bbox = new LinkedHashMap<>();
+            bbox.put("north", north);
+            bbox.put("south", south);
+            bbox.put("east", east);
+            bbox.put("west", west);
+            payload.put("bbox", bbox);
         } else {
-            json.append("null");
+            payload.put("bbox", null);
         }
-        json.append(',');
-        if (anyLength) {
-            appendNumber(json, "lengthM", round(lengthMeters));
-        } else {
-            appendNull(json, "lengthM");
-        }
-        json.append(',');
+        payload.put("lengthM", anyLength ? round(lengthMeters) : null);
         // lengthKind tracks lengthM: when nothing was computable (lengthM null)
         // the kind is null too, rather than falsely defaulting to "track"
         // (specs/00055). rc-site tolerates null: data.get('lengthKind') or ''.
-        if (aggregateKind != null) {
-            appendString(json, "lengthKind", aggregateKind);
-        } else {
-            appendNull(json, "lengthKind");
-        }
-        json.append(',');
-        if (anyTime) {
-            appendNumber(json, "durationS", round(durationMillis / 1000.0));
-        } else {
-            appendNull(json, "durationS");
-        }
-        json.append(',');
-        if (anyElevation) {
-            appendNumber(json, "elevationGainM", round(elevationGain));
-            json.append(',');
-            appendNumber(json, "elevationLossM", round(elevationLoss));
-        } else {
-            appendNull(json, "elevationGainM");
-            json.append(',');
-            appendNull(json, "elevationLossM");
-        }
-        json.append(',');
-        if (startMillis != null) {
-            appendString(json, "startTime", DateTimeFormatter.ISO_INSTANT.format(Instant.ofEpochMilli(startMillis)));
-        } else {
-            appendNull(json, "startTime");
-        }
-        json.append(',');
-        if (firstName != null) {
-            appendString(json, "firstName", firstName);
-        } else {
-            appendNull(json, "firstName");
-        }
-        json.append(',');
-        if (extension != null) {
-            appendString(json, "extension", extension);
-        } else {
-            appendNull(json, "extension");
-        }
-        json.append('}');
-        return json.toString();
+        payload.put("lengthKind", aggregateKind);
+        payload.put("durationS", anyTime ? round(durationMillis / 1000.0) : null);
+        payload.put("elevationGainM", anyElevation ? round(elevationGain) : null);
+        payload.put("elevationLossM", anyElevation ? round(elevationLoss) : null);
+        payload.put("startTime", startMillis != null
+                ? DateTimeFormatter.ISO_INSTANT.format(Instant.ofEpochMilli(startMillis)) : null);
+        payload.put("firstName", firstName);
+        payload.put("extension", extension);
+        return OBJECT_MAPPER.writeValueAsString(payload);
     }
 
     /**
@@ -246,41 +208,5 @@ public class FileAnalyzer {
         if ("routed".equals(current) || "routed".equals(next))
             return "routed";
         return "track";
-    }
-
-    private static void appendString(StringBuilder builder, String key, String value) {
-        builder.append('"').append(key).append("\":\"").append(escape(value)).append('"');
-    }
-
-    private static void appendNumber(StringBuilder builder, String key, long value) {
-        builder.append('"').append(key).append("\":").append(value);
-    }
-
-    private static void appendRawNumber(StringBuilder builder, String key, double value) {
-        builder.append('"').append(key).append("\":").append(value);
-    }
-
-    private static void appendNull(StringBuilder builder, String key) {
-        builder.append('"').append(key).append("\":null");
-    }
-
-    private static String escape(String value) {
-        StringBuilder result = new StringBuilder(value.length());
-        for (int i = 0; i < value.length(); i++) {
-            char c = value.charAt(i);
-            switch (c) {
-                case '"':  result.append("\\\""); break;
-                case '\\': result.append("\\\\"); break;
-                case '\n': result.append("\\n"); break;
-                case '\r': result.append("\\r"); break;
-                case '\t': result.append("\\t"); break;
-                default:
-                    if (c < 0x20)
-                        result.append(String.format("\\u%04x", (int) c));
-                    else
-                        result.append(c);
-            }
-        }
-        return result.toString();
     }
 }

--- a/route-converter-cmdline/src/main/java/slash/navigation/converter/cmdline/FileAnalyzer.java
+++ b/route-converter-cmdline/src/main/java/slash/navigation/converter/cmdline/FileAnalyzer.java
@@ -66,6 +66,28 @@ public class FileAnalyzer {
 
         List<BaseRoute> routes = result.getAllRoutes();
 
+        // A file the parser accepts but with no positions carries no usable
+        // geometry (empty/binary/garbage sniffed as a permissive text format).
+        // Treat it as broken so the caller marks it broken rather than creating
+        // an empty metadata row / rescuing a non-route (specs/00055, 00056).
+        int total = 0;
+        for (BaseRoute route : routes)
+            total += route.getPositionCount();
+        if (total == 0)
+            throw new IOException("No positions found in '" + source.getAbsolutePath() + "'");
+
+        return toJson(routes, source.length(), result.getFormat().getName(),
+                result.getFormat().getExtension(), lengthComputer);
+    }
+
+    /**
+     * JSON emission seam: aggregates the metadata across every position list and
+     * renders the single-line JSON of the analyze contract. Package-visible and
+     * decoupled from parsing so the emission (bbox union, length-kind roll-up,
+     * null handling) can be unit-tested with crafted routes (specs/00055).
+     */
+    static String toJson(List<BaseRoute> routes, long size, String format, String extension,
+                         RouteLengthComputer lengthComputer) {
         int positions = 0;
         double lengthMeters = 0;
         boolean anyLength = false;
@@ -105,7 +127,12 @@ public class FileAnalyzer {
             for (NavigationPosition position : positionList) {
                 Double longitude = position.getLongitude();
                 Double latitude = position.getLatitude();
-                if (longitude != null && latitude != null) {
+                // A non-finite coordinate (NaN/Infinity from a malformed source)
+                // is treated as absent: it never enters the bbox union, so the
+                // emitted bbox doubles stay valid JSON. If no position carries a
+                // finite coordinate pair the bbox is null (specs/00055).
+                if (longitude != null && latitude != null
+                        && Double.isFinite(longitude) && Double.isFinite(latitude)) {
                     anyCoordinate = true;
                     if (latitude > north) north = latitude;
                     if (latitude < south) south = latitude;
@@ -130,18 +157,11 @@ public class FileAnalyzer {
             }
         }
 
-        // A file the parser accepts but with no positions carries no usable
-        // geometry (empty/binary/garbage sniffed as a permissive text format).
-        // Treat it as broken so the caller marks it broken rather than creating
-        // an empty metadata row / rescuing a non-route (specs/00055, 00056).
-        if (positions == 0)
-            throw new IOException("No positions found in '" + source.getAbsolutePath() + "'");
-
         StringBuilder json = new StringBuilder();
         json.append('{');
-        appendNumber(json, "size", source.length());
+        appendNumber(json, "size", size);
         json.append(',');
-        appendString(json, "format", result.getFormat().getName());
+        appendString(json, "format", format);
         json.append(',');
         appendNumber(json, "positionLists", routes.size());
         json.append(',');
@@ -198,7 +218,6 @@ public class FileAnalyzer {
             appendNull(json, "firstName");
         }
         json.append(',');
-        String extension = result.getFormat().getExtension();
         if (extension != null) {
             appendString(json, "extension", extension);
         } else {

--- a/route-converter-cmdline/src/main/java/slash/navigation/converter/cmdline/FileAnalyzer.java
+++ b/route-converter-cmdline/src/main/java/slash/navigation/converter/cmdline/FileAnalyzer.java
@@ -188,7 +188,14 @@ public class FileAnalyzer {
             appendNull(json, "lengthM");
         }
         json.append(',');
-        appendString(json, "lengthKind", aggregateKind != null ? aggregateKind : "track");
+        // lengthKind tracks lengthM: when nothing was computable (lengthM null)
+        // the kind is null too, rather than falsely defaulting to "track"
+        // (specs/00055). rc-site tolerates null: data.get('lengthKind') or ''.
+        if (aggregateKind != null) {
+            appendString(json, "lengthKind", aggregateKind);
+        } else {
+            appendNull(json, "lengthKind");
+        }
         json.append(',');
         if (anyTime) {
             appendNumber(json, "durationS", round(durationMillis / 1000.0));

--- a/route-converter-cmdline/src/main/java/slash/navigation/converter/cmdline/RouteConverterCmdLine.java
+++ b/route-converter-cmdline/src/main/java/slash/navigation/converter/cmdline/RouteConverterCmdLine.java
@@ -157,7 +157,7 @@ public class RouteConverterCmdLine {
      * missing or non-existent directory is not fatal: everything is measured as
      * beeline/track so the analyze run still emits JSON.
      */
-    private RouteLengthComputer createLengthComputer(String[] args) {
+    static RouteLengthComputer createLengthComputer(String[] args) {
         for (int i = 2; i < args.length; i++) {
             if ("--brouter-segments".equals(args[i])) {
                 if (i == args.length - 1) {

--- a/route-converter-cmdline/src/test/java/slash/navigation/converter/cmdline/BRouterRouteLengthComputerTest.java
+++ b/route-converter-cmdline/src/test/java/slash/navigation/converter/cmdline/BRouterRouteLengthComputerTest.java
@@ -38,10 +38,10 @@ import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
 
 /**
- * Exercises {@link BRouterRouteLengthComputer} through the {@code LegRouter}
- * seam so the routed-summation and beeline-fallback logic are covered without
- * real {@code .rd5} segments (specs/00055 P2b). One case drives the production
- * {@link BRouterLegRouter} against a non-existent segments directory to prove
+ * Exercises {@link BRouterRouteLengthComputer} through the {@code RouteRouter}
+ * seam so the routed and beeline-fallback logic are covered without real
+ * {@code .rd5} segments (specs/00055 P2b). One case drives the production
+ * {@link BRouterRouteRouter} against a non-existent segments directory to prove
  * the real path degrades to beeline rather than crashing.
  */
 public class BRouterRouteLengthComputerTest {
@@ -55,32 +55,34 @@ public class BRouterRouteLengthComputerTest {
     }
 
     @Test
-    public void routeTypeSumsRoutedLegDistancesAndReportsRouted() throws IOException, URISyntaxException {
+    public void routeTypeRoutesWholeListInOneCallAndReportsRouted() throws IOException, URISyntaxException {
         BaseRoute<?, ?> route = firstRoute("analyze-route.gpx");
         assertEquals(RouteCharacteristics.Route, route.getCharacteristics());
 
-        List<Object[]> legs = new ArrayList<>();
-        BRouterRouteLengthComputer.LegRouter fake = (fromLon, fromLat, toLon, toLat) -> {
-            legs.add(new Object[]{fromLon, fromLat, toLon, toLat});
-            return 1234.0;
+        // routing must be one call over all three route points, and the routed
+        // distance must be plausibly >= the straight-line beeline
+        int[] calls = {0};
+        int[] pointCount = {0};
+        double routedMeters = route.getDistance() + 5000.0;
+        BRouterRouteLengthComputer.RouteRouter fake = (longitudes, latitudes) -> {
+            calls[0]++;
+            pointCount[0] = longitudes.length;
+            return routedMeters;
         };
         RouteLengthComputer computer = new BRouterRouteLengthComputer(fake);
 
         RouteLengthComputer.LengthResult result = computer.computeLength(route);
         assertEquals("routed", result.kind());
-        // three route points -> two routed legs -> 2 * 1234
-        assertEquals(2, legs.size());
-        assertEquals(2468.0, result.meters(), 0.0001);
+        assertEquals(1, calls[0]);
+        assertEquals(3, pointCount[0]);
+        assertEquals(routedMeters, result.meters(), 0.0001);
     }
 
     @Test
-    public void routeTypeFallsBackToBeelineWhenALegCannotBeRouted() throws IOException, URISyntaxException {
+    public void routeTypeFallsBackToBeelineWhenRoutingFails() throws IOException, URISyntaxException {
         BaseRoute<?, ?> route = firstRoute("analyze-route.gpx");
 
-        // fail the second leg only
-        int[] calls = {0};
-        BRouterRouteLengthComputer.LegRouter fake = (fromLon, fromLat, toLon, toLat) ->
-                (++calls[0] == 1) ? 1000.0 : null;
+        BRouterRouteLengthComputer.RouteRouter fake = (longitudes, latitudes) -> null;
         RouteLengthComputer computer = new BRouterRouteLengthComputer(fake);
 
         RouteLengthComputer.LengthResult result = computer.computeLength(route);
@@ -89,10 +91,10 @@ public class BRouterRouteLengthComputerTest {
     }
 
     @Test
-    public void routeTypeTreatsRoutingExceptionAsLegFailureAndFallsBackToBeeline() throws IOException, URISyntaxException {
+    public void routeTypeTreatsRoutingExceptionAsFailureAndFallsBackToBeeline() throws IOException, URISyntaxException {
         BaseRoute<?, ?> route = firstRoute("analyze-route.gpx");
 
-        BRouterRouteLengthComputer.LegRouter throwing = (fromLon, fromLat, toLon, toLat) -> {
+        BRouterRouteLengthComputer.RouteRouter throwing = (longitudes, latitudes) -> {
             throw new RuntimeException("simulated routing crash");
         };
         RouteLengthComputer computer = new BRouterRouteLengthComputer(throwing);
@@ -107,8 +109,8 @@ public class BRouterRouteLengthComputerTest {
         BaseRoute<?, ?> track = firstRoute("analyze-two-tracks.gpx");
         assertEquals(RouteCharacteristics.Track, track.getCharacteristics());
 
-        // a LegRouter that must never be consulted for a non-Route list
-        BRouterRouteLengthComputer.LegRouter forbidden = (fromLon, fromLat, toLon, toLat) -> {
+        // a RouteRouter that must never be consulted for a non-Route list
+        BRouterRouteLengthComputer.RouteRouter forbidden = (longitudes, latitudes) -> {
             throw new AssertionError("routing must not be attempted for a Track list");
         };
         RouteLengthComputer computer = new BRouterRouteLengthComputer(forbidden);
@@ -131,7 +133,7 @@ public class BRouterRouteLengthComputerTest {
 
     @Test
     public void shortRouteWithFewerThanTwoCoordinatesReturnsNull() {
-        BRouterRouteLengthComputer.LegRouter fake = (fromLon, fromLat, toLon, toLat) -> 1.0;
+        BRouterRouteLengthComputer.RouteRouter fake = (longitudes, latitudes) -> 1.0;
         RouteLengthComputer computer = new BRouterRouteLengthComputer(fake);
 
         BaseRoute<?, ?> empty = new slash.navigation.gpx.GpxRoute(new slash.navigation.gpx.Gpx11Format(),

--- a/route-converter-cmdline/src/test/java/slash/navigation/converter/cmdline/BRouterRouteLengthComputerTest.java
+++ b/route-converter-cmdline/src/test/java/slash/navigation/converter/cmdline/BRouterRouteLengthComputerTest.java
@@ -105,6 +105,21 @@ public class BRouterRouteLengthComputerTest {
     }
 
     @Test
+    public void impossiblyShortRoutedLengthIsDistrustedAndFallsBackToBeeline() throws IOException, URISyntaxException {
+        BaseRoute<?, ?> route = firstRoute("analyze-route.gpx");
+
+        // a routed length far below the beeline through the same points is
+        // impossible (routing can never be shorter than the straight line), so
+        // it must be distrusted and reported as beeline
+        BRouterRouteLengthComputer.RouteRouter tooShort = (longitudes, latitudes) -> 1.0;
+        RouteLengthComputer computer = new BRouterRouteLengthComputer(tooShort);
+
+        RouteLengthComputer.LengthResult result = computer.computeLength(route);
+        assertEquals("beeline", result.kind());
+        assertEquals(route.getDistance(), result.meters(), 0.0001);
+    }
+
+    @Test
     public void trackListIsDelegatedToPointToPointAndReportsTrack() throws IOException, URISyntaxException {
         BaseRoute<?, ?> track = firstRoute("analyze-two-tracks.gpx");
         assertEquals(RouteCharacteristics.Track, track.getCharacteristics());

--- a/route-converter-cmdline/src/test/java/slash/navigation/converter/cmdline/FileAnalyzerTest.java
+++ b/route-converter-cmdline/src/test/java/slash/navigation/converter/cmdline/FileAnalyzerTest.java
@@ -133,6 +133,22 @@ public class FileAnalyzerTest {
     }
 
     @Test
+    public void noComputableLengthEmitsNullLengthKind() throws Exception {
+        // a single-position list has no computable length: lengthM is null, and
+        // lengthKind must be null too rather than falsely defaulting to "track"
+        java.util.List<slash.navigation.gpx.GpxPosition> positions = new java.util.ArrayList<>();
+        positions.add(new slash.navigation.gpx.GpxPosition(13.4, 52.5, null, null, null, "lonely"));
+        slash.navigation.gpx.GpxRoute route = new slash.navigation.gpx.GpxRoute(new slash.navigation.gpx.Gpx11Format(),
+                slash.navigation.base.RouteCharacteristics.Track, "one point", new java.util.ArrayList<>(), positions);
+
+        String json = FileAnalyzer.toJson(new java.util.ArrayList<>(java.util.List.of(route)), 0L, "test", ".gpx",
+                new PointToPointLengthComputer());
+        assertTrue(json, json.contains("\"lengthM\":null"));
+        assertTrue(json, json.contains("\"lengthKind\":null"));
+        assertNotNull(new com.fasterxml.jackson.databind.ObjectMapper().readTree(json));
+    }
+
+    @Test
     public void corruptZipFails() throws URISyntaxException {
         // a hostile/corrupt zip must fail the analysis, not produce metadata
         File source = resource("analyze-corrupt.zip");

--- a/route-converter-cmdline/src/test/java/slash/navigation/converter/cmdline/FileAnalyzerTest.java
+++ b/route-converter-cmdline/src/test/java/slash/navigation/converter/cmdline/FileAnalyzerTest.java
@@ -98,6 +98,41 @@ public class FileAnalyzerTest {
     }
 
     @Test
+    public void nonFiniteCoordinatesAreExcludedFromBboxAndJsonStaysValid() throws Exception {
+        // a position list where some positions carry NaN/Infinity coordinates:
+        // those must never reach the bbox doubles (NaN/Infinity are invalid JSON)
+        java.util.List<slash.navigation.gpx.GpxPosition> positions = new java.util.ArrayList<>();
+        positions.add(new slash.navigation.gpx.GpxPosition(13.4, 52.5, null, null, null, "finite"));
+        positions.add(new slash.navigation.gpx.GpxPosition(Double.NaN, 52.6, null, null, null, "nanLon"));
+        positions.add(new slash.navigation.gpx.GpxPosition(13.5, Double.POSITIVE_INFINITY, null, null, null, "infLat"));
+        positions.add(new slash.navigation.gpx.GpxPosition(13.41, 52.51, null, null, null, "finite2"));
+        slash.navigation.gpx.GpxRoute route = new slash.navigation.gpx.GpxRoute(new slash.navigation.gpx.Gpx11Format(),
+                slash.navigation.base.RouteCharacteristics.Track, "NaN track", new java.util.ArrayList<>(), positions);
+
+        String json = FileAnalyzer.toJson(new java.util.ArrayList<>(java.util.List.of(route)), 0L, "test", ".gpx",
+                new PointToPointLengthComputer());
+
+        // bbox is unioned over the two finite positions only
+        assertTrue(json, json.contains("\"bbox\":{\"north\":52.51,\"south\":52.5,\"east\":13.41,\"west\":13.4}"));
+        // and the payload is parseable JSON (no NaN/Infinity tokens)
+        assertNotNull(new com.fasterxml.jackson.databind.ObjectMapper().readTree(json));
+    }
+
+    @Test
+    public void allNonFiniteCoordinatesYieldNullBbox() throws Exception {
+        java.util.List<slash.navigation.gpx.GpxPosition> positions = new java.util.ArrayList<>();
+        positions.add(new slash.navigation.gpx.GpxPosition(Double.NaN, Double.NaN, null, null, null, "a"));
+        positions.add(new slash.navigation.gpx.GpxPosition(Double.NEGATIVE_INFINITY, 1.0, null, null, null, "b"));
+        slash.navigation.gpx.GpxRoute route = new slash.navigation.gpx.GpxRoute(new slash.navigation.gpx.Gpx11Format(),
+                slash.navigation.base.RouteCharacteristics.Track, "no finite", new java.util.ArrayList<>(), positions);
+
+        String json = FileAnalyzer.toJson(new java.util.ArrayList<>(java.util.List.of(route)), 0L, "test", ".gpx",
+                new PointToPointLengthComputer());
+        assertTrue(json, json.contains("\"bbox\":null"));
+        assertNotNull(new com.fasterxml.jackson.databind.ObjectMapper().readTree(json));
+    }
+
+    @Test
     public void corruptZipFails() throws URISyntaxException {
         // a hostile/corrupt zip must fail the analysis, not produce metadata
         File source = resource("analyze-corrupt.zip");

--- a/route-converter-cmdline/src/test/java/slash/navigation/converter/cmdline/RouteConverterCmdLineTest.java
+++ b/route-converter-cmdline/src/test/java/slash/navigation/converter/cmdline/RouteConverterCmdLineTest.java
@@ -1,0 +1,71 @@
+/*
+    This file is part of RouteConverter.
+
+    RouteConverter is free software; you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation; either version 2 of the License, or
+    (at your option) any later version.
+
+    RouteConverter is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with RouteConverter; if not, write to the Free Software
+    Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
+
+    Copyright (C) 2007 Christian Pesch. All Rights Reserved.
+*/
+
+package slash.navigation.converter.cmdline;
+
+import org.junit.Test;
+
+import java.io.File;
+import java.io.IOException;
+import java.nio.file.Files;
+
+import static org.junit.Assert.assertTrue;
+
+/**
+ * Covers the {@code --brouter-segments} argument handling of
+ * {@link RouteConverterCmdLine#createLengthComputer}: a dangling option and a
+ * non-existent directory both degrade to the point-to-point (beeline) computer
+ * so the analyze run still emits JSON, while an existing directory selects the
+ * BRouter-backed computer (specs/00055).
+ */
+public class RouteConverterCmdLineTest {
+
+    @Test
+    public void noBRouterOptionUsesPointToPoint() {
+        RouteLengthComputer computer = RouteConverterCmdLine.createLengthComputer(
+                new String[]{"analyze", "route.gpx"});
+        assertTrue(computer.getClass().getName(), computer instanceof PointToPointLengthComputer);
+    }
+
+    @Test
+    public void danglingBRouterSegmentsOptionUsesPointToPoint() {
+        // --brouter-segments given without a directory argument: warn and beeline
+        RouteLengthComputer computer = RouteConverterCmdLine.createLengthComputer(
+                new String[]{"analyze", "route.gpx", "--brouter-segments"});
+        assertTrue(computer.getClass().getName(), computer instanceof PointToPointLengthComputer);
+    }
+
+    @Test
+    public void nonExistentBRouterSegmentsDirectoryUsesPointToPoint() {
+        File missing = new File(System.getProperty("java.io.tmpdir"), "no-such-brouter-segments-dir-" + System.nanoTime());
+        RouteLengthComputer computer = RouteConverterCmdLine.createLengthComputer(
+                new String[]{"analyze", "route.gpx", "--brouter-segments", missing.getAbsolutePath()});
+        assertTrue(computer.getClass().getName(), computer instanceof PointToPointLengthComputer);
+    }
+
+    @Test
+    public void existingBRouterSegmentsDirectorySelectsBRouterComputer() throws IOException {
+        File segments = Files.createTempDirectory("brouter-segments-test").toFile();
+        segments.deleteOnExit();
+        RouteLengthComputer computer = RouteConverterCmdLine.createLengthComputer(
+                new String[]{"analyze", "route.gpx", "--brouter-segments", segments.getAbsolutePath()});
+        assertTrue(computer.getClass().getName(), computer instanceof BRouterRouteLengthComputer);
+    }
+}


### PR DESCRIPTION
Applies 8 review findings to the analyze/BRouter code merged in #120:

- **NaN/Infinity guard**: non-finite coordinates excluded from bbox union (all non-finite → `bbox:null`) — invalid-JSON output to the rc-site consumer is now impossible.
- **`lengthKind:null`** when no length is computable (was mislabeled `"track"` even for Route files); contract doc updated, Django side already tolerates null.
- **Routed<beeline sanity check**: physically impossible routed totals log a warning and fall back to beeline.
- **Single-pass routing**: one multi-waypoint `RoutingEngine` call per position list instead of one engine per leg — the rd5 node cache is no longer discarded N-1 times; seam renamed `LegRouter` → `RouteRouter`. Timeout scales with total beeline (cap 300s, documented).
- **Reuse over hand-rolling**: `Bearing.calculateBearing().getDistance()` replaces the equirectangular math; `InputOutput.copyAndClose` replaces the byte-copy loop; Jackson (`LinkedHashMap` + `ObjectMapper`) replaces the StringBuilder JSON assembly + `escape()` (~90 lines gone, output byte-identical — the exact-string contract test passes unchanged).
- **CLI tests**: new `RouteConverterCmdLineTest` covering all `--brouter-segments` branches incl. the dangling-option warning from the #120 review.

Tests: cmdline module 18 (7 FileAnalyzer, 7 BRouter computer, 4 CLI), full `-am` chain green.