### PR TITLE
fix(feedback): crash-secret tests fail under CI build-time injection (master hotfix)

### DIFF
--- a/feedback/src/test/resources/slash/navigation/feedback/domain/crash-report.properties
+++ b/feedback/src/test/resources/slash/navigation/feedback/domain/crash-report.properties
@@ -1,0 +1,6 @@
+# Test-scoped copy with the token deliberately left UNRESOLVED. Test resources
+# are not filtered, and target/test-classes precedes target/classes on the test
+# classpath, so this shadows the main resource. That keeps the unit tests seeing
+# the "secret not injected" state even when the CI `mvn package` build filters
+# the main resource with -DcrashReportSecret=<real key>.
+crashReportSecret=${crashReportSecret}


### PR DESCRIPTION
**Master prereleases are red.** #127 merged the build-time HMAC injection, but two `CrashReportSenderTest` cases assumed the `${crashReportSecret}` token stays unresolved. CI's `mvn package -DcrashReportSecret=<key>` filters the main `crash-report.properties` with the real key, so `bundledSecret()`/`secret()` return it and `testBundledSecretUnresolvedTokenTreatedAsUnset` + `testWarnsOnceWhenSecretIsPlaceholder` fail — on `build-linux-mac` and `build-windows` (reactor stops at `:feedback`). Local `mvn test` (no `-D`) passed, which is why it slipped through.

## Fix
Add a **test-scoped** `feedback/src/test/resources/.../crash-report.properties` keeping the literal token. Test resources aren't filtered and `target/test-classes` precedes `target/classes`, so it shadows the injected main resource — the unit tests always see the not-injected state, independent of whether the packaging build baked a key.

## Verified
`mvn -pl feedback -DcrashReportSecret=SIMULATED-CI-VALUE test` → green (reproduces the CI condition). Confirmed main resource = `SIMULATED-CI-VALUE`, test resource = `${crashReportSecret}`.