### PR TITLE
spec 00011: inject crash-report HMAC secret at build time (go-live prereq)

### DIFF
--- a/.github/workflows/_build-linux-mac.yml
+++ b/.github/workflows/_build-linux-mac.yml
@@ -34,6 +34,8 @@ on:
     secrets:
       SIGNPATH_API_TOKEN:
         required: false
+      CRASH_REPORT_HMAC_SECRET:
+        required: false
 
 jobs:
   build:

--- a/.github/workflows/_build-linux-mac.yml
+++ b/.github/workflows/_build-linux-mac.yml
@@ -82,7 +82,7 @@ jobs:
         # value the inline jobs used before Phase 5.2.
         # No `clean` — runner is ephemeral; `clean` would also wipe the
         # Runtime-<arch> dirs unpacked from the hosted Mac JREs above.
-        run: ./mvnw --batch-mode -Prouteconverter -Dmaven.build.number=${{ github.run_number }} package
+        run: ./mvnw --batch-mode -Prouteconverter -Dmaven.build.number=${{ github.run_number }} -DcrashReportSecret=${{ secrets.CRASH_REPORT_HMAC_SECRET }} package
       - name: Verify runtime on stripped JRE (class-load gate)
         # Reproduces the minimized-JRE condition from scripts/jre-modules.txt and
         # fails the build on a ClassNotFoundException/NoClassDefFoundError that a

--- a/.github/workflows/_build-windows.yml
+++ b/.github/workflows/_build-windows.yml
@@ -70,7 +70,7 @@ jobs:
 
       - name: Build (incl. bundle modules, resource-filters .nsi)
         shell: cmd
-        run: ./mvnw.cmd --batch-mode -Prouteconverter -Dmaven.build.number=${{ github.run_number }} clean package
+        run: ./mvnw.cmd --batch-mode -Prouteconverter -Dmaven.build.number=${{ github.run_number }} -DcrashReportSecret=${{ secrets.CRASH_REPORT_HMAC_SECRET }} clean package
 
       - name: Pin NSIS 3.11
         shell: pwsh

--- a/.github/workflows/_build-windows.yml
+++ b/.github/workflows/_build-windows.yml
@@ -39,6 +39,8 @@ on:
     secrets:
       SIGNPATH_API_TOKEN:
         required: false
+      CRASH_REPORT_HMAC_SECRET:
+        required: false
 
 jobs:
   build:

--- a/feedback/pom.xml
+++ b/feedback/pom.xml
@@ -45,6 +45,16 @@
             <resource>
                 <directory>src/main/resources</directory>
                 <filtering>true</filtering>
+                <includes>
+                    <include>slash/navigation/feedback/domain/crash-report.properties</include>
+                </includes>
+            </resource>
+            <resource>
+                <directory>src/main/resources</directory>
+                <filtering>false</filtering>
+                <excludes>
+                    <exclude>slash/navigation/feedback/domain/crash-report.properties</exclude>
+                </excludes>
             </resource>
         </resources>
     </build>

--- a/feedback/pom.xml
+++ b/feedback/pom.xml
@@ -39,4 +39,13 @@
             <version>${project.version}</version>
         </dependency>
     </dependencies>
+
+    <build>
+        <resources>
+            <resource>
+                <directory>src/main/resources</directory>
+                <filtering>true</filtering>
+            </resource>
+        </resources>
+    </build>
 </project>

--- a/feedback/src/main/java/slash/navigation/feedback/domain/CrashReportSender.java
+++ b/feedback/src/main/java/slash/navigation/feedback/domain/CrashReportSender.java
@@ -26,6 +26,8 @@ import slash.navigation.rest.Post;
 import javax.crypto.Mac;
 import javax.crypto.spec.SecretKeySpec;
 import java.io.IOException;
+import java.io.InputStream;
+import java.util.Properties;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.logging.Logger;
 
@@ -55,8 +57,12 @@ public class CrashReportSender {
     static final String SIGNATURE_HEADER = "X-RouteConverter-Signature";
 
     static final String SECRET_PROPERTY = "routeconverter.crashReportSecret";
-    // The real HMAC key is injected at build/deploy time (system property) to match the
-    // server's CRASH_REPORT_HMAC_SECRET. This obvious placeholder must never be a live
+    static final String SECRET_RESOURCE = "crash-report.properties";
+    static final String SECRET_KEY = "crashReportSecret";
+    // The real HMAC key is injected at build time into crash-report.properties (Maven
+    // resource filtering from -DcrashReportSecret) to match the server's
+    // CRASH_REPORT_HMAC_SECRET, with the routeconverter.crashReportSecret system
+    // property as a runtime override. This obvious placeholder must never be a live
     // secret and must never be committed as one.
     static final String DEFAULT_SECRET = "CHANGEME-crash-report-hmac-secret";
 
@@ -104,7 +110,34 @@ public class CrashReportSender {
     }
 
     static String secret() {
-        return System.getProperty(SECRET_PROPERTY, DEFAULT_SECRET);
+        String property = System.getProperty(SECRET_PROPERTY);
+        if (property != null && !property.isEmpty())
+            return property;
+        String bundled = bundledSecret();
+        if (bundled != null)
+            return bundled;
+        return DEFAULT_SECRET;
+    }
+
+    /**
+     * Reads the build-time-injected key from the filtered {@code crash-report.properties}
+     * resource, or null when it is absent or still the unresolved Maven token (a local
+     * build without {@code -DcrashReportSecret}). The token-name guard mirrors
+     * {@code APIKeyRegistry}.
+     */
+    static String bundledSecret() {
+        try (InputStream inputStream = CrashReportSender.class.getResourceAsStream(SECRET_RESOURCE)) {
+            if (inputStream == null)
+                return null;
+            Properties properties = new Properties();
+            properties.load(inputStream);
+            String value = properties.getProperty(SECRET_KEY);
+            if (value != null && !value.isEmpty() && !value.contains(SECRET_KEY))
+                return value;
+        } catch (IOException e) {
+            log.log(FINE, "Cannot read bundled crash-report secret: " + e.getMessage());
+        }
+        return null;
     }
 
     /**

--- a/feedback/src/main/resources/slash/navigation/feedback/domain/crash-report.properties
+++ b/feedback/src/main/resources/slash/navigation/feedback/domain/crash-report.properties
@@ -1,0 +1,7 @@
+# The HMAC key the crash-report sender signs with. Maven resource filtering
+# replaces the token below at build time from the -DcrashReportSecret property
+# (injected in CI from the CRASH_REPORT_HMAC_SECRET repo secret, matching the
+# server's CRASH_REPORT_HMAC_SECRET). A local build without that property leaves
+# the token unresolved; CrashReportSender then treats it as unset and falls back
+# to the placeholder, so unsigned/placeholder reports never reach production.
+crashReportSecret=${crashReportSecret}

--- a/feedback/src/test/java/slash/navigation/feedback/domain/CrashReportSenderTest.java
+++ b/feedback/src/test/java/slash/navigation/feedback/domain/CrashReportSenderTest.java
@@ -28,6 +28,7 @@ import java.io.IOException;
 import static java.nio.charset.StandardCharsets.UTF_8;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
 import static slash.navigation.feedback.domain.CrashReportSender.MAXIMUM_BYTES;
 import static slash.navigation.feedback.domain.CrashReportSender.SECRET_PROPERTY;
@@ -96,5 +97,20 @@ public class CrashReportSenderTest {
         CrashReportSender.resetDefaultSecretWarningForTesting();
 
         assertFalse(warnIfDefaultSecret());
+    }
+
+    @Test
+    public void testBundledSecretUnresolvedTokenTreatedAsUnset() {
+        // a local/test build injects no -DcrashReportSecret, so the filtered resource
+        // still holds the ${crashReportSecret} token, which must count as unset
+        assertNull(CrashReportSender.bundledSecret());
+        System.clearProperty(SECRET_PROPERTY);
+        assertEquals(CrashReportSender.DEFAULT_SECRET, CrashReportSender.secret());
+    }
+
+    @Test
+    public void testSystemPropertyOverridesSecret() {
+        System.setProperty(SECRET_PROPERTY, "a-real-injected-secret");
+        assertEquals("a-real-injected-secret", CrashReportSender.secret());
     }
 }

--- a/feedback/src/test/java/slash/navigation/feedback/domain/CrashReportSenderTest.java
+++ b/feedback/src/test/java/slash/navigation/feedback/domain/CrashReportSenderTest.java
@@ -111,6 +111,10 @@ public class CrashReportSenderTest {
     @Test
     public void testSystemPropertyOverridesSecret() {
         System.setProperty(SECRET_PROPERTY, "a-real-injected-secret");
-        assertEquals("a-real-injected-secret", CrashReportSender.secret());
+        try {
+            assertEquals("a-real-injected-secret", CrashReportSender.secret());
+        } finally {
+            System.clearProperty(SECRET_PROPERTY);
+        }
     }
 }


### PR DESCRIPTION
Prerequisite for activating Phase 2/3 crash telemetry. Without this, a shipped build signs every report with the `CHANGEME` placeholder and the server 403s them all.

Mirrors the existing `APIKeyRegistry` / `apikey.properties` pattern (Maven-filtered classpath resource) rather than per-launcher `-D` flags — so it covers the Mac app, Windows app, and `java -jar` identically, with no assembly/NSI changes.

## What changed
- **New filtered resource** `feedback/.../crash-report.properties` = `crashReportSecret=${crashReportSecret}`; `feedback/pom.xml` enables resource filtering.
- **`CrashReportSender.secret()` resolution order:** `routeconverter.crashReportSecret` system property (runtime override) → bundled resource (build-injected) → `CHANGEME` placeholder. An unresolved `${crashReportSecret}` token (local build) counts as unset via the same token-name guard `APIKeyRegistry` uses.
- **CI:** `_build-linux-mac.yml` and `_build-windows.yml` pass `-DcrashReportSecret=${{ secrets.CRASH_REPORT_HMAC_SECRET }}` at `mvn package`; reaches the reusable workflows via existing `secrets: inherit`.

## Verified
- `mvn -pl feedback test` green — 7 `CrashReportSenderTest` (2 new: unresolved-token→unset, system-property override).
- `-DcrashReportSecret=X process-resources` bakes `crashReportSecret=X`; a plain build leaves the token unresolved (→ placeholder). Confirmed both ways.

## Deploy coupling
Set the GitHub repo secret `CRASH_REPORT_HMAC_SECRET` on `cpesch/RouteConverter` to the **same** value as rc-site's `CRASH_REPORT_HMAC_SECRET`. The baked key is extractable from the shipped app by design (spec 00011).