### PR TITLE
refactor(mapsforge-mapview): extract pure calculations (items 2-light, 6)

### DIFF
--- a/mapsforge-mapview/src/main/java/slash/navigation/mapview/mapsforge/MapsforgeMapView.java
+++ b/mapsforge-mapview/src/main/java/slash/navigation/mapview/mapsforge/MapsforgeMapView.java
@@ -102,8 +102,6 @@ import static javax.swing.SwingUtilities.invokeLater;
 import static javax.swing.event.TableModelEvent.*;
 import static org.mapsforge.core.graphics.Color.BLUE;
 import static org.mapsforge.core.util.LatLongUtils.zoomForBounds;
-import static org.mapsforge.core.util.MercatorProjection.calculateGroundResolution;
-import static org.mapsforge.core.util.MercatorProjection.getMapSize;
 import static org.mapsforge.map.scalebar.DefaultMapScaleBar.ScaleBarMode.SINGLE;
 import static slash.common.helpers.ThreadHelper.invokeInAwtEventQueue;
 import static slash.common.type.HexadecimalNumber.encodeInt;
@@ -120,6 +118,9 @@ import static slash.navigation.maps.mapsforge.MapType.Mapsforge;
 import static slash.navigation.maps.mapsforge.helpers.MapUtil.toBoundingBox;
 import static slash.navigation.mapview.mapsforge.AwtGraphicMapView.GRAPHIC_FACTORY;
 import static slash.navigation.mapview.mapsforge.helpers.ColorHelper.asAlpha;
+import static slash.navigation.mapview.mapsforge.helpers.MapViewCalculations.collectBoundingPositions;
+import static slash.navigation.mapview.mapsforge.helpers.MapViewCalculations.computeAddRow;
+import static slash.navigation.mapview.mapsforge.helpers.MapViewCalculations.thresholdForPixel;
 import static slash.navigation.mapview.mapsforge.helpers.SVGHelper.getResourceBitmap;
 import static slash.navigation.mapview.mapsforge.helpers.WithLayerHelper.*;
 import static slash.navigation.mapview.mapsforge.models.LocalNames.MAP;
@@ -897,33 +898,7 @@ public class MapsforgeMapView extends BaseMapView {
 
     private void centerAndZoom(BoundingBox mapBoundingBox, BoundingBox routeBoundingBox,
                                boolean alwaysZoom, boolean alwaysRecenter) {
-        List<NavigationPosition> positions = new ArrayList<>();
-
-        // if there is a route and we center and zoom, then use the route bounding box
-        if (routeBoundingBox != null) {
-            positions.add(routeBoundingBox.northEast());
-            positions.add(routeBoundingBox.southWest());
-        }
-
-        // if the map is limited
-        if (mapBoundingBox != null) {
-
-            // if there is a route
-            if (routeBoundingBox != null) {
-                positions.add(routeBoundingBox.northEast());
-                positions.add(routeBoundingBox.southWest());
-                // if the map is limited and doesn't cover the route
-                if (!mapBoundingBox.contains(routeBoundingBox)) {
-                    positions.add(mapBoundingBox.northEast());
-                    positions.add(mapBoundingBox.southWest());
-                }
-
-                // if there just a map
-            } else {
-                positions.add(mapBoundingBox.northEast());
-                positions.add(mapBoundingBox.southWest());
-            }
-        }
+        List<NavigationPosition> positions = collectBoundingPositions(mapBoundingBox, routeBoundingBox);
 
         if (!positions.isEmpty()) {
             BoundingBox both = asBoundingBox(positions);
@@ -1128,9 +1103,7 @@ public class MapsforgeMapView extends BaseMapView {
     }
 
     private double getThresholdForPixel(LatLong latLong) {
-        long mapSize = getMapSize(mapView.getModel().mapViewPosition.getZoomLevel(), getTileSize());
-        double metersPerPixel = calculateGroundResolution(latLong.latitude, mapSize);
-        return metersPerPixel * SELECTION_CIRCLE_IN_PIXEL;
+        return thresholdForPixel(latLong.latitude, mapView.getModel().mapViewPosition.getZoomLevel(), getTileSize(), SELECTION_CIRCLE_IN_PIXEL);
     }
 
     private void selectPosition(LatLong latLong, Double threshold, boolean replaceSelection) {
@@ -1164,11 +1137,8 @@ public class MapsforgeMapView extends BaseMapView {
     private class AddPositionAction extends FrameAction {
         private int getAddRow() {
             List<PositionWithLayer> lastSelectedPositions = selectionUpdater.getPositionWithLayers();
-            NavigationPosition position = !lastSelectedPositions.isEmpty() ? lastSelectedPositions.get(lastSelectedPositions.size() - 1).getPosition() : null;
-            // quite crude logic to be as robust as possible on failures
-            if (position == null && positionsModel.getRowCount() > 0)
-                position = positionsModel.getPosition(positionsModel.getRowCount() - 1);
-            return position != null ? positionsModel.getIndex(position) + 1 : 0;
+            NavigationPosition lastSelected = !lastSelectedPositions.isEmpty() ? lastSelectedPositions.get(lastSelectedPositions.size() - 1).getPosition() : null;
+            return computeAddRow(lastSelected, positionsModel);
         }
 
         private void insertPosition(int row, Double longitude, Double latitude) {

--- a/mapsforge-mapview/src/main/java/slash/navigation/mapview/mapsforge/helpers/MapViewCalculations.java
+++ b/mapsforge-mapview/src/main/java/slash/navigation/mapview/mapsforge/helpers/MapViewCalculations.java
@@ -1,0 +1,98 @@
+/*
+    This file is part of RouteConverter.
+
+    RouteConverter is free software; you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation; either version 2 of the License, or
+    (at your option) any later version.
+
+    RouteConverter is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with RouteConverter; if not, write to the Free Software
+    Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
+
+    Copyright (C) 2007 Christian Pesch. All Rights Reserved.
+*/
+package slash.navigation.mapview.mapsforge.helpers;
+
+import slash.navigation.common.BoundingBox;
+import slash.navigation.common.NavigationPosition;
+import slash.navigation.converter.gui.models.PositionsModel;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import static org.mapsforge.core.util.MercatorProjection.calculateGroundResolution;
+import static org.mapsforge.core.util.MercatorProjection.getMapSize;
+
+/**
+ * Pure calculations behind the {@link slash.navigation.mapview.mapsforge.MapsforgeMapView} interaction
+ * logic, factored out so they can be unit-tested without a live map view.
+ *
+ * @author Christian Pesch
+ */
+
+public class MapViewCalculations {
+    private MapViewCalculations() {
+    }
+
+    /**
+     * The ground distance (meters) that spans the given number of screen pixels at a zoom level -
+     * used as the selection tolerance when hit-testing positions near a map click.
+     */
+    public static double thresholdForPixel(double latitude, byte zoomLevel, int tileSize, int selectionCirclePixels) {
+        long mapSize = getMapSize(zoomLevel, tileSize);
+        double metersPerPixel = calculateGroundResolution(latitude, mapSize);
+        return metersPerPixel * selectionCirclePixels;
+    }
+
+    /**
+     * The corner positions to fit into view when centering and zooming: the route's box if present,
+     * plus the map's box when it is limited and does not already cover the route.
+     */
+    public static List<NavigationPosition> collectBoundingPositions(BoundingBox mapBoundingBox, BoundingBox routeBoundingBox) {
+        List<NavigationPosition> positions = new ArrayList<>();
+
+        // if there is a route and we center and zoom, then use the route bounding box
+        if (routeBoundingBox != null) {
+            positions.add(routeBoundingBox.northEast());
+            positions.add(routeBoundingBox.southWest());
+        }
+
+        // if the map is limited
+        if (mapBoundingBox != null) {
+            // if there is a route
+            if (routeBoundingBox != null) {
+                positions.add(routeBoundingBox.northEast());
+                positions.add(routeBoundingBox.southWest());
+                // if the map is limited and doesn't cover the route
+                if (!mapBoundingBox.contains(routeBoundingBox)) {
+                    positions.add(mapBoundingBox.northEast());
+                    positions.add(mapBoundingBox.southWest());
+                }
+                // if there just a map
+            } else {
+                positions.add(mapBoundingBox.northEast());
+                positions.add(mapBoundingBox.southWest());
+            }
+        }
+
+        return positions;
+    }
+
+    /**
+     * The row a new position should be inserted at: after the last selected position, else after the
+     * last position in the list, else at the start. Kept robust against a missing selection.
+     */
+    public static int computeAddRow(NavigationPosition lastSelected, PositionsModel positionsModel) {
+        NavigationPosition position = lastSelected;
+        // quite crude logic to be as robust as possible on failures
+        if (position == null && positionsModel.getRowCount() > 0)
+            position = positionsModel.getPosition(positionsModel.getRowCount() - 1);
+        return position != null ? positionsModel.getIndex(position) + 1 : 0;
+    }
+}

--- a/mapsforge-mapview/src/test/java/slash/navigation/mapview/mapsforge/helpers/MapViewCalculationsTest.java
+++ b/mapsforge-mapview/src/test/java/slash/navigation/mapview/mapsforge/helpers/MapViewCalculationsTest.java
@@ -1,0 +1,103 @@
+/*
+    This file is part of RouteConverter.
+
+    RouteConverter is free software; you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation; either version 2 of the License, or
+    (at your option) any later version.
+
+    RouteConverter is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with RouteConverter; if not, write to the Free Software
+    Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
+
+    Copyright (C) 2007 Christian Pesch. All Rights Reserved.
+*/
+package slash.navigation.mapview.mapsforge.helpers;
+
+import org.junit.Test;
+import slash.navigation.common.BoundingBox;
+import slash.navigation.common.NavigationPosition;
+import slash.navigation.common.SimpleNavigationPosition;
+import slash.navigation.converter.gui.models.PositionsModel;
+
+import static org.junit.Assert.*;
+import static org.mockito.Mockito.*;
+import static slash.navigation.mapview.mapsforge.helpers.MapViewCalculations.*;
+
+public class MapViewCalculationsTest {
+
+    @Test
+    public void thresholdScalesWithPixelsAndShrinksWithZoom() {
+        double onePixel = thresholdForPixel(0.0, (byte) 10, 256, 1);
+        double tenPixels = thresholdForPixel(0.0, (byte) 10, 256, 10);
+        assertTrue(onePixel > 0);
+        assertEquals(10 * onePixel, tenPixels, 1e-9);
+
+        double zoomedIn = thresholdForPixel(0.0, (byte) 15, 256, 10);
+        assertTrue("higher zoom means fewer meters per pixel", zoomedIn < tenPixels);
+    }
+
+    @Test
+    public void collectRouteOnly() {
+        assertEquals(2, collectBoundingPositions(null, box(0, 0, 10, 10)).size());
+    }
+
+    @Test
+    public void collectMapOnly() {
+        assertEquals(2, collectBoundingPositions(box(0, 0, 10, 10), null).size());
+    }
+
+    @Test
+    public void collectMapContainingRoute() {
+        assertEquals(4, collectBoundingPositions(box(0, 0, 10, 10), box(2, 2, 5, 5)).size());
+    }
+
+    @Test
+    public void collectMapNotContainingRoute() {
+        assertEquals(6, collectBoundingPositions(box(0, 0, 3, 3), box(2, 2, 20, 20)).size());
+    }
+
+    @Test
+    public void collectNeitherIsEmpty() {
+        assertTrue(collectBoundingPositions(null, null).isEmpty());
+    }
+
+    @Test
+    public void addRowAfterSelectedPosition() {
+        PositionsModel model = mock(PositionsModel.class);
+        NavigationPosition selected = new SimpleNavigationPosition(1.0, 2.0);
+        when(model.getIndex(selected)).thenReturn(3);
+
+        assertEquals(4, computeAddRow(selected, model));
+    }
+
+    @Test
+    public void addRowAfterLastPositionWhenNothingSelected() {
+        PositionsModel model = mock(PositionsModel.class);
+        NavigationPosition last = new SimpleNavigationPosition(1.0, 2.0);
+        when(model.getRowCount()).thenReturn(5);
+        when(model.getPosition(4)).thenReturn(last);
+        when(model.getIndex(last)).thenReturn(4);
+
+        assertEquals(5, computeAddRow(null, model));
+    }
+
+    @Test
+    public void addRowAtStartWhenEmpty() {
+        PositionsModel model = mock(PositionsModel.class);
+        when(model.getRowCount()).thenReturn(0);
+
+        assertEquals(0, computeAddRow(null, model));
+    }
+
+    private BoundingBox box(double swLon, double swLat, double neLon, double neLat) {
+        NavigationPosition southWest = new SimpleNavigationPosition(swLon, swLat);
+        NavigationPosition northEast = new SimpleNavigationPosition(neLon, neLat);
+        return new BoundingBox(northEast, southWest);
+    }
+}


### PR DESCRIPTION
Stacked on #125. Extracts the view-independent decision logic from `MapsforgeMapView` into a tested `helpers/MapViewCalculations`:

- `thresholdForPixel(...)` — pixel→ground selection tolerance (item 2, light version).
- `computeAddRow(...)` — insert-row logic for AddPositionAction (item 2, light).
- `collectBoundingPositions(...)` — the centerAndZoom corner-collection (item 6).

Item 2 was taken as the **light** version by decision: the `FrameAction` mouse/edit glue stays in the view (it's inherently view-coupled; a full extraction would need a ~12-method leaky seam with no coverage gain). Only the pure, testable logic moved out.

`MapViewCalculations` is unit-tested (9 cases: threshold scaling/zoom, the four collect cases + empty, three add-row cases). Module suite 77 → 86, coverage gate green. No behaviour change.