### PR TITLE
ci(release): prune stale assets from /latest/ and /prerelease/ with rsync --delete

### DIFF
--- a/.github/workflows/prerelease.yml
+++ b/.github/workflows/prerelease.yml
@@ -71,7 +71,9 @@ jobs:
         env:
           DEPLOY_HOST: ${{ secrets.RC_RELEASE_DEPLOY_HOST }}
         run: |
-          rsync -av --omit-dir-times --no-perms \
+          # --delete: /prerelease/ mirrors only the current build; prunes renamed/
+          # discontinued assets so stale files aren't served (matches release.yml)
+          rsync -av --delete --omit-dir-times --no-perms \
             artefacts/ \
             "rc-release-deploy@${DEPLOY_HOST}:/var/www/routeconverter.com/static/downloads/prereleases/"
       - name: Update rolling 'prerelease' GitHub Release

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -79,7 +79,9 @@ jobs:
         env:
           DEPLOY_HOST: ${{ secrets.RC_RELEASE_DEPLOY_HOST }}
         run: |
-          rsync -av --omit-dir-times --no-perms \
+          # --delete: /latest/ must only hold the current release; prunes prior-version
+          # orphans (renamed/discontinued assets) that would otherwise serve stale builds
+          rsync -av --delete --omit-dir-times --no-perms \
             artefacts/ \
             "rc-release-deploy@${DEPLOY_HOST}:/var/www/routeconverter.com/static/downloads/release/"
       - name: Rsync to static.routeconverter.com/downloads/previous-releases/<v>/


### PR DESCRIPTION
Renamed/discontinued assets (e.g. 3.4 `*Bundle.exe`, `*OpenSource.*`) lingered in the release/prerelease download dirs because both deploy rsyncs ran without `--delete`. After 3.5 renamed the artifacts to single `RouteConverterWindows.exe` / `RouteConverterLinux.jar` / `RouteConverterMac-{aarch64,x64}-app.zip`, the old files stayed in `/latest/` and the download page kept serving the stale 3.4 Windows build under its old name (forum thread-4133).

Add `--delete` to both deploy rsyncs so each publish leaves only the current release/prerelease set. Matches the javadoc rsync, which already uses `--delete`.

## Changes
- `.github/workflows/release.yml` — `--delete` on the `/latest/` rsync
- `.github/workflows/prerelease.yml` — `--delete` on the `/prerelease/` rsync

## Note
Live cleanup (WP downloads page, releases-host landing, PAD catalog, orphan file removal) already done out-of-band; this PR is the durable fix that prevents recurrence.