### PR TITLE
Review follow-up: crash telemetry privacy, robustness + consent UX (spec 00011)

### DIFF
--- a/common-gui/src/main/java/slash/navigation/gui/Application.java
+++ b/common-gui/src/main/java/slash/navigation/gui/Application.java
@@ -111,28 +111,30 @@ public abstract class Application {
         return bundle;
     }
 
-    public static <T extends Application> void launch(final Class<T> applicationClass, final List<String> bundleNames, final String[] args) {
-        // Last-resort net: since Java 7 the EDT routes uncaught exceptions to the
-        // thread's handler, which falls back to this default. Without it, a throw
-        // in an invokeLater/background runnable (e.g. the async map/profile view
-        // setup) died on System.err and never reached the log file or an error
-        // report — a blank/half-built UI with nothing to diagnose. Now every
-        // uncaught exception, on any thread, lands in the RC log.
-        //
-        // This also covers exceptions thrown on the EDT while a modal dialog's
-        // secondary event pump is active: on Java 9+ (verified on 17/21)
-        // EventDispatchThread.processException routes to
-        // getUncaughtExceptionHandler().uncaughtException(...), and the nested modal
-        // pump uses the same pumpOneEventForFilters -> processException path, so it
-        // falls back to this default handler too. No custom EventQueue is needed.
-        // (See EventDispatchThreadExceptionTest for the plain-EDT verification.)
+    /**
+     * Installs the last-resort uncaught-exception handler. Since Java 7 the EDT routes
+     * uncaught exceptions to the thread's handler, which falls back to this default.
+     * Without it, a throw in an invokeLater/background runnable (e.g. the async
+     * map/profile view setup) died on System.err and never reached the log file or an
+     * error report — a blank/half-built UI with nothing to diagnose. Now every uncaught
+     * exception, on any thread, lands in the RC log.
+     * <p>
+     * This also covers exceptions thrown on the EDT while a modal dialog's secondary
+     * event pump is active: on Java 9+ (verified on 17/21) EventDispatchThread.processException
+     * routes to getUncaughtExceptionHandler().uncaughtException(...), and the nested modal
+     * pump uses the same pumpOneEventForFilters -> processException path, so it falls back
+     * to this default handler too. No custom EventQueue is needed. (See
+     * EventDispatchThreadExceptionTest for the plain-EDT verification.)
+     * <p>
+     * The hand-off to the pluggable {@link CrashHandler} is guarded against a crash loop:
+     * a throw from within the handler is caught and must not re-enter it on the same
+     * thread (the concrete handler additionally shows at most one dialog per session and
+     * only spools further crashes).
+     */
+    static void installDefaultUncaughtExceptionHandler() {
         Thread.setDefaultUncaughtExceptionHandler((thread, throwable) -> {
             log.log(SEVERE, format("Uncaught exception in thread %s", thread.getName()), throwable);
 
-            // hand off to the pluggable application handler, guarded against a crash
-            // loop: a throw from within the handler must not re-enter it on the same
-            // thread (the concrete handler additionally shows at most one dialog per
-            // session and only spools further crashes)
             CrashHandler handler = crashHandler;
             if (handler != null && !handlingCrash.get()) {
                 handlingCrash.set(Boolean.TRUE);
@@ -145,6 +147,10 @@ public abstract class Application {
                 }
             }
         });
+    }
+
+    public static <T extends Application> void launch(final Class<T> applicationClass, final List<String> bundleNames, final String[] args) {
+        installDefaultUncaughtExceptionHandler();
 
         Runnable doCreateAndShowGUI = () -> {
             try {

--- a/common-gui/src/test/java/slash/navigation/gui/ApplicationCrashDispatchTest.java
+++ b/common-gui/src/test/java/slash/navigation/gui/ApplicationCrashDispatchTest.java
@@ -1,0 +1,74 @@
+/*
+    This file is part of RouteConverter.
+
+    RouteConverter is free software; you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation; either version 2 of the License, or
+    (at your option) any later version.
+
+    RouteConverter is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with RouteConverter; if not, write to the Free Software
+    Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
+
+    Copyright (C) 2007 Christian Pesch. All Rights Reserved.
+*/
+
+package slash.navigation.gui;
+
+import org.junit.After;
+import org.junit.Test;
+
+import java.util.concurrent.atomic.AtomicInteger;
+
+import static org.junit.Assert.assertEquals;
+
+/**
+ * Verifies the crash dispatch installed by {@link Application#installDefaultUncaughtExceptionHandler}:
+ * a {@link CrashHandler} that itself throws must be caught (no infinite recursion) and the
+ * re-entry latch must be reset afterwards so the next crash still reaches the handler.
+ * Headless in the style of {@link EventDispatchThreadExceptionTest}: it drives
+ * {@code Thread.getDefaultUncaughtExceptionHandler().uncaughtException(...)} directly.
+ */
+
+public class ApplicationCrashDispatchTest {
+
+    @After
+    public void tearDown() {
+        Application.setCrashHandler(null);
+    }
+
+    @Test
+    public void crashHandlerInvokedOncePerDispatchAndLatchResetAfterThrow() {
+        Thread.UncaughtExceptionHandler previous = Thread.getDefaultUncaughtExceptionHandler();
+        try {
+            Application.installDefaultUncaughtExceptionHandler();
+
+            AtomicInteger calls = new AtomicInteger();
+            Application.setCrashHandler((thread, throwable) -> {
+                calls.incrementAndGet();
+                throw new RuntimeException("crash handler itself blows up");
+            });
+
+            Thread thread = Thread.currentThread();
+            RuntimeException crash = new RuntimeException("boom");
+
+            // the handler throws, but the dispatch must swallow it: invoked exactly once,
+            // no re-entry on the same thread, no infinite recursion
+            Thread.getDefaultUncaughtExceptionHandler().uncaughtException(thread, crash);
+            assertEquals("handler must be invoked exactly once, without recursing", 1, calls.get());
+
+            // the handlingCrash latch must have been cleared in the finally block, so a
+            // later crash on the same thread reaches the handler again rather than being
+            // permanently suppressed
+            Thread.getDefaultUncaughtExceptionHandler().uncaughtException(thread, crash);
+            assertEquals("latch must reset so a subsequent crash is handled", 2, calls.get());
+        } finally {
+            Thread.setDefaultUncaughtExceptionHandler(previous);
+        }
+    }
+}

--- a/common/src/main/java/slash/common/helpers/ExceptionHelper.java
+++ b/common/src/main/java/slash/common/helpers/ExceptionHelper.java
@@ -26,6 +26,12 @@ import java.io.StringWriter;
 import java.net.ConnectException;
 import java.net.SocketTimeoutException;
 import java.net.UnknownHostException;
+import java.util.ArrayList;
+import java.util.IdentityHashMap;
+import java.util.List;
+import java.util.Set;
+
+import static java.util.Collections.newSetFromMap;
 
 /**
  * Provides exception helpers
@@ -52,16 +58,37 @@ public class ExceptionHelper {
     }
 
     /**
+     * Walks the {@link Throwable#getCause() cause} chain from {@code throwable} to the
+     * deepest cause and returns every distinct throwable on the way, outermost first.
+     * <p>
+     * The walk is cycle-safe: a throwable is only visited once (identity-based), so a
+     * self-referential ({@code A -> A}) or looping ({@code A -> B -> A}) chain, which a
+     * naive {@code getCause()} loop would follow forever, terminates. This is the single
+     * cause-chain traversal every other helper here (and {@code DiagnosticReport}) shares.
+     */
+    public static List<Throwable> getCauseChain(Throwable throwable) {
+        List<Throwable> chain = new ArrayList<>();
+        Set<Throwable> visited = newSetFromMap(new IdentityHashMap<>());
+        Throwable cause = throwable;
+        // visited.add() returns false once a throwable recurs, which ends the walk on a
+        // self-referential (A -> A) or looping (A -> B -> A) chain
+        while (cause != null && visited.add(cause)) {
+            chain.add(cause);
+            cause = cause.getCause();
+        }
+        return chain;
+    }
+
+    /**
      * Walks the {@link Throwable#getCause() cause} chain to the deepest cause.
      * A wrapper like ExceptionInInitializerError or InvocationTargetException
      * carries the real fault (e.g. a NoClassDefFoundError for a missing JDK
      * module) as its cause; this returns that fault instead of the wrapper.
+     * Cycle-safe via {@link #getCauseChain}.
      */
     public static Throwable getRootCause(Throwable throwable) {
-        Throwable cause = throwable;
-        while (cause.getCause() != null && cause.getCause() != cause)
-            cause = cause.getCause();
-        return cause;
+        List<Throwable> chain = getCauseChain(throwable);
+        return chain.get(chain.size() - 1);
     }
 
     /**
@@ -69,20 +96,17 @@ public class ExceptionHelper {
      * "ExceptionInInitializerError caused by NoClassDefFoundError: jdk/net/Sockets".
      * Surfaces the underlying fault that a single getMessage() hides -- the
      * outermost message is often a generic "Could not initialize class ...".
+     * Cycle-safe via {@link #getCauseChain}.
      */
     public static String getMessageWithCauses(Throwable throwable) {
         StringBuilder builder = new StringBuilder();
-        Throwable cause = throwable;
-        while (cause != null) {
+        for (Throwable cause : getCauseChain(throwable)) {
             if (builder.length() > 0)
                 builder.append("\ncaused by ");
             builder.append(cause.getClass().getSimpleName());
             String message = cause.getLocalizedMessage();
             if (message != null)
                 builder.append(": ").append(message);
-            if (cause.getCause() == cause)
-                break;
-            cause = cause.getCause();
         }
         return builder.toString();
     }

--- a/common/src/main/java/slash/common/log/CrashReportSpool.java
+++ b/common/src/main/java/slash/common/log/CrashReportSpool.java
@@ -56,6 +56,11 @@ public class CrashReportSpool {
     private static final String FILE_PREFIX = "crash-";
     private static final String FILE_SUFFIX = ".json";
     private static final AtomicLong sequence = new AtomicLong();
+    // the process id makes a file name unique across concurrent RouteConverter processes:
+    // two of them can otherwise write in the same millisecond with per-process sequence
+    // counters that both start at zero and collide. It trails the timestamp and sequence
+    // so sorting by name still orders reports chronologically within a process.
+    private static final long PID = ProcessHandle.current().pid();
 
     private final File directory;
 
@@ -70,7 +75,7 @@ public class CrashReportSpool {
     public File write(String json) throws IOException {
         ensureDirectory(directory);
         String name = FILE_PREFIX + new SimpleDateFormat("yyyyMMdd-HHmmss-SSS").format(new Date()) +
-                String.format("-%04d", sequence.incrementAndGet() % 10000) + FILE_SUFFIX;
+                String.format("-%04d", sequence.incrementAndGet() % 10000) + "-" + PID + FILE_SUFFIX;
         File file = new File(directory, name);
         try (Writer writer = new OutputStreamWriter(new FileOutputStream(file), UTF_8)) {
             writer.write(json);

--- a/common/src/main/java/slash/common/log/DiagnosticReport.java
+++ b/common/src/main/java/slash/common/log/DiagnosticReport.java
@@ -22,8 +22,11 @@ package slash.common.log;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
 
 import static java.util.Arrays.asList;
+import static slash.common.helpers.ExceptionHelper.getCauseChain;
 import static slash.common.helpers.ExceptionHelper.getMessageWithCauses;
 import static slash.common.helpers.ExceptionHelper.getRootCause;
 import static slash.common.helpers.ExceptionHelper.printStackTrace;
@@ -50,9 +53,26 @@ import static slash.common.system.Platform.getPlatform;
 
 public class DiagnosticReport {
     static final int SCHEMA_VERSION = 1;
+    // each free-text field (cause chain, stack trace) is capped so the assembled JSON
+    // stays well under the crash-report endpoint's 64 KB limit. Without this, a runaway
+    // stack (deep recursion) or a huge exception message would spool a report the sender
+    // rejects as oversized on every launch, keeping the file forever (it is never sent,
+    // so never deleted). A truncated report is still useful; an undeliverable one is not.
+    static final int MAXIMUM_FIELD_LENGTH = 24 * 1024;
+    static final String TRUNCATION_MARKER = "\n... [truncated]";
     static final String BUNDLED_JRE_PROPERTY = "routeconverter.bundledJre";
     static final String HOME_PLACEHOLDER = "<USER_HOME>";
     static final String USER_PLACEHOLDER = "<USER>";
+    static final String PATH_PLACEHOLDER = "<PATH>";
+
+    // a Windows absolute path (drive letter + backslash), e.g. D:\Trips\vacation2024.gpx;
+    // the drive letter must not be the tail of a word and the separator must be a
+    // backslash so a URL like https://host/x is left intact
+    private static final Pattern WINDOWS_PATH = Pattern.compile("(?<![A-Za-z])[A-Za-z]:\\\\[^\\s\"]+");
+    // a unix absolute path on an external/user mount point, e.g. /Volumes/Backup/secret.gpx
+    // or /home/other/notes.gpx; the running user's own home is replaced first, so anything
+    // still matching here is a path outside it
+    private static final Pattern UNIX_PATH = Pattern.compile("/(?:Volumes|media|mnt|home)/[^\\s\"]+");
 
     // the OS user name and home directory leak into exception messages / stack traces
     // via absolute paths; both are known values, so they are scrubbed by literal
@@ -81,11 +101,11 @@ public class DiagnosticReport {
     private final boolean bundledJre;
 
     public DiagnosticReport(String threadName, Throwable throwable, String appVersion, String build) {
-        List<Throwable> chain = toChain(throwable);
+        List<Throwable> chain = getCauseChain(throwable);
         this.threadName = threadName;
         this.rootCauseClass = getRootCause(throwable).getClass().getName();
-        this.causeChain = scrub(getMessageWithCauses(throwable));
-        this.stackTrace = scrub(printStackTrace(throwable));
+        this.causeChain = scrub(truncate(getMessageWithCauses(throwable)));
+        this.stackTrace = scrub(truncate(printStackTrace(throwable)));
         this.prioritySignature = computePrioritySignature(chain);
         this.missingClass = scrub(extractMissingClass(chain));
         this.appVersion = appVersion;
@@ -112,32 +132,43 @@ public class DiagnosticReport {
     }
 
     /**
-     * Replaces the known {@code user.home} and {@code user.name} values with
-     * placeholders so an absolute path in a message or stack trace cannot reveal
-     * them. This is a literal replacement of two known strings, not a heuristic path
-     * mask; the short-value guard avoids scrubbing an accidental common substring.
+     * Removes personal data an absolute path in a message or stack trace can carry.
+     * First the known {@code user.home} and {@code user.name} values are replaced with
+     * placeholders (home literally; the name on word boundaries, so even a two-character
+     * name is scrubbed inside a path without rewriting it inside an unrelated word such
+     * as {@code json}). Then any remaining absolute-path-like token -- a Windows drive
+     * path or a unix external-mount path outside the user's home -- is replaced whole,
+     * so a message like {@code "cannot read D:\Trips\vacation2024.gpx"} cannot leak the
+     * document name. Class names and stack frames carry no such token and are left
+     * intact.
      */
     static String scrub(String value) {
+        return scrub(value, USER_HOME, USER_NAME);
+    }
+
+    /**
+     * Caps a free-text field at {@link #MAXIMUM_FIELD_LENGTH} characters, appending a
+     * marker when it had to cut, so no single crash can assemble a payload the sender
+     * rejects as oversized.
+     */
+    static String truncate(String value) {
+        if (value == null || value.length() <= MAXIMUM_FIELD_LENGTH)
+            return value;
+        return value.substring(0, MAXIMUM_FIELD_LENGTH) + TRUNCATION_MARKER;
+    }
+
+    static String scrub(String value, String home, String name) {
         if (value == null)
             return null;
         String result = value;
-        if (USER_HOME != null && USER_HOME.length() >= 3)
-            result = result.replace(USER_HOME, HOME_PLACEHOLDER);
-        if (USER_NAME != null && USER_NAME.length() >= 3)
-            result = result.replace(USER_NAME, USER_PLACEHOLDER);
+        if (home != null && !home.isEmpty())
+            result = result.replace(home, HOME_PLACEHOLDER);
+        if (name != null && !name.isEmpty())
+            result = result.replaceAll("(?<![A-Za-z0-9])" + Pattern.quote(name) + "(?![A-Za-z0-9])",
+                    Matcher.quoteReplacement(USER_PLACEHOLDER));
+        result = WINDOWS_PATH.matcher(result).replaceAll(PATH_PLACEHOLDER);
+        result = UNIX_PATH.matcher(result).replaceAll(PATH_PLACEHOLDER);
         return result;
-    }
-
-    private static List<Throwable> toChain(Throwable throwable) {
-        List<Throwable> chain = new ArrayList<>();
-        Throwable cause = throwable;
-        while (cause != null && !chain.contains(cause) && chain.size() < 100) {
-            chain.add(cause);
-            if (cause.getCause() == cause)
-                break;
-            cause = cause.getCause();
-        }
-        return chain;
     }
 
     private static boolean isPrioritySignature(Throwable throwable) {

--- a/common/src/test/java/slash/common/helpers/ExceptionHelperTest.java
+++ b/common/src/test/java/slash/common/helpers/ExceptionHelperTest.java
@@ -26,11 +26,13 @@ import javax.net.ssl.SSLException;
 import java.net.ConnectException;
 import java.net.SocketTimeoutException;
 import java.net.UnknownHostException;
+import java.util.List;
 
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertEquals;
+import static slash.common.helpers.ExceptionHelper.getCauseChain;
 import static slash.common.helpers.ExceptionHelper.getLocalizedMessage;
 import static slash.common.helpers.ExceptionHelper.getMessageWithCauses;
 import static slash.common.helpers.ExceptionHelper.getRootCause;
@@ -150,6 +152,69 @@ public class ExceptionHelperTest {
         Throwable root = new NoClassDefFoundError("jdk/net/Sockets");
         Throwable wrapper = new ExceptionInInitializerError(root);  // no own message
         assertEquals("jdk/net/Sockets", getLocalizedMessage(wrapper));
+    }
+
+    @Test
+    public void testGetCauseChainReturnsOutermostFirst() {
+        Throwable root = new NoClassDefFoundError("jdk/net/Sockets");
+        Throwable wrapper = new ExceptionInInitializerError(root);
+        List<Throwable> chain = getCauseChain(wrapper);
+        assertEquals(2, chain.size());
+        assertEquals(wrapper, chain.get(0));
+        assertEquals(root, chain.get(1));
+    }
+
+    /**
+     * A -> A: a throwable whose cause is itself. A naive getCause() loop would spin
+     * forever; the shared traversal must terminate for all three consumers.
+     */
+    @Test
+    public void testSelfReferentialCauseIsCycleSafe() {
+        Throwable[] self = new Throwable[1];
+        Throwable a = new RuntimeException("self") {
+            public Throwable getCause() {
+                return self[0];
+            }
+        };
+        self[0] = a;
+
+        assertEquals(1, getCauseChain(a).size());
+        assertEquals(a, getRootCause(a));
+        assertEquals("only one distinct throwable is rendered", 1,
+                getMessageWithCauses(a).split("caused by", -1).length);
+    }
+
+    /**
+     * A -> B -> A: a two-node cause cycle. The traversal must visit each node once and
+     * stop, for getCauseChain, getRootCause and getMessageWithCauses alike.
+     */
+    @Test
+    public void testLoopingCauseChainIsCycleSafe() {
+        Throwable[] holder = new Throwable[2];
+        Throwable a = new RuntimeException("A") {
+            public Throwable getCause() {
+                return holder[1];
+            }
+        };
+        Throwable b = new RuntimeException("B") {
+            public Throwable getCause() {
+                return holder[0];
+            }
+        };
+        holder[0] = a;
+        holder[1] = b;
+
+        List<Throwable> chain = getCauseChain(a);
+        assertEquals(2, chain.size());
+        assertEquals(a, chain.get(0));
+        assertEquals(b, chain.get(1));
+        // getRootCause returns the deepest distinct cause, not spinning on the loop
+        assertEquals(b, getRootCause(a));
+        String message = getMessageWithCauses(a);
+        assertTrue(message.contains("A"));
+        assertTrue(message.contains("B"));
+        assertEquals("the loop is walked once, not repeatedly", 2,
+                message.split("caused by", -1).length);
     }
 }
 

--- a/common/src/test/java/slash/common/log/CrashReportSpoolTest.java
+++ b/common/src/test/java/slash/common/log/CrashReportSpoolTest.java
@@ -98,6 +98,21 @@ public class CrashReportSpoolTest {
     }
 
     @Test
+    public void testFileNameCarriesProcessIdAndIsUnique() throws IOException {
+        long pid = ProcessHandle.current().pid();
+        File first = spool.write("{\"n\":0}");
+        File second = spool.write("{\"n\":1}");
+
+        // crash-<yyyyMMdd-HHmmss-SSS>-<sequence>-<pid>.json: the trailing process id keeps
+        // the name unique across concurrent RouteConverter processes writing in the same
+        // millisecond with sequence counters that both start at zero
+        String pattern = "crash-\\d{8}-\\d{6}-\\d{3}-\\d{4}-" + pid + "\\.json";
+        assertTrue("unexpected name " + first.getName(), first.getName().matches(pattern));
+        assertTrue("unexpected name " + second.getName(), second.getName().matches(pattern));
+        assertFalse("two writes must not collide", first.getName().equals(second.getName()));
+    }
+
+    @Test
     public void testListEmptyWhenDirectoryMissing() {
         CrashReportSpool missing = new CrashReportSpool(new File(directory, "does-not-exist"));
         assertEquals(0, missing.list().size());

--- a/common/src/test/java/slash/common/log/DiagnosticReportTest.java
+++ b/common/src/test/java/slash/common/log/DiagnosticReportTest.java
@@ -129,6 +129,59 @@ public class DiagnosticReportTest {
     }
 
     @Test
+    public void testScrubsWindowsPathOutsideHome() {
+        // a document opened from a different drive than user.home still leaks its name
+        // through a free-form message; the whole path token is redacted
+        String scrubbed = DiagnosticReport.scrub("Cannot read D:\\Trips\\vacation2024.gpx", "C:\\Users\\me", "me");
+        assertTrue(scrubbed.contains("<PATH>"));
+        assertFalse(scrubbed.contains("vacation2024"));
+        assertFalse(scrubbed.contains("Trips"));
+    }
+
+    @Test
+    public void testScrubsUnixExternalPath() {
+        String scrubbed = DiagnosticReport.scrub("Cannot read /Volumes/Backup/trips/secret.gpx", "/home/me", "me");
+        assertTrue(scrubbed.contains("<PATH>"));
+        assertFalse(scrubbed.contains("secret.gpx"));
+    }
+
+    @Test
+    public void testScrubsShortUserNameOnWordBoundary() {
+        // a two-character user name must still be scrubbed (the old length>=3 guard let
+        // it leak) but only as a whole word, never inside an unrelated token like "json"
+        String scrubbed = DiagnosticReport.scrub("parsing json failed for jo", null, "jo");
+        assertTrue("standalone user name is scrubbed", scrubbed.contains("<USER>"));
+        assertTrue("substring inside another word is left intact", scrubbed.contains("json"));
+        assertFalse(scrubbed.contains("for jo"));
+    }
+
+    @Test
+    public void testTruncateCapsLongValueWithMarker() {
+        assertNull(DiagnosticReport.truncate(null));
+        assertEquals("short", DiagnosticReport.truncate("short"));
+
+        StringBuilder builder = new StringBuilder();
+        while (builder.length() < DiagnosticReport.MAXIMUM_FIELD_LENGTH + 100)
+            builder.append("x");
+        String truncated = DiagnosticReport.truncate(builder.toString());
+        assertTrue(truncated.endsWith(DiagnosticReport.TRUNCATION_MARKER));
+        assertEquals(DiagnosticReport.MAXIMUM_FIELD_LENGTH + DiagnosticReport.TRUNCATION_MARKER.length(),
+                truncated.length());
+    }
+
+    @Test
+    public void testHugeMessageProducesBoundedTruncatedJson() {
+        StringBuilder builder = new StringBuilder();
+        while (builder.length() < 200 * 1024)
+            builder.append("boom ");
+        String json = report(new RuntimeException(builder.toString())).toJson();
+        // the cause chain carrying the huge message is truncated, so the payload stays
+        // well under the 64 KB the crash-report endpoint accepts (no forever-retry loop)
+        assertTrue(json.contains("[truncated]"));
+        assertTrue("payload must stay under the sender limit, was " + json.length(), json.length() < 64 * 1024);
+    }
+
+    @Test
     public void testBundledJreFlag() {
         String previous = System.getProperty(BUNDLED_JRE_PROPERTY);
         try {

--- a/feedback/src/main/java/slash/navigation/feedback/domain/CrashReportSender.java
+++ b/feedback/src/main/java/slash/navigation/feedback/domain/CrashReportSender.java
@@ -26,10 +26,12 @@ import slash.navigation.rest.Post;
 import javax.crypto.Mac;
 import javax.crypto.spec.SecretKeySpec;
 import java.io.IOException;
+import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.logging.Logger;
 
 import static java.nio.charset.StandardCharsets.UTF_8;
 import static java.util.logging.Level.FINE;
+import static java.util.logging.Level.WARNING;
 import static slash.navigation.datasources.DataSourceManager.V1;
 
 /**
@@ -62,6 +64,11 @@ public class CrashReportSender {
 
     private static final String HMAC_ALGORITHM = "HmacSHA256";
 
+    // warns exactly once per run: a build that forgot to inject the real key would sign
+    // every report with the placeholder, so the server rejects them all silently. One
+    // warning surfaces the misconfiguration without spamming the log on every crash.
+    private static final AtomicBoolean warnedAboutDefaultSecret = new AtomicBoolean(false);
+
     /**
      * Signs and POSTs the given JSON payload to {@code apiUrl}. Returns true only on a
      * 2xx response (the report was accepted and may be removed from the spool); returns
@@ -75,6 +82,7 @@ public class CrashReportSender {
                 log.log(FINE, "Skipping oversized crash report of " + body.length + " bytes");
                 return false;
             }
+            warnIfDefaultSecret();
             String signature = sign(secret(), body);
             return post(apiUrl + CRASH_REPORT_URI, json, signature);
         } catch (Exception e) {
@@ -97,6 +105,23 @@ public class CrashReportSender {
 
     static String secret() {
         return System.getProperty(SECRET_PROPERTY, DEFAULT_SECRET);
+    }
+
+    /**
+     * Logs a single warning if the effective secret is still the committed placeholder.
+     * Returns true only on the call that emitted the warning, so it can be exercised.
+     */
+    static boolean warnIfDefaultSecret() {
+        if (DEFAULT_SECRET.equals(secret()) && warnedAboutDefaultSecret.compareAndSet(false, true)) {
+            log.log(WARNING, "Crash report secret is the committed placeholder; set -D" + SECRET_PROPERTY +
+                    " to the server's key or reports will fail signature verification");
+            return true;
+        }
+        return false;
+    }
+
+    static void resetDefaultSecretWarningForTesting() {
+        warnedAboutDefaultSecret.set(false);
     }
 
     /**

--- a/feedback/src/test/java/slash/navigation/feedback/domain/CrashReportSenderTest.java
+++ b/feedback/src/test/java/slash/navigation/feedback/domain/CrashReportSenderTest.java
@@ -20,6 +20,7 @@
 
 package slash.navigation.feedback.domain;
 
+import org.junit.After;
 import org.junit.Test;
 
 import java.io.IOException;
@@ -27,9 +28,18 @@ import java.io.IOException;
 import static java.nio.charset.StandardCharsets.UTF_8;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
 import static slash.navigation.feedback.domain.CrashReportSender.MAXIMUM_BYTES;
+import static slash.navigation.feedback.domain.CrashReportSender.SECRET_PROPERTY;
+import static slash.navigation.feedback.domain.CrashReportSender.warnIfDefaultSecret;
 
 public class CrashReportSenderTest {
+
+    @After
+    public void tearDown() {
+        System.clearProperty(SECRET_PROPERTY);
+        CrashReportSender.resetDefaultSecretWarningForTesting();
+    }
 
     @Test
     public void testSignatureMatchesKnownVector() throws Exception {
@@ -67,5 +77,24 @@ public class CrashReportSenderTest {
 
         // no exception must propagate; the failed send simply reports false
         assertFalse(sender.send("https://api.routeconverter.com/", "{\"schema_version\":1}"));
+    }
+
+    @Test
+    public void testWarnsOnceWhenSecretIsPlaceholder() {
+        System.clearProperty(SECRET_PROPERTY);
+        CrashReportSender.resetDefaultSecretWarningForTesting();
+
+        // the committed placeholder is still in effect: warn exactly once
+        assertTrue(warnIfDefaultSecret());
+        assertFalse("the placeholder warning must not repeat", warnIfDefaultSecret());
+        assertFalse(warnIfDefaultSecret());
+    }
+
+    @Test
+    public void testDoesNotWarnWhenRealSecretInjected() {
+        System.setProperty(SECRET_PROPERTY, "a-real-injected-secret");
+        CrashReportSender.resetDefaultSecretWarningForTesting();
+
+        assertFalse(warnIfDefaultSecret());
     }
 }

--- a/rest/src/main/java/slash/navigation/rest/MultipartRequest.java
+++ b/rest/src/main/java/slash/navigation/rest/MultipartRequest.java
@@ -92,13 +92,23 @@ abstract class MultipartRequest extends HttpRequest {
         super.setHeader(name, value);
     }
 
-    public <T> T execute(HttpClientResponseHandler<T> responseHandler) throws IOException {
+    /**
+     * Sets the request entity from the raw body if one was supplied via {@link #setBody},
+     * otherwise from the accumulated multipart parts. A raw body takes precedence: it is
+     * sent verbatim so the server can sign-verify the exact bytes. Package-visible so the
+     * entity assembly can be verified without a live transport.
+     */
+    void prepareEntity() {
         if (rawEntity != null) {
             getMethod().setEntity(rawEntity);
         } else if (builder != null) {
             HttpEntity entity = builder.build();
             getMethod().setEntity(entity);
         }
+    }
+
+    public <T> T execute(HttpClientResponseHandler<T> responseHandler) throws IOException {
+        prepareEntity();
         return super.execute(responseHandler);
     }
 

--- a/rest/src/test/java/slash/navigation/rest/MultipartRequestTest.java
+++ b/rest/src/test/java/slash/navigation/rest/MultipartRequestTest.java
@@ -1,0 +1,74 @@
+/*
+    This file is part of RouteConverter.
+
+    RouteConverter is free software; you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation; either version 2 of the License, or
+    (at your option) any later version.
+
+    RouteConverter is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with RouteConverter; if not, write to the Free Software
+    Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
+
+    Copyright (C) 2007 Christian Pesch. All Rights Reserved.
+*/
+
+package slash.navigation.rest;
+
+import org.apache.hc.core5.http.HttpEntity;
+import org.apache.hc.core5.http.io.entity.StringEntity;
+import org.junit.Test;
+
+import java.io.IOException;
+
+import static java.nio.charset.StandardCharsets.UTF_8;
+import static org.apache.hc.core5.http.ContentType.APPLICATION_JSON;
+import static org.junit.Assert.assertArrayEquals;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+public class MultipartRequestTest {
+    // a multi-byte character proves the body is encoded as UTF-8, not the platform charset
+    private static final String BODY = "{\"schema_version\":1,\"note\":\"café résumé\"}";
+
+    @Test
+    public void testRawBodyIsSentVerbatimAsUtf8StringEntity() throws IOException {
+        Post request = new Post("http://localhost/");
+        request.setBody(BODY, APPLICATION_JSON);
+        request.prepareEntity();
+
+        HttpEntity entity = request.getMethod().getEntity();
+        assertTrue("a raw body must produce a StringEntity", entity instanceof StringEntity);
+
+        byte[] expected = BODY.getBytes(UTF_8);
+        assertArrayEquals(expected, entity.getContent().readAllBytes());
+        assertEquals(expected.length, entity.getContentLength());
+        assertTrue("content type " + entity.getContentType(),
+                entity.getContentType().contains("application/json"));
+        assertTrue("content type " + entity.getContentType(),
+                entity.getContentType().toUpperCase().contains("UTF-8"));
+    }
+
+    @Test
+    public void testRawBodyTakesPrecedenceOverAddStringParts() throws IOException {
+        Post request = new Post("http://localhost/");
+        // a multipart part is added first, then a raw body: the raw body must win so the
+        // server receives exactly the bytes it will sign-verify
+        request.addString("part", "ignored-multipart-part");
+        request.setBody(BODY, APPLICATION_JSON);
+        request.prepareEntity();
+
+        HttpEntity entity = request.getMethod().getEntity();
+        assertTrue(entity instanceof StringEntity);
+        byte[] actual = entity.getContent().readAllBytes();
+        assertArrayEquals(BODY.getBytes(UTF_8), actual);
+        assertFalse("the multipart part must not leak into a raw body request",
+                new String(actual, UTF_8).contains("ignored-multipart-part"));
+    }
+}

--- a/route-converter-gui/src/main/java/slash/navigation/converter/gui/RouteConverter.java
+++ b/route-converter-gui/src/main/java/slash/navigation/converter/gui/RouteConverter.java
@@ -1330,6 +1330,10 @@ public abstract class RouteConverter extends SingleFrameApplication {
         return preferences.getBoolean(SEND_CRASH_REPORTS_PREFERENCE, false);
     }
 
+    public static void setSendCrashReportsEnabled(boolean enabled) {
+        preferences.putBoolean(SEND_CRASH_REPORTS_PREFERENCE, enabled);
+    }
+
     private File getTileServersDirectory() {
         return getApplicationDirectory("tileservers");
     }

--- a/route-converter-gui/src/main/java/slash/navigation/converter/gui/dialogs/OptionsDialog.form
+++ b/route-converter-gui/src/main/java/slash/navigation/converter/gui/dialogs/OptionsDialog.form
@@ -48,7 +48,7 @@
             <properties/>
             <border type="none"/>
             <children>
-              <grid id="5015e" layout-manager="GridLayoutManager" row-count="4" column-count="2" same-size-horizontally="false" same-size-vertically="false" hgap="-1" vgap="-1">
+              <grid id="5015e" layout-manager="GridLayoutManager" row-count="5" column-count="2" same-size-horizontally="false" same-size-vertically="false" hgap="-1" vgap="-1">
                 <margin top="3" left="3" bottom="3" right="3"/>
                 <constraints>
                   <grid row="0" column="0" row-span="1" col-span="1" vsize-policy="3" hsize-policy="3" anchor="0" fill="3" indent="0" use-parent-layout="false"/>
@@ -84,10 +84,24 @@
                     </constraints>
                     <properties/>
                   </component>
+                  <component id="c1a5f" class="javax.swing.JLabel">
+                    <constraints>
+                      <grid row="3" column="0" row-span="1" col-span="1" vsize-policy="0" hsize-policy="0" anchor="8" fill="0" indent="0" use-parent-layout="false"/>
+                    </constraints>
+                    <properties>
+                      <text resource-bundle="slash/navigation/converter/gui/RouteConverter" key="send-crash-reports-option"/>
+                    </properties>
+                  </component>
+                  <component id="c1a60" class="javax.swing.JCheckBox" binding="checkBoxSendCrashReports">
+                    <constraints>
+                      <grid row="3" column="1" row-span="1" col-span="1" vsize-policy="0" hsize-policy="3" anchor="8" fill="0" indent="0" use-parent-layout="false"/>
+                    </constraints>
+                    <properties/>
+                  </component>
                   <grid id="4728" layout-manager="GridLayoutManager" row-count="1" column-count="1" same-size-horizontally="false" same-size-vertically="false" hgap="-1" vgap="-1">
                     <margin top="6" left="0" bottom="0" right="0"/>
                     <constraints>
-                      <grid row="3" column="0" row-span="1" col-span="2" vsize-policy="3" hsize-policy="3" anchor="0" fill="3" indent="0" use-parent-layout="false"/>
+                      <grid row="4" column="0" row-span="1" col-span="2" vsize-policy="3" hsize-policy="3" anchor="0" fill="3" indent="0" use-parent-layout="false"/>
                     </constraints>
                     <properties/>
                     <border type="none"/>

--- a/route-converter-gui/src/main/java/slash/navigation/converter/gui/dialogs/OptionsDialog.java
+++ b/route-converter-gui/src/main/java/slash/navigation/converter/gui/dialogs/OptionsDialog.java
@@ -144,6 +144,7 @@ public class OptionsDialog extends SimpleDialog {
     private JLabel labelGoogleApiKey;
     private JLabel labelThunderforestApiKey;
     private JLabel labelGeonamesUserName;
+    private JCheckBox checkBoxSendCrashReports;
 
 
     public OptionsDialog() {
@@ -349,6 +350,13 @@ public class OptionsDialog extends SimpleDialog {
             }
         });
         textFieldGeonamesUserName.setText(APIKeyRegistry.getInstance().getAPIKeyPreference("geonames"));
+
+        checkBoxSendCrashReports.setSelected(isSendCrashReportsEnabled());
+        checkBoxSendCrashReports.addItemListener(new ItemListener() {
+            public void itemStateChanged(ItemEvent e) {
+                setSendCrashReportsEnabled(checkBoxSendCrashReports.isSelected());
+            }
+        });
 
         checkBoxShowAllPositionsAfterLoading.setSelected(r.getShowAllPositionsAfterLoading().getBoolean());
         checkBoxShowAllPositionsAfterLoading.addItemListener(new ItemListener() {
@@ -779,7 +787,7 @@ public class OptionsDialog extends SimpleDialog {
         panel2.setLayout(new GridLayoutManager(5, 1, new Insets(5, 0, 0, 0), -1, -1));
         tabbedPane1.addTab(this.$$$getMessageFromBundle$$$("slash/navigation/converter/gui/RouteConverter", "general-options-tab"), panel2);
         final JPanel panel3 = new JPanel();
-        panel3.setLayout(new GridLayoutManager(4, 2, new Insets(3, 3, 3, 3), -1, -1));
+        panel3.setLayout(new GridLayoutManager(5, 2, new Insets(3, 3, 3, 3), -1, -1));
         panel2.add(panel3, new GridConstraints(0, 0, 1, 1, GridConstraints.ANCHOR_CENTER, GridConstraints.FILL_BOTH, GridConstraints.SIZEPOLICY_CAN_SHRINK | GridConstraints.SIZEPOLICY_CAN_GROW, GridConstraints.SIZEPOLICY_CAN_SHRINK | GridConstraints.SIZEPOLICY_CAN_GROW, null, null, null, 0, false));
         final JLabel label1 = new JLabel();
         this.$$$loadLabelText$$$(label1, this.$$$getMessageFromBundle$$$("slash/navigation/converter/gui/RouteConverter", "preferred-locale"));
@@ -791,9 +799,14 @@ public class OptionsDialog extends SimpleDialog {
         panel3.add(label2, new GridConstraints(0, 0, 1, 1, GridConstraints.ANCHOR_WEST, GridConstraints.FILL_NONE, GridConstraints.SIZEPOLICY_FIXED, GridConstraints.SIZEPOLICY_FIXED, null, null, null, 0, false));
         final JSeparator separator1 = new JSeparator();
         panel3.add(separator1, new GridConstraints(1, 0, 1, 2, GridConstraints.ANCHOR_CENTER, GridConstraints.FILL_BOTH, GridConstraints.SIZEPOLICY_FIXED, GridConstraints.SIZEPOLICY_FIXED, null, null, null, 0, false));
+        final JLabel labelSendCrashReports = new JLabel();
+        this.$$$loadLabelText$$$(labelSendCrashReports, this.$$$getMessageFromBundle$$$("slash/navigation/converter/gui/RouteConverter", "send-crash-reports-option"));
+        panel3.add(labelSendCrashReports, new GridConstraints(3, 0, 1, 1, GridConstraints.ANCHOR_WEST, GridConstraints.FILL_NONE, GridConstraints.SIZEPOLICY_FIXED, GridConstraints.SIZEPOLICY_FIXED, null, null, null, 0, false));
+        checkBoxSendCrashReports = new JCheckBox();
+        panel3.add(checkBoxSendCrashReports, new GridConstraints(3, 1, 1, 1, GridConstraints.ANCHOR_WEST, GridConstraints.FILL_NONE, GridConstraints.SIZEPOLICY_CAN_SHRINK | GridConstraints.SIZEPOLICY_CAN_GROW, GridConstraints.SIZEPOLICY_FIXED, null, null, null, 0, false));
         final JPanel panel4 = new JPanel();
         panel4.setLayout(new GridLayoutManager(1, 1, new Insets(6, 0, 0, 0), -1, -1));
-        panel3.add(panel4, new GridConstraints(3, 0, 1, 2, GridConstraints.ANCHOR_CENTER, GridConstraints.FILL_BOTH, GridConstraints.SIZEPOLICY_CAN_SHRINK | GridConstraints.SIZEPOLICY_CAN_GROW, GridConstraints.SIZEPOLICY_CAN_SHRINK | GridConstraints.SIZEPOLICY_CAN_GROW, null, null, null, 0, false));
+        panel3.add(panel4, new GridConstraints(4, 0, 1, 2, GridConstraints.ANCHOR_CENTER, GridConstraints.FILL_BOTH, GridConstraints.SIZEPOLICY_CAN_SHRINK | GridConstraints.SIZEPOLICY_CAN_GROW, GridConstraints.SIZEPOLICY_CAN_SHRINK | GridConstraints.SIZEPOLICY_CAN_GROW, null, null, null, 0, false));
         final JPanel panel5 = new JPanel();
         panel5.setLayout(new GridLayoutManager(4, 4, new Insets(3, 3, 3, 3), -1, -1));
         panel2.add(panel5, new GridConstraints(3, 0, 1, 1, GridConstraints.ANCHOR_CENTER, GridConstraints.FILL_BOTH, GridConstraints.SIZEPOLICY_CAN_SHRINK | GridConstraints.SIZEPOLICY_CAN_GROW, GridConstraints.SIZEPOLICY_CAN_SHRINK | GridConstraints.SIZEPOLICY_CAN_GROW, null, null, null, 0, false));

--- a/route-converter-gui/src/main/java/slash/navigation/converter/gui/helpers/CrashReporter.java
+++ b/route-converter-gui/src/main/java/slash/navigation/converter/gui/helpers/CrashReporter.java
@@ -69,19 +69,37 @@ public class CrashReporter implements CrashHandler {
     private final CrashReportSender sender;
     private final BooleanSupplier telemetryOptedIn;
     private final Supplier<String> apiUrl;
+    private final DialogOpener dialogOpener;
+
+    /**
+     * Opens the manual review dialog for a report and reports back whether the user sent
+     * it. Injected so the manual (opt-out) branching is exercised without the static
+     * {@link RouteConverter#getInstance()} Swing singleton; the public constructor wires
+     * the real {@link SendErrorReportDialog}.
+     */
+    interface DialogOpener {
+        boolean openAndConfirmSent(String json);
+    }
 
     public CrashReporter() {
         this(CrashReportSpool.createDefault(), new CrashReportSender(),
                 RouteConverter::isSendCrashReportsEnabled,
-                () -> RouteConverter.getInstance().getApiUrl());
+                () -> RouteConverter.getInstance().getApiUrl(),
+                CrashReporter::showSendErrorReportDialog);
     }
 
     CrashReporter(CrashReportSpool spool, CrashReportSender sender,
                   BooleanSupplier telemetryOptedIn, Supplier<String> apiUrl) {
+        this(spool, sender, telemetryOptedIn, apiUrl, CrashReporter::showSendErrorReportDialog);
+    }
+
+    CrashReporter(CrashReportSpool spool, CrashReportSender sender,
+                  BooleanSupplier telemetryOptedIn, Supplier<String> apiUrl, DialogOpener dialogOpener) {
         this.spool = spool;
         this.sender = sender;
         this.telemetryOptedIn = telemetryOptedIn;
         this.apiUrl = apiUrl;
+        this.dialogOpener = dialogOpener;
     }
 
     public void handleCrash(Thread thread, Throwable throwable) {
@@ -103,7 +121,7 @@ public class CrashReporter implements CrashHandler {
 
         // not opted in: the Phase 1 manual review dialog is the only send path.
         if (claimDialogSlot())
-            invokeLater(() -> showReportDialog(json));
+            invokeLater(() -> dialogOpener.openAndConfirmSent(json));
     }
 
     /**
@@ -126,22 +144,27 @@ public class CrashReporter implements CrashHandler {
         if (!claimDialogSlot())
             return;
 
-        // offer every spooled report, not just the newest: a report the user dismisses
-        // without sending is kept, so offering only the newest would block all older
-        // ones from ever being surfaced (they would linger until evicted by the cap)
-        invokeLater(() -> {
-            for (File file : spool.list()) {
-                try {
-                    String json = spool.read(file);
-                    SendErrorReportDialog dialog = new SendErrorReportDialog(json);
-                    dialog.showWithPreferences();
-                    if (dialog.isSent())
-                        spool.delete(file);
-                } catch (IOException e) {
-                    log.log(WARNING, "Cannot read spooled crash report " + file, e);
-                }
+        invokeLater(this::offerSpooledReportsInDialog);
+    }
+
+    /**
+     * Offers every spooled report in the manual review dialog, deleting each only once
+     * the user actually sent it. Every report is offered, not just the newest: a report
+     * the user dismisses without sending is kept, so offering only the newest would block
+     * all older ones from ever being surfaced (they would linger until evicted by the
+     * cap). Package-visible and free of the event dispatch thread so the per-file
+     * delete-only-when-sent branching can be exercised directly.
+     */
+    void offerSpooledReportsInDialog() {
+        for (File file : spool.list()) {
+            try {
+                String json = spool.read(file);
+                if (dialogOpener.openAndConfirmSent(json))
+                    spool.delete(file);
+            } catch (IOException e) {
+                log.log(WARNING, "Cannot read spooled crash report " + file, e);
             }
-        });
+        }
     }
 
     /**
@@ -171,15 +194,20 @@ public class CrashReporter implements CrashHandler {
         }
     }
 
-    private void showReportDialog(String json) {
+    /**
+     * The production {@link DialogOpener}: shows the {@link SendErrorReportDialog} on the
+     * RouteConverter frame and reports whether the user sent the report. Returns false
+     * with no frame yet (a very early crash): the report is spooled and offered on the
+     * next successful launch instead.
+     */
+    private static boolean showSendErrorReportDialog(String json) {
         RouteConverter instance = RouteConverter.getInstance();
-        // no frame yet (a very early crash): the report is spooled and offered on the
-        // next successful launch instead
         if (instance == null || instance.getFrame() == null)
-            return;
+            return false;
 
         SendErrorReportDialog dialog = new SendErrorReportDialog(json);
         dialog.showWithPreferences();
+        return dialog.isSent();
     }
 
     /**

--- a/route-converter-gui/src/main/resources/slash/navigation/converter/gui/RouteConverter_de.properties
+++ b/route-converter-gui/src/main/resources/slash/navigation/converter/gui/RouteConverter_de.properties
@@ -723,7 +723,8 @@ send-error-report-title=Sende Fehlerbericht
 send-error-report-log=Für Deinen Fehlerbericht an den RouteConverter-Dienst wird die folgende Information übermittelt:
 send-error-report-description=Bitte füge eine Beschreibung hinzu, wann der Fehler auftrat und wie er reproduziert werden kann:
 send-error-report-file=Bitte füge zusätzliche Informationen wie Bildschirmfotos oder Dateien mit GPS-Daten hinzu, um den Fehler leichter reproduzieren zu können:
-send-crash-reports-question=<html>Anonyme Fehlerberichte senden, um beim Beheben von Abstürzen zu helfen?<br><br>Es werden nur technische Daten übermittelt: der Fehler und seine technischen Details (Stacktrace) sowie Deine Java- und Betriebssystem-Version. Es werden keine Routen oder Dokumente gesendet, und Dein Benutzername wird aus Dateipfaden im Bericht entfernt. Mehr dazu erfährst Du auf der RouteConverter-Webseite.
+send-crash-reports-question=<html><body width='420'><b>Anonyme Fehlerberichte senden, um beim Beheben von Abstürzen zu helfen?</b><p>Was gesendet wird: der Fehler und seine technischen Details (Stacktrace) sowie Deine Java- und Betriebssystem-Version.<p>Was nicht gesendet wird: keine Routen oder Dokumente, und Dein Benutzername wird aus Dateipfaden entfernt.<p>Mehr dazu erfährst Du auf der RouteConverter-Webseite.
+send-crash-reports-option=Anonyme Fehlerberichte senden
 choose-file-path=Wähle Pfad zu Datei:
 send=Senden
 copy-diagnostic-report=Diagnosebericht kopieren

--- a/route-converter-gui/src/main/resources/slash/navigation/converter/gui/RouteConverter_en.properties
+++ b/route-converter-gui/src/main/resources/slash/navigation/converter/gui/RouteConverter_en.properties
@@ -714,7 +714,8 @@ send-error-report-title=Send Error Report
 send-error-report-log=For your error report to the RouteConverter service the following information will be transmitted:
 send-error-report-description=Please add a description when the error occured and how to reproduce it:
 send-error-report-file=Please add additional information like screenshots or files with GPS data to help reproducing the error:
-send-crash-reports-question=<html>Send anonymous error reports to help fix crashes?<br><br>Only technical data is sent: the error and its stack trace, plus your Java and operating system version. No routes or documents are sent, and your user name is removed from any file paths in the report. You can find out more on the RouteConverter website.
+send-crash-reports-question=<html><body width='420'><b>Send anonymous error reports to help fix crashes?</b><p>What is sent: the error and its stack trace, plus your Java and operating system version.<p>What is not sent: no routes or documents, and your user name is removed from any file paths.<p>You can find out more on the RouteConverter website.
+send-crash-reports-option=Send anonymous error reports
 choose-file-path=Choose path to file:
 send=Send
 copy-diagnostic-report=Copy diagnostic report

--- a/route-converter-gui/src/test/java/slash/navigation/converter/gui/helpers/CrashReporterTest.java
+++ b/route-converter-gui/src/test/java/slash/navigation/converter/gui/helpers/CrashReporterTest.java
@@ -119,4 +119,37 @@ public class CrashReporterTest {
         assertEquals(2, sender.sent.size());
         assertEquals("a failed send must leave the report for the next launch", 2, spool.list().size());
     }
+
+    @Test
+    public void testManualDialogDeletesOnlyReportsTheUserSent() throws IOException {
+        CrashReportSpool spool = spoolWithReports(3);
+        RecordingSender sender = new RecordingSender(true);
+        // the injected opener stands in for the Swing dialog: the user "sends" only the
+        // n:1 report and dismisses the rest
+        CrashReporter.DialogOpener opener = json -> json.contains("\"n\":1");
+        CrashReporter reporter = new CrashReporter(spool, sender, () -> false, () -> "http://localhost/", opener);
+
+        reporter.offerSpooledReportsInDialog();
+
+        assertEquals("only the sent report is deleted; dismissed ones are kept", 2, spool.list().size());
+        assertEquals("the manual path never uses the silent sender", 0, sender.sent.size());
+    }
+
+    @Test
+    public void testManualDialogOffersEveryReportAndDismissedKeepsAll() throws IOException {
+        CrashReportSpool spool = spoolWithReports(3);
+        RecordingSender sender = new RecordingSender(true);
+        List<String> opened = new ArrayList<>();
+        CrashReporter.DialogOpener opener = json -> {
+            opened.add(json);
+            return false;
+        };
+        CrashReporter reporter = new CrashReporter(spool, sender, () -> false, () -> "http://localhost/", opener);
+
+        reporter.offerSpooledReportsInDialog();
+
+        assertEquals("every spooled report is offered, not just the newest", 3, opened.size());
+        assertEquals("a report the user dismisses is kept for a later offer", 3, spool.list().size());
+        assertEquals(0, sender.sent.size());
+    }
 }


### PR DESCRIPTION
Applies 10 review findings to the crash-telemetry feature merged in #118:

**Privacy**
- `DiagnosticReport.scrub` now redacts absolute-path-like tokens outside `user.home` (Windows drive paths, `/Volumes|/media|/mnt|/home/...`) from free-form messages — a `FileNotFoundException: D:\Trips\vacation2024.gpx` no longer leaves the machine. URLs and stack frames untouched; short usernames scrubbed via word-boundary matching.

**Robustness**
- Spool filenames gain the pid — two concurrent RC instances crashing in the same millisecond no longer overwrite each other's report.
- Free-text report fields capped at 24 KB at spool time — oversized reports could previously never be sent NOR deleted, re-POSTing every launch forever.
- One cycle-safe `ExceptionHelper.getCauseChain` now backs `getRootCause`, `getMessageWithCauses` and `DiagnosticReport` — an A→B→A cause cycle previously hung the crash handler itself.
- One-time WARNING when the committed placeholder HMAC secret is in use (misconfigured build was 100% silent report loss).

**Consent UX**
- Options dialog gains a "Send anonymous error reports" checkbox — consent is now revocable/grantable after the first-launch question (was one-shot forever). *Note: `.form` + generated UI edited in sync; worth one look in the IntelliJ designer.*
- First-launch consent dialog reformatted: bold headline + wrapped body (`<html><body width='420'>`) instead of one screen-wide paragraph; en + de.

**Test coverage**
- `MultipartRequest` raw-body path (the HMAC-verified bytes): entity type, exact UTF-8 bytes, precedence over multipart parts.
- `Application`'s uncaught-handler→`handleCrash` dispatch: called once, re-entry guard holds, latch resets.
- `CrashReporter` dialog-opener seam injected — manual-consent branching (claim latch, delete-only-when-sent) now unit-tested headless.

12 tests added; full reactor green.