### PR TITLE
Refactors + test coverage: catalog links, parser buffering, Columbus formats

### DIFF
--- a/common/src/main/java/slash/common/io/Files.java
+++ b/common/src/main/java/slash/common/io/Files.java
@@ -71,7 +71,7 @@ public class Files {
     }
 
     public static String getExtension(URL url) {
-        return getExtension(url.toExternalForm()).toLowerCase();
+        return getExtension(url.toExternalForm());
     }
 
     public static String getExtension(List<URL> urls) {
@@ -81,7 +81,23 @@ public class Files {
             if (found.length() > extension.length())
                 extension = found;
         }
-        return extension.toLowerCase();
+        return extension;
+    }
+
+    /**
+     * Resolves a file that may be an indirection to another file or directory:
+     * a Windows shortcut ({@code .lnk}) or a macOS Finder alias.
+     *
+     * @param file the file to inspect
+     * @return a {@link ResolvableLink} for the target, or null if the file is not such an indirection
+     * @throws IOException if the file cannot be read
+     */
+    public static ResolvableLink resolveLink(File file) throws IOException {
+        if (WindowsShortcut.isPotentialValidLink(file))
+            return new WindowsShortcut(file);
+        if (MacAlias.isPotentialValidAlias(file))
+            return new MacAlias(file);
+        return null;
     }
 
     /**

--- a/common/src/main/java/slash/common/io/MacAlias.java
+++ b/common/src/main/java/slash/common/io/MacAlias.java
@@ -21,6 +21,7 @@
 package slash.common.io;
 
 import java.io.*;
+import java.util.Arrays;
 import java.util.concurrent.TimeUnit;
 
 import static java.lang.String.format;
@@ -35,7 +36,7 @@ import static slash.common.system.Platform.isMac;
  *
  * @author Christian Pesch
  */
-public class MacAlias {
+public class MacAlias implements ResolvableLink {
     // modern Finder aliases are bookmark data starting with "book\0\0\0\0mark"
     private static final byte[] MAGIC = {'b', 'o', 'o', 'k'};
     private static final long RESOLVE_TIMEOUT_SECONDS = 10;
@@ -58,7 +59,7 @@ public class MacAlias {
 
         try (InputStream inputStream = new FileInputStream(file)) {
             byte[] head = new byte[MAGIC.length];
-            return inputStream.read(head) == MAGIC.length && isMagicPresent(head);
+            return inputStream.read(head) == MAGIC.length && Arrays.equals(head, MAGIC);
         }
     }
 
@@ -85,15 +86,6 @@ public class MacAlias {
 
     public boolean isFile() {
         return !isDirectory();
-    }
-
-    private static boolean isMagicPresent(byte[] head) {
-        if (head.length < MAGIC.length)
-            return false;
-        for (int i = 0; i < MAGIC.length; i++)
-            if (head[i] != MAGIC[i])
-                return false;
-        return true;
     }
 
     /**

--- a/common/src/main/java/slash/common/io/ResolvableLink.java
+++ b/common/src/main/java/slash/common/io/ResolvableLink.java
@@ -1,0 +1,45 @@
+/*
+    This file is part of RouteConverter.
+
+    RouteConverter is free software; you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation; either version 2 of the License, or
+    (at your option) any later version.
+
+    RouteConverter is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with RouteConverter; if not, write to the Free Software
+    Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
+
+    Copyright (C) 2007 Christian Pesch. All Rights Reserved.
+*/
+
+package slash.common.io;
+
+/**
+ * A filesystem indirection that points at another file or directory: a Windows
+ * shortcut ({@link WindowsShortcut}) or a macOS alias ({@link MacAlias}).
+ * Use {@link Files#resolveLink(java.io.File)} to obtain one.
+ *
+ * @author Christian Pesch
+ */
+public interface ResolvableLink {
+    /**
+     * @return true if the link points to a directory
+     */
+    boolean isDirectory();
+
+    /**
+     * @return true if the link points to a file
+     */
+    boolean isFile();
+
+    /**
+     * @return the path of the file or directory pointed to by this link
+     */
+    String getRealFilename();
+}

--- a/common/src/main/java/slash/common/io/Transfer.java
+++ b/common/src/main/java/slash/common/io/Transfer.java
@@ -472,10 +472,6 @@ public class Transfer {
     public static String formatTime(CompactCalendar time) {
         if (time == null)
             return "?";
-        long totalSeconds = time.getTimeInMillis() / 1000;
-        long hours = totalSeconds / 3600;
-        long minutes = (totalSeconds % 3600) / 60;
-        long seconds = totalSeconds % 60;
-        return String.format("%02d:%02d:%02d", hours, minutes, seconds);
+        return formatDuration(time.getTimeInMillis());
     }
 }

--- a/common/src/main/java/slash/common/io/WindowsShortcut.java
+++ b/common/src/main/java/slash/common/io/WindowsShortcut.java
@@ -38,7 +38,7 @@ import static slash.common.io.Files.getExtension;
  *
  * @author Christian Pesch
  */
-public class WindowsShortcut {
+public class WindowsShortcut implements ResolvableLink {
     private static final int MINIMUM_LENGTH = 0x64;
     private static final int MAGIC = 0x0000004C;
 

--- a/navigation-formats/src/main/java/slash/navigation/base/NavigationFormatParser.java
+++ b/navigation-formats/src/main/java/slash/navigation/base/NavigationFormatParser.java
@@ -220,29 +220,29 @@ public class NavigationFormatParser {
                 bytes = inputStream.readAllBytes();
             }
             log.info("Reading '" + url + "' with " + bytes.length + " bytes");
-            NotClosingUnderlyingInputStream buffer = new NotClosingUnderlyingInputStream(new BufferedInputStream(new ByteArrayInputStream(bytes), CHUNK_BUFFER_SIZE));
-            // the whole content is buffered, so reset() between format attempts always succeeds
-            buffer.mark(bytes.length + CHUNK_BUFFER_SIZE * 2);
-            try {
-                CompactCalendar startDate = extractStartDate(url);
-                internalSetStartDate(startDate);
-                internalRead(buffer, getNavigationFormatRegistry().getReadFormats(), this);
-            } finally {
-                buffer.closeUnderlyingInputStream();
-            }
+            internalSetStartDate(extractStartDate(url));
+            bufferedInternalRead(new ByteArrayInputStream(bytes), bytes.length, getNavigationFormatRegistry().getReadFormats(), this);
         }
     }
 
     private ParserResult read(InputStream source, int readBufferSize, CompactCalendar startDate, File file,
                               List<NavigationFormat> formats) throws IOException {
         log.fine("Reading '" + source + "' with a buffer of " + readBufferSize + " bytes by " + formats.size() + " formats");
+        ParserContext<BaseRoute> context = new InternalParserContext<>(file, startDate);
+        bufferedInternalRead(source, readBufferSize, formats, context);
+        return createResult(context);
+    }
+
+    /**
+     * Buffers the source and marks past its end so reset() between format
+     * attempts always succeeds, then probes the formats into the context.
+     */
+    private void bufferedInternalRead(InputStream source, int markSize, List<NavigationFormat> formats,
+                                      ParserContext context) throws IOException {
         NotClosingUnderlyingInputStream buffer = new NotClosingUnderlyingInputStream(new BufferedInputStream(source, CHUNK_BUFFER_SIZE));
-        // make sure not to read a byte after the limit
-        buffer.mark(readBufferSize + CHUNK_BUFFER_SIZE * 2);
+        buffer.mark(markSize + CHUNK_BUFFER_SIZE * 2);
         try {
-            ParserContext<BaseRoute> context = new InternalParserContext<>(file, startDate);
             internalRead(buffer, formats, context);
-            return createResult(context);
         } finally {
             buffer.closeUnderlyingInputStream();
         }

--- a/navigation-formats/src/main/java/slash/navigation/columbus/ColumbusGpsBinaryFormat.java
+++ b/navigation-formats/src/main/java/slash/navigation/columbus/ColumbusGpsBinaryFormat.java
@@ -157,7 +157,7 @@ public class ColumbusGpsBinaryFormat extends SimpleFormat<Wgs84Route> {
         return ((aByte >> position) & 1) == 1;
     }
 
-    private WaypointType parseTag(byte aByte) {
+    WaypointType parseTag(byte aByte) {
         if (!hasBitSet(aByte, 0) && !hasBitSet(aByte, 1))
             return Waypoint;
         else if (hasBitSet(aByte, 0) && !hasBitSet(aByte, 1))
@@ -172,7 +172,7 @@ public class ColumbusGpsBinaryFormat extends SimpleFormat<Wgs84Route> {
     private static final long MINUTE_MASK = parseLong("00000000000000000000111111000000", 2);
     private static final long SECOND_MASK = parseLong("00000000000000000000000000111111", 2);
 
-    private CompactCalendar parseTime(int time) {
+    CompactCalendar parseTime(int time) {
         int year = (int) ((time & YEAR_MASK) >> 26);
         int month = (int) ((time & MONTH_MASK) >> 22);
         int day = (int) ((time & DAY_MASK) >> 17);

--- a/navigation-formats/src/main/java/slash/navigation/columbus/ColumbusGpsFormat.java
+++ b/navigation-formats/src/main/java/slash/navigation/columbus/ColumbusGpsFormat.java
@@ -23,13 +23,15 @@ import slash.common.type.CompactCalendar;
 import slash.navigation.base.*;
 import slash.navigation.common.NavigationPosition;
 
+import java.io.File;
 import java.io.PrintWriter;
 import java.util.List;
 import java.util.logging.Logger;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
-import static slash.common.io.Transfer.trim;
+import static java.lang.Math.abs;
+import static slash.common.io.Transfer.*;
 import static slash.common.type.CompactCalendar.createDateFormat;
 import static slash.common.type.CompactCalendar.parseDate;
 import static slash.navigation.base.RouteCharacteristics.Track;
@@ -158,5 +160,83 @@ public abstract class ColumbusGpsFormat extends SimpleLineBasedFormat<SimpleRout
 
     protected String formatTag(Wgs84Position position) {
         return extractWaypointType(position).value();
+    }
+
+    // --- shared LINE_PATTERN building blocks ---
+
+    /**
+     * A comma-terminated capturing field surrounded by optional whitespace/NUL padding.
+     */
+    protected static String field(String regex) {
+        return SPACE_OR_ZERO + "(" + regex + ")" + SPACE_OR_ZERO + SEPARATOR;
+    }
+
+    /**
+     * A capturing field without a trailing separator (the last field of a line).
+     */
+    protected static String lastField(String regex) {
+        return SPACE_OR_ZERO + "(" + regex + ")" + SPACE_OR_ZERO;
+    }
+
+    /**
+     * A coordinate field: a decimal number followed by its hemisphere letter, each captured.
+     */
+    protected static String coordinate(String hemisphere) {
+        return SPACE_OR_ZERO + "([\\d\\.]+)(" + hemisphere + ")" + SPACE_OR_ZERO + SEPARATOR;
+    }
+
+    // --- shared read/write of the fields common to all Columbus line formats ---
+
+    /**
+     * Parses the fields common to every Columbus line format (index, tag, date/time,
+     * latitude/longitude with hemisphere sign, height, speed, heading, description) and
+     * builds the position; format-specific fields (dop/pressure/temperature) are set by callers.
+     *
+     * @param descriptionGroup the matcher group holding the description/voice column
+     * @param isTypeA          whether the line has the extended (Type-A) columns, enabling a voice file
+     */
+    protected Wgs84Position parseCommonPosition(Matcher matcher, ParserContext context, CompactCalendar dateAndTime,
+                                                int descriptionGroup, boolean isTypeA) {
+        WaypointType waypointType = parseTag(trim(matcher.group(2)));
+        Double latitude = parseDouble(matcher.group(5));
+        if ("S".equals(matcher.group(6)) && latitude != null)
+            latitude = -latitude;
+        Double longitude = parseDouble(matcher.group(7));
+        if ("W".equals(matcher.group(8)) && longitude != null)
+            longitude = -longitude;
+        String description = parseDescription(removeZeros(matcher.group(descriptionGroup)), removeZeros(matcher.group(1)), waypointType);
+
+        Wgs84Position position = new Wgs84Position(longitude, latitude, parseDouble(matcher.group(9)), parseDouble(matcher.group(10)),
+                dateAndTime, description,
+                context.getFile() != null && isTypeA ? new File(context.getFile().getParentFile(), description) : null);
+        position.setWaypointType(waypointType);
+        position.setHeading(parseDouble(matcher.group(11)));
+        return position;
+    }
+
+    protected String latitudeHemisphere(Wgs84Position position) {
+        return position.getLatitude() != null && position.getLatitude() < 0.0 ? "S" : "N";
+    }
+
+    protected String longitudeHemisphere(Wgs84Position position) {
+        return position.getLongitude() != null && position.getLongitude() < 0.0 ? "W" : "E";
+    }
+
+    /**
+     * Formats the leading columns shared by all Columbus line formats up to and
+     * including height: index, tag, date, time, latitude+hemisphere, longitude+hemisphere, height.
+     */
+    protected String formatCommonPrefix(Wgs84Position position, int index) {
+        String date = fillWithZeros(formatDate(position.getTime()), 6);
+        String time = fillWithZeros(formatTime(position.getTime()), 6);
+        String latitude = formatDoubleAsString(abs(position.getLatitude()), 6);
+        String longitude = formatDoubleAsString(abs(position.getLongitude()), 6);
+        String height = fillWithZeros(position.getElevation() != null ? formatIntAsString(position.getElevation().intValue()) : "0", 5);
+        return fillWithZeros(Integer.toString(index + 1), 6) + SEPARATOR +
+                formatTag(position) + SEPARATOR +
+                date + SEPARATOR + time + SEPARATOR +
+                latitude + latitudeHemisphere(position) + SEPARATOR +
+                longitude + longitudeHemisphere(position) + SEPARATOR +
+                height;
     }
  }

--- a/navigation-formats/src/main/java/slash/navigation/columbus/ColumbusGpsType1Format.java
+++ b/navigation-formats/src/main/java/slash/navigation/columbus/ColumbusGpsType1Format.java
@@ -21,10 +21,8 @@
 package slash.navigation.columbus;
 
 import slash.navigation.base.ParserContext;
-import slash.navigation.base.WaypointType;
 import slash.navigation.base.Wgs84Position;
 
-import java.io.File;
 import java.io.PrintWriter;
 import java.util.HashSet;
 import java.util.Set;
@@ -32,7 +30,6 @@ import java.util.prefs.Preferences;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
-import static java.lang.Math.abs;
 import static java.util.Arrays.asList;
 import static slash.common.io.Transfer.*;
 import static slash.navigation.base.RouteComments.isDefaultDescription;
@@ -61,23 +58,23 @@ public class ColumbusGpsType1Format extends ColumbusGpsFormat {
             compile("INDEX,TAG,DATE,TIME,LATITUDE N/S,LONGITUDE E/W,(HEIGHT|ALTITUDE),SPEED,HEADING,(FIX MODE,VALID,PDOP,HDOP,VDOP,)?VOX");
     private static final Pattern LINE_PATTERN = Pattern.
             compile(BEGIN_OF_LINE +
-                    SPACE_OR_ZERO + "(\\d+)" + SPACE_OR_ZERO + SEPARATOR +
-                    SPACE_OR_ZERO + "([" + VALID_TAG_VALUES + "])" + SPACE_OR_ZERO + SEPARATOR +
-                    SPACE_OR_ZERO + "(\\d*)" + SPACE_OR_ZERO + SEPARATOR +
-                    SPACE_OR_ZERO + "(\\d*)" + SPACE_OR_ZERO + SEPARATOR +
-                    SPACE_OR_ZERO + "([\\d\\.]+)([NS])" + SPACE_OR_ZERO + SEPARATOR +
-                    SPACE_OR_ZERO + "([\\d\\.]+)([WE])" + SPACE_OR_ZERO + SEPARATOR +
-                    SPACE_OR_ZERO + "([-\\d]+)" + SPACE_OR_ZERO + SEPARATOR +
-                    SPACE_OR_ZERO + "(\\d+)" + SPACE_OR_ZERO + SEPARATOR +
-                    SPACE_OR_ZERO + "(\\d+)" + SPACE_OR_ZERO + SEPARATOR +
-                    "(" +
-                    SPACE_OR_ZERO + "([^" + SEPARATOR + "]*)" + SPACE_OR_ZERO + SEPARATOR +
-                    SPACE_OR_ZERO + "([^" + SEPARATOR + "]*)" + SPACE_OR_ZERO + SEPARATOR +
-                    SPACE_OR_ZERO + "([\\d\\.]*)" + SPACE_OR_ZERO + SEPARATOR +
-                    SPACE_OR_ZERO + "([\\d\\.]*)" + SPACE_OR_ZERO + SEPARATOR +
-                    SPACE_OR_ZERO + "([\\d\\.]*)" + SPACE_OR_ZERO + SEPARATOR +
+                    field("\\d+") +                         // 1 index
+                    field("[" + VALID_TAG_VALUES + "]") +   // 2 tag
+                    field("\\d*") +                         // 3 date
+                    field("\\d*") +                         // 4 time
+                    coordinate("[NS]") +                    // 5 latitude, 6 hemisphere
+                    coordinate("[WE]") +                    // 7 longitude, 8 hemisphere
+                    field("[-\\d]+") +                      // 9 height
+                    field("\\d+") +                         // 10 speed
+                    field("\\d+") +                         // 11 heading
+                    "(" +                                   // 12 optional Type-A block
+                    field("[^" + SEPARATOR + "]*") +        // 13 fix mode
+                    field("[^" + SEPARATOR + "]*") +        // 14 valid
+                    field("[\\d\\.]*") +                    // 15 pdop
+                    field("[\\d\\.]*") +                    // 16 hdop
+                    field("[\\d\\.]*") +                    // 17 vdop
                     ")?" +
-                    SPACE_OR_ZERO + "([^" + SEPARATOR + "]*)" + SPACE_OR_ZERO +
+                    lastField("[^" + SEPARATOR + "]*") +    // 18 vox
                     END_OF_LINE);
     private static final Set<String> VALID_FIX_MODES = new HashSet<>(asList("2D", "3D"));
     private static final Set<String> VALID_VALID = new HashSet<>(asList("SPS", "DGPS"));
@@ -116,45 +113,16 @@ public class ColumbusGpsType1Format extends ColumbusGpsFormat {
         Matcher lineMatcher = LINE_PATTERN.matcher(line);
         if (!lineMatcher.matches())
             throw new IllegalArgumentException("'" + line + "' does not match");
-        WaypointType waypointType = parseTag(trim(lineMatcher.group(2)));
-        String date = lineMatcher.group(3);
-        String time = lineMatcher.group(4);
-        Double latitude = parseDouble(lineMatcher.group(5));
-        String northOrSouth = lineMatcher.group(6);
-        if ("S".equals(northOrSouth) && latitude != null)
-            latitude = -latitude;
-        Double longitude = parseDouble(lineMatcher.group(7));
-        String westOrEasth = lineMatcher.group(8);
-        if ("W".equals(westOrEasth) && longitude != null)
-            longitude = -longitude;
-        String height = lineMatcher.group(9);
-        String speed = lineMatcher.group(10);
-        String heading = lineMatcher.group(11);
         boolean isTypeA = trim(lineMatcher.group(14)) != null;
-        String pdop = lineMatcher.group(15);
-        String hdop = lineMatcher.group(16);
-        String vdop = lineMatcher.group(17);
-        String description = parseDescription(removeZeros(lineMatcher.group(18)), removeZeros(lineMatcher.group(1)), waypointType);
-
-        Wgs84Position position = new Wgs84Position(longitude, latitude, parseDouble(height), parseDouble(speed),
-                parseDateAndTime(date, time), description,
-                context.getFile() != null && isTypeA ? new File(context.getFile().getParentFile(), description) : null);
-        position.setWaypointType(waypointType);
-        position.setHeading(parseDouble(heading));
-        position.setPdop(parseDouble(pdop));
-        position.setHdop(parseDouble(hdop));
-        position.setVdop(parseDouble(vdop));
+        Wgs84Position position = parseCommonPosition(lineMatcher, context,
+                parseDateAndTime(lineMatcher.group(3), lineMatcher.group(4)), 18, isTypeA);
+        position.setPdop(parseDouble(lineMatcher.group(15)));
+        position.setHdop(parseDouble(lineMatcher.group(16)));
+        position.setVdop(parseDouble(lineMatcher.group(17)));
         return position;
     }
 
     protected void writePosition(Wgs84Position position, PrintWriter writer, int index, boolean firstPosition) {
-        String date = fillWithZeros(formatDate(position.getTime()), 6);
-        String time = fillWithZeros(formatTime(position.getTime()), 6);
-        String latitude = formatDoubleAsString(abs(position.getLatitude()), 6);
-        String northOrSouth = position.getLatitude() != null && position.getLatitude() < 0.0 ? "S" : "N";
-        String longitude = formatDoubleAsString(abs(position.getLongitude()), 6);
-        String westOrEast = position.getLongitude() != null && position.getLongitude() < 0.0 ? "W" : "E";
-        String height = fillWithZeros(position.getElevation() != null ? formatIntAsString(position.getElevation().intValue()) : "0", 5);
         String speed = fillWithZeros(position.getSpeed() != null ? formatIntAsString(position.getSpeed().intValue()) : "0", 4);
         String heading = fillWithZeros(position.getHeading() != null ? formatIntAsString(position.getHeading().intValue()) : "0", 3);
         String pdop = fillWithZeros(position.getPdop() != null ? formatAccuracyAsString(position.getPdop()) : "", 5);
@@ -162,12 +130,7 @@ public class ColumbusGpsType1Format extends ColumbusGpsFormat {
         String vdop = fillWithZeros(position.getVdop() != null ? formatAccuracyAsString(position.getVdop()) : "", 5);
         String description = !isDefaultDescription(position.getDescription()) ? position.getDescription() : "";
 
-        writer.println(fillWithZeros(Integer.toString(index + 1), 6) + SEPARATOR +
-                formatTag(position) + SEPARATOR +
-                date + SEPARATOR + time + SEPARATOR +
-                latitude + northOrSouth + SEPARATOR +
-                longitude + westOrEast + SEPARATOR +
-                height + SEPARATOR +
+        writer.println(formatCommonPrefix(position, index) + SEPARATOR +
                 speed + SEPARATOR +
                 heading + SEPARATOR +
                 "3D" + SEPARATOR +

--- a/navigation-formats/src/main/java/slash/navigation/columbus/ColumbusGpsType2Format.java
+++ b/navigation-formats/src/main/java/slash/navigation/columbus/ColumbusGpsType2Format.java
@@ -22,16 +22,13 @@ package slash.navigation.columbus;
 
 import slash.common.type.CompactCalendar;
 import slash.navigation.base.ParserContext;
-import slash.navigation.base.WaypointType;
 import slash.navigation.base.Wgs84Position;
 
-import java.io.File;
 import java.io.PrintWriter;
 import java.util.TimeZone;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
-import static java.lang.Math.abs;
 import static slash.common.io.Transfer.*;
 import static slash.navigation.base.RouteComments.isDefaultDescription;
 import static slash.navigation.columbus.ColumbusV1000Device.getTimeZone;
@@ -60,19 +57,19 @@ public class ColumbusGpsType2Format extends ColumbusGpsFormat {
     private static final Pattern HEADER_PATTERN = Pattern.compile(COMMON_HEADER + "(" + TYPE_A_HEADER + ")?");
     private static final Pattern LINE_PATTERN = Pattern.
             compile(BEGIN_OF_LINE +
-                    SPACE_OR_ZERO + "(\\d+)" + SPACE_OR_ZERO + SEPARATOR +
-                    SPACE_OR_ZERO + "([" + VALID_TAG_VALUES + "])" + SPACE_OR_ZERO + SEPARATOR +
-                    SPACE_OR_ZERO + "(\\d*)" + SPACE_OR_ZERO + SEPARATOR +
-                    SPACE_OR_ZERO + "(\\d*)" + SPACE_OR_ZERO + SEPARATOR +
-                    SPACE_OR_ZERO + "([\\d\\.]+)([NS])" + SPACE_OR_ZERO + SEPARATOR +
-                    SPACE_OR_ZERO + "([\\d\\.]+)([WE])" + SPACE_OR_ZERO + SEPARATOR +
-                    SPACE_OR_ZERO + "([-\\d]+)" + SPACE_OR_ZERO + SEPARATOR +
-                    SPACE_OR_ZERO + "([\\d\\.]+)" + SPACE_OR_ZERO + SEPARATOR +
-                    SPACE_OR_ZERO + "(\\d*)" + SPACE_OR_ZERO +
-                    "(" + SEPARATOR +
-                    SPACE_OR_ZERO + "([\\d\\.]+)" + SPACE_OR_ZERO + SEPARATOR +
-                    SPACE_OR_ZERO + "([-\\d]+)" + SPACE_OR_ZERO + SEPARATOR + "?" +
-                    SPACE_OR_ZERO + "([^" + SEPARATOR + "]*)" + SPACE_OR_ZERO +
+                    field("\\d+") +                         // 1 index
+                    field("[" + VALID_TAG_VALUES + "]") +   // 2 tag
+                    field("\\d*") +                         // 3 date
+                    field("\\d*") +                         // 4 time
+                    coordinate("[NS]") +                    // 5 latitude, 6 hemisphere
+                    coordinate("[WE]") +                    // 7 longitude, 8 hemisphere
+                    field("[-\\d]+") +                      // 9 height
+                    field("[\\d\\.]+") +                    // 10 speed
+                    lastField("\\d*") +                     // 11 heading
+                    "(" + SEPARATOR +                       // 12 optional Type-A block
+                    field("[\\d\\.]+") +                    // 13 pressure
+                    field("[-\\d]+") + "?" +                // 14 temperature (trailing separator optional)
+                    lastField("[^" + SEPARATOR + "]*") +    // 15 description
                     ")?" +
                     END_OF_LINE);
 
@@ -101,58 +98,24 @@ public class ColumbusGpsType2Format extends ColumbusGpsFormat {
         Matcher lineMatcher = LINE_PATTERN.matcher(line);
         if (!lineMatcher.matches())
             throw new IllegalArgumentException("'" + line + "' does not match");
-        WaypointType waypointType = parseTag(trim(lineMatcher.group(2)));
-        String date = lineMatcher.group(3);
-        String time = lineMatcher.group(4);
-        Double latitude = parseDouble(lineMatcher.group(5));
-        String northOrSouth = lineMatcher.group(6);
-        if ("S".equals(northOrSouth) && latitude != null)
-            latitude = -latitude;
-        Double longitude = parseDouble(lineMatcher.group(7));
-        String westOrEasth = lineMatcher.group(8);
-        if ("W".equals(westOrEasth) && longitude != null)
-            longitude = -longitude;
-        String height = lineMatcher.group(9);
-        String speed = lineMatcher.group(10);
-        String heading = lineMatcher.group(11);
         boolean isTypeA = trim(lineMatcher.group(12)) != null;
-        String pressure = lineMatcher.group(13);
-        String temperature = lineMatcher.group(14);
-        String description = parseDescription(removeZeros(lineMatcher.group(15)), removeZeros(lineMatcher.group(1)), waypointType);
-
-        CompactCalendar dateAndTime = parseDateAndTime(date, time);
-        if(getUseLocalTimeZone())
+        CompactCalendar dateAndTime = parseDateAndTime(lineMatcher.group(3), lineMatcher.group(4));
+        if (getUseLocalTimeZone())
             dateAndTime = dateAndTime.asUTCTimeInTimeZone(TimeZone.getTimeZone(getTimeZone()));
-        Wgs84Position position = new Wgs84Position(longitude, latitude, parseDouble(height), parseDouble(speed),
-                dateAndTime, description,
-                context.getFile() != null && isTypeA ? new File(context.getFile().getParentFile(), description) : null);
-        position.setWaypointType(waypointType);
-        position.setHeading(parseDouble(heading));
-        position.setPressure(parseDouble(pressure));
-        position.setTemperature(parseDouble(temperature));
+        Wgs84Position position = parseCommonPosition(lineMatcher, context, dateAndTime, 15, isTypeA);
+        position.setPressure(parseDouble(lineMatcher.group(13)));
+        position.setTemperature(parseDouble(lineMatcher.group(14)));
         return position;
     }
 
     protected void writePosition(Wgs84Position position, PrintWriter writer, int index, boolean firstPosition) {
-        String date = fillWithZeros(formatDate(position.getTime()), 6);
-        String time = fillWithZeros(formatTime(position.getTime()), 6);
-        String latitude = formatDoubleAsString(abs(position.getLatitude()), 6);
-        String northOrSouth = position.getLatitude() != null && position.getLatitude() < 0.0 ? "S" : "N";
-        String longitude = formatDoubleAsString(abs(position.getLongitude()), 6);
-        String westOrEast = position.getLongitude() != null && position.getLongitude() < 0.0 ? "W" : "E";
-        String height = fillWithZeros(position.getElevation() != null ? formatIntAsString(position.getElevation().intValue()) : "0", 5);
         String speed = position.getSpeed() != null ? formatDoubleAsString(position.getSpeed()) : "0";
         String heading = fillWithZeros(position.getHeading() != null ? formatIntAsString(position.getHeading().intValue()) : "0", 3);
         String pressure = position.getPressure() != null ? formatDoubleAsString(position.getPressure()) : "0";
         String temperature = fillWithZeros(position.getTemperature() != null ? formatIntAsString(position.getTemperature().intValue()) : "0", 2);
         String description = !isDefaultDescription(position.getDescription()) ? position.getDescription() : "";
 
-        writer.println(fillWithZeros(Integer.toString(index + 1), 6) + SEPARATOR +
-                formatTag(position) + SEPARATOR +
-                date + SEPARATOR + time + SEPARATOR +
-                latitude + northOrSouth + SEPARATOR +
-                longitude + westOrEast + SEPARATOR +
-                height + SEPARATOR +
+        writer.println(formatCommonPrefix(position, index) + SEPARATOR +
                 speed + SEPARATOR +
                 heading + SEPARATOR +
                 pressure + SEPARATOR +

--- a/navigation-formats/src/test/java/slash/navigation/columbus/ColumbusGpsBinaryFormatTest.java
+++ b/navigation-formats/src/test/java/slash/navigation/columbus/ColumbusGpsBinaryFormatTest.java
@@ -1,16 +1,34 @@
 package slash.navigation.columbus;
 
+import org.junit.After;
+import org.junit.Before;
 import org.junit.Test;
 
 import java.nio.ByteBuffer;
 
 import static jakarta.xml.bind.DatatypeConverter.parseHexBinary;
+import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 import static slash.common.TestCase.assertDoubleEquals;
+import static slash.common.TestCase.calendar;
+import static slash.navigation.base.WaypointType.PointOfInterestC;
+import static slash.navigation.base.WaypointType.Waypoint;
 
 public class ColumbusGpsBinaryFormatTest {
     private final ColumbusGpsBinaryFormat format = new ColumbusGpsBinaryFormat();
+    private boolean useLocalTimeZone;
+
+    @Before
+    public void setUp() {
+        useLocalTimeZone = ColumbusV1000Device.getUseLocalTimeZone();
+        ColumbusV1000Device.setUseLocalTimeZone(false);
+    }
+
+    @After
+    public void tearDown() {
+        ColumbusV1000Device.setUseLocalTimeZone(useLocalTimeZone);
+    }
 
     @Test
     public void testHasBitSet() {
@@ -25,5 +43,20 @@ public class ColumbusGpsBinaryFormatTest {
         assertDoubleEquals(10.0, format.parseCoordinate(buffer1.getInt(), false));
         ByteBuffer buffer2 = ByteBuffer.wrap(parseHexBinary("00989680"));
         assertDoubleEquals(-10.0, format.parseCoordinate(buffer2.getInt(), true));
+    }
+
+    @Test
+    public void testParseTag() {
+        assertEquals(Waypoint, format.parseTag((byte) 0x00));         // neither bit 0 nor bit 1
+        assertEquals(PointOfInterestC, format.parseTag((byte) 0x01)); // bit 0 set, bit 1 clear
+        assertEquals(Waypoint, format.parseTag((byte) 0x02));         // bit 1 set
+        assertEquals(Waypoint, format.parseTag((byte) 0x03));         // bit 0 and bit 1 set
+    }
+
+    @Test
+    public void testParseTime() {
+        // packed fields: year=2 (2016+2), month=11 (stored, => November), day=29, hour=12, minute=0, second=2
+        int packed = (2 << 26) | (11 << 22) | (29 << 17) | (12 << 12) | (0 << 6) | 2;
+        assertEquals(calendar(2018, 11, 29, 12, 0, 2), format.parseTime(packed));
     }
 }

--- a/navigation-formats/src/test/java/slash/navigation/columbus/ColumbusV1000DeviceTest.java
+++ b/navigation-formats/src/test/java/slash/navigation/columbus/ColumbusV1000DeviceTest.java
@@ -1,0 +1,40 @@
+package slash.navigation.columbus;
+
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+public class ColumbusV1000DeviceTest {
+    private boolean useLocalTimeZone;
+    private String timeZone;
+
+    @Before
+    public void setUp() {
+        useLocalTimeZone = ColumbusV1000Device.getUseLocalTimeZone();
+        timeZone = ColumbusV1000Device.getTimeZone();
+    }
+
+    @After
+    public void tearDown() {
+        ColumbusV1000Device.setUseLocalTimeZone(useLocalTimeZone);
+        ColumbusV1000Device.setTimeZone(timeZone);
+    }
+
+    @Test
+    public void testUseLocalTimeZoneRoundtrip() {
+        ColumbusV1000Device.setUseLocalTimeZone(false);
+        assertFalse(ColumbusV1000Device.getUseLocalTimeZone());
+        ColumbusV1000Device.setUseLocalTimeZone(true);
+        assertTrue(ColumbusV1000Device.getUseLocalTimeZone());
+    }
+
+    @Test
+    public void testTimeZoneRoundtrip() {
+        ColumbusV1000Device.setTimeZone("Europe/Berlin");
+        assertEquals("Europe/Berlin", ColumbusV1000Device.getTimeZone());
+    }
+}

--- a/navigation-formats/src/test/java/slash/navigation/columbus/GarbleColumbusGpsType1FormatTest.java
+++ b/navigation-formats/src/test/java/slash/navigation/columbus/GarbleColumbusGpsType1FormatTest.java
@@ -1,0 +1,31 @@
+package slash.navigation.columbus;
+
+import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+public class GarbleColumbusGpsType1FormatTest {
+    private final GarbleColumbusGpsType1Format format = new GarbleColumbusGpsType1Format();
+
+    @Test
+    public void testName() {
+        assertEquals("Columbus GPS Type 1 Garble (*.csv)", format.getName());
+    }
+
+    @Test
+    public void testDoesNotSupportWriting() {
+        assertFalse(format.isSupportsWriting());
+    }
+
+    @Test
+    public void testToleratesMuchGarble() {
+        assertEquals(1000, format.getGarbleCount());
+    }
+
+    @Test
+    public void testInheritsType1LineParsing() {
+        assertTrue(format.isPosition("2971  ,V,090508,084815,48.132451N,016.321871E,319  ,12  ,207,3D,SPS ,1.6  ,1.3  ,0.9  ,VOX02971"));
+    }
+}

--- a/route-catalog/src/main/java/slash/navigation/routes/local/DirectoryFileFilter.java
+++ b/route-catalog/src/main/java/slash/navigation/routes/local/DirectoryFileFilter.java
@@ -21,12 +21,11 @@
 package slash.navigation.routes.local;
 
 import slash.common.io.MacAlias;
+import slash.common.io.WindowsShortcut;
 
 import java.io.File;
 import java.io.FileFilter;
 import java.io.IOException;
-
-import static slash.common.io.Files.getExtension;
 
 /**
  * A file filter that accepts only directories not starting with a dot plus the
@@ -37,7 +36,15 @@ import static slash.common.io.Files.getExtension;
 public class DirectoryFileFilter implements FileFilter {
     public boolean accept(File file) {
         return file.isDirectory() && !file.getName().startsWith(".") ||
-                file.isFile() && (getExtension(file).equals(".lnk") || isAlias(file));
+                file.isFile() && (isLink(file) || isAlias(file));
+    }
+
+    private static boolean isLink(File file) {
+        try {
+            return WindowsShortcut.isPotentialValidLink(file);
+        } catch (IOException e) {
+            return false;
+        }
     }
 
     private static boolean isAlias(File file) {

--- a/route-catalog/src/main/java/slash/navigation/routes/local/LocalCategory.java
+++ b/route-catalog/src/main/java/slash/navigation/routes/local/LocalCategory.java
@@ -20,8 +20,7 @@
 
 package slash.navigation.routes.local;
 
-import slash.common.io.MacAlias;
-import slash.common.io.WindowsShortcut;
+import slash.common.io.ResolvableLink;
 import slash.navigation.rest.exception.DuplicateNameException;
 import slash.navigation.rest.exception.ForbiddenException;
 import slash.navigation.routes.Category;
@@ -41,12 +40,10 @@ import static java.lang.String.format;
 import static java.nio.charset.StandardCharsets.UTF_8;
 import static org.apache.commons.io.IOUtils.copyLarge;
 import static slash.common.io.Files.recursiveDelete;
-import static slash.common.io.Files.removeExtension;
 import static slash.common.io.InputOutput.DEFAULT_BUFFER_SIZE;
 import static slash.common.io.Transfer.UTF8_ENCODING;
 import static slash.common.io.Transfer.encodeFileName;
-import static slash.common.io.MacAlias.isPotentialValidAlias;
-import static slash.common.io.WindowsShortcut.isPotentialValidLink;
+import static slash.common.io.Files.resolveLink;
 
 /**
  * Represents a category in the file system.
@@ -80,18 +77,11 @@ public class LocalCategory implements Category {
         File[] directories = directory.listFiles(new DirectoryFileFilter());
         if(directories != null) {
             for (File subDirectory : directories) {
-                if (isPotentialValidLink(subDirectory)) {
-                    WindowsShortcut shortcut = new WindowsShortcut(subDirectory);
-                    if (shortcut.isDirectory()) {
-                        subDirectory = new File(removeExtension(shortcut.getRealFilename()));
-                    } else
+                ResolvableLink link = resolveLink(subDirectory);
+                if (link != null) {
+                    if (!link.isDirectory())
                         continue;
-                } else if (isPotentialValidAlias(subDirectory)) {
-                    MacAlias alias = new MacAlias(subDirectory);
-                    if (alias.isDirectory())
-                        subDirectory = new File(alias.getRealFilename());
-                    else
-                        continue;
+                    subDirectory = new File(link.getRealFilename());
                 }
                 categories.add(new LocalCategory(catalog, subDirectory));
             }
@@ -135,18 +125,11 @@ public class LocalCategory implements Category {
         File[] files = directory.listFiles(new RouteFileFilter());
         if(files != null) {
             for (File file : files) {
-                if (isPotentialValidLink(file)) {
-                    WindowsShortcut shortcut = new WindowsShortcut(file);
-                    if (shortcut.isFile())
-                        file = new File(shortcut.getRealFilename());
-                    else
+                ResolvableLink link = resolveLink(file);
+                if (link != null) {
+                    if (!link.isFile())
                         continue;
-                } else if (isPotentialValidAlias(file)) {
-                    MacAlias alias = new MacAlias(file);
-                    if (alias.isFile())
-                        file = new File(alias.getRealFilename());
-                    else
-                        continue;
+                    file = new File(link.getRealFilename());
                 }
                 routes.add(new LocalRoute(file));
             }

--- a/route-catalog/src/test/java/slash/navigation/routes/local/DirectoryFileFilterTest.java
+++ b/route-catalog/src/test/java/slash/navigation/routes/local/DirectoryFileFilterTest.java
@@ -56,7 +56,11 @@ public class DirectoryFileFilterTest {
         regularFile = File.createTempFile("route", ".gpx", base);
 
         lnkFile = new File(base, "shortcut.lnk");
-        assertTrue(lnkFile.createNewFile());
+        // a .lnk is accepted only when it carries the shortcut magic (little-endian
+        // DWORD 0x0000004C at offset 0) and is at least 0x64 bytes long
+        byte[] header = new byte[0x64];
+        header[0] = 0x4C;
+        java.nio.file.Files.write(lnkFile.toPath(), header);
     }
 
     @After
@@ -95,6 +99,13 @@ public class DirectoryFileFilterTest {
     @Test
     public void acceptsLnkFile() {
         assertTrue(filter.accept(lnkFile));
+    }
+
+    @Test
+    public void rejectsLnkFileWithoutMagic() throws IOException {
+        File emptyLnk = new File(tempDir, "empty.lnk");
+        assertTrue(emptyLnk.createNewFile());
+        assertFalse(filter.accept(emptyLnk));
     }
 
     @Test

--- a/route-catalog/src/test/java/slash/navigation/routes/local/RouteFileFilterTest.java
+++ b/route-catalog/src/test/java/slash/navigation/routes/local/RouteFileFilterTest.java
@@ -1,0 +1,87 @@
+/*
+    This file is part of RouteConverter.
+
+    RouteConverter is free software; you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation; either version 2 of the License, or
+    (at your option) any later version.
+
+    RouteConverter is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with RouteConverter; if not, write to the Free Software
+    Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
+
+    Copyright (C) 2007 Christian Pesch. All Rights Reserved.
+*/
+
+package slash.navigation.routes.local;
+
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+
+import java.io.File;
+import java.io.IOException;
+
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+/**
+ * Unit tests for {@link RouteFileFilter}, which lists local routes while hiding
+ * dot-prefixed system files such as {@code .DS_Store}.
+ *
+ * @author Christian Pesch
+ */
+public class RouteFileFilterTest {
+    private final RouteFileFilter filter = new RouteFileFilter();
+    private File tempDir;
+
+    @Before
+    public void setUp() {
+        tempDir = new File(System.getProperty("java.io.tmpdir"), "rff-test-" + System.currentTimeMillis());
+        assertTrue(tempDir.mkdir());
+    }
+
+    @After
+    public void tearDown() {
+        File[] children = tempDir.listFiles();
+        if (children != null)
+            for (File child : children)
+                //noinspection ResultOfMethodCallIgnored
+                child.delete();
+        //noinspection ResultOfMethodCallIgnored
+        tempDir.delete();
+    }
+
+    private File file(String name) throws IOException {
+        File file = new File(tempDir, name);
+        assertTrue(file.createNewFile());
+        return file;
+    }
+
+    @Test
+    public void acceptsRegularFile() throws IOException {
+        assertTrue(filter.accept(file("route.gpx")));
+    }
+
+    @Test
+    public void acceptsFileWithoutExtension() throws IOException {
+        assertTrue(filter.accept(file("route")));
+    }
+
+    @Test
+    public void rejectsDotFile() throws IOException {
+        assertFalse(filter.accept(file(".DS_Store")));
+    }
+
+    @Test
+    public void rejectsDirectory() {
+        File dir = new File(tempDir, "subDirectory");
+        assertTrue(dir.mkdir());
+        assertFalse(filter.accept(dir));
+    }
+}


### PR DESCRIPTION
Ten improvements across the areas touched by the recent catalog work — deduplication, code-size reduction, a latent-bug fix, and coverage. No behaviour change (except the bug fix); verified by existing + new tests.

### Refactors / size reduction
1. **`ResolvableLink`** interface (in `common.io`) implemented by `WindowsShortcut` and `MacAlias`, plus `Files.resolveLink(File)` — collapses the duplicated `.lnk`/alias branches in `LocalCategory.getCategories()`/`getRoutes()` to one resolve step.
2. **`NavigationFormatParser.bufferedInternalRead`** — extracts the slurp/mark/try-finally plumbing duplicated across the URL read paths (the exact spot the >1 MB `mark/reset` bug lived).
3–5. **Columbus Type 1/Type 2 dedup** — shared `parseCommonPosition()`, `formatCommonPrefix()` + `latitudeHemisphere/longitudeHemisphere`, and `field()/lastField()/coordinate()` regex builders moved into `ColumbusGpsFormat`. Compiled patterns and written bytes are unchanged (Format tests + roundtrip ITs pass).

### Correctness
9. **Dropped the errant `removeExtension()`** applied to resolved *directory*-shortcut targets — `getRealFilename()` already returns the real path, so stripping would corrupt a directory name containing a dot.

### Coverage
6. `RouteFileFilterTest` (the `.DS_Store` filter had none).
7. `ColumbusGpsBinaryFormat.parseTag`/`parseTime` tests — the bitmask date decode and tag bits (package-privatized to test directly).
8. `ColumbusV1000DeviceTest` + `GarbleColumbusGpsType1FormatTest`.

### Consolidation (#10)
`DirectoryFileFilter` gates shortcuts on `isPotentialValidLink` (magic-checked) instead of a raw `.lnk` extension; `Transfer.formatTime` delegates to `formatDuration`; `MacAlias` magic via `Arrays.equals`; `Files.getExtension` drops a redundant `toLowerCase()`.

### Verification
Full unit tests for `common`, `route-catalog`, `navigation-formats` pass. Columbus Format tests (7+7), read/write roundtrip ITs (2+2), the parser suite (14), and all new tests are green. (One pre-existing, unrelated failure — `GpxExtensionsIT.testReadTrekbuddyExtension2`, a Trekbuddy sample lacking speed — fails identically on clean master.)

Net: production code shrinks (Type 1 −~50, Type 2 −~45 lines) while adding tests.