### PR TITLE
Opting out of telemetry suppresses all automatic crash dialogs (spec 00011)

### DIFF
--- a/route-converter-gui/src/main/java/slash/navigation/converter/gui/helpers/CrashReporter.java
+++ b/route-converter-gui/src/main/java/slash/navigation/converter/gui/helpers/CrashReporter.java
@@ -24,82 +24,56 @@ import slash.common.log.CrashReportSpool;
 import slash.common.log.DiagnosticReport;
 import slash.common.system.Version;
 import slash.navigation.converter.gui.RouteConverter;
-import slash.navigation.converter.gui.dialogs.SendErrorReportDialog;
 import slash.navigation.feedback.domain.CrashReportSender;
 import slash.navigation.gui.CrashHandler;
 
 import java.io.File;
 import java.io.IOException;
-import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.function.BooleanSupplier;
 import java.util.function.Supplier;
 import java.util.logging.Logger;
 
 import static java.util.logging.Level.WARNING;
-import static javax.swing.SwingUtilities.invokeLater;
 import static slash.common.system.Version.parseVersionFromManifest;
 
 /**
- * Assembles a {@link DiagnosticReport} from a captured crash, spools it to disk and
- * either offers it through the existing {@link SendErrorReportDialog} or -- when the
- * user has opted in to anonymous crash telemetry (spec 00011 Phase 2) -- sends it
- * silently to the crash-report endpoint. Registered with
- * {@link slash.navigation.gui.Application#setCrashHandler} at startup.
+ * Assembles a {@link DiagnosticReport} from a captured crash and spools it to disk.
+ * Registered with {@link slash.navigation.gui.Application#setCrashHandler} at startup.
  * <p>
- * <b>Opted-in vs manual (no double-send):</b> a spooled report is delivered through
- * exactly one path. When telemetry is opted in it is sent silently and the spool file
- * is deleted on success; the manual review dialog is <i>not</i> opened for it. When
- * telemetry is off the Phase 1 behaviour is unchanged: the newest report is offered in
- * the dialog and deleted once the user sends it. So a report is never both silently
- * sent and dialog-offered.
- * <p>
- * At most one report dialog is opened per session (a crash-loop latch): further
- * crashes are only spooled and offered on the next successful launch. Silent sending is
- * always fully asynchronous and fail-silent so telemetry never blocks, slows or crashes
- * the app.
+ * Delivery is telemetry-driven and never opens a dialog on its own:
+ * <ul>
+ * <li><b>Opted in</b> (spec 00011 Phase 2): spooled reports are sent silently in the
+ *     background and deleted on success.</li>
+ * <li><b>Opted out</b>: reports only stay spooled &mdash; nothing is sent and no dialog
+ *     is opened automatically. The user can still review and send a report manually via
+ *     Help &rarr; Send Error Report.</li>
+ * </ul>
+ * Silent sending is always fully asynchronous and fail-silent so telemetry never blocks,
+ * slows or crashes the app.
  *
  * @author Christian Pesch
  */
 
 public class CrashReporter implements CrashHandler {
     private static final Logger log = Logger.getLogger(CrashReporter.class.getName());
-    private static final AtomicBoolean dialogShown = new AtomicBoolean(false);
 
     private final CrashReportSpool spool;
     private final CrashReportSender sender;
     private final BooleanSupplier telemetryOptedIn;
     private final Supplier<String> apiUrl;
-    private final DialogOpener dialogOpener;
-
-    /**
-     * Opens the manual review dialog for a report and reports back whether the user sent
-     * it. Injected so the manual (opt-out) branching is exercised without the static
-     * {@link RouteConverter#getInstance()} Swing singleton; the public constructor wires
-     * the real {@link SendErrorReportDialog}.
-     */
-    interface DialogOpener {
-        boolean openAndConfirmSent(String json);
-    }
 
     public CrashReporter() {
         this(CrashReportSpool.createDefault(), new CrashReportSender(),
                 RouteConverter::isSendCrashReportsEnabled,
-                () -> RouteConverter.getInstance().getApiUrl(),
-                CrashReporter::showSendErrorReportDialog);
+                () -> RouteConverter.getInstance().getApiUrl());
     }
 
     CrashReporter(CrashReportSpool spool, CrashReportSender sender,
                   BooleanSupplier telemetryOptedIn, Supplier<String> apiUrl) {
-        this(spool, sender, telemetryOptedIn, apiUrl, CrashReporter::showSendErrorReportDialog);
-    }
-
-    CrashReporter(CrashReportSpool spool, CrashReportSender sender,
-                  BooleanSupplier telemetryOptedIn, Supplier<String> apiUrl, DialogOpener dialogOpener) {
         this.spool = spool;
         this.sender = sender;
         this.telemetryOptedIn = telemetryOptedIn;
         this.apiUrl = apiUrl;
-        this.dialogOpener = dialogOpener;
     }
 
     public void handleCrash(Thread thread, Throwable throwable) {
@@ -113,22 +87,16 @@ public class CrashReporter implements CrashHandler {
             log.log(WARNING, "Cannot spool crash report", e);
         }
 
-        // opted in: send silently in the background and delete on success -- no dialog.
-        if (telemetryOptedIn.getAsBoolean()) {
+        // opted in: send silently in the background, deleting each on success. opted out:
+        // the report only stays spooled -- no dialog is ever opened automatically.
+        if (telemetryOptedIn.getAsBoolean())
             flushSpooledReportsAsync();
-            return;
-        }
-
-        // not opted in: the Phase 1 manual review dialog is the only send path.
-        if (claimDialogSlot())
-            invokeLater(() -> dialogOpener.openAndConfirmSent(json));
     }
 
     /**
-     * On a successful launch, delivers unsent spooled reports (crashes before the dialog
-     * could be shown, or before login). When telemetry is opted in they are sent
-     * silently in the background; otherwise the newest is offered in the dialog and
-     * deleted once the user sends it.
+     * On a successful launch, delivers unsent spooled reports (crashes from a previous
+     * session). When telemetry is opted in they are sent silently in the background;
+     * when opted out the backlog is left spooled and silent -- no dialog is opened.
      */
     public void offerSpooledReports() {
         if (spool.newest() == null)
@@ -137,33 +105,6 @@ public class CrashReporter implements CrashHandler {
         if (telemetryOptedIn.getAsBoolean()) {
             log.info("Sending " + spool.list().size() + " spooled crash report(s) from a previous session");
             flushSpooledReportsAsync();
-            return;
-        }
-
-        log.info("Offering " + spool.list().size() + " spooled crash report(s) from a previous session");
-        if (!claimDialogSlot())
-            return;
-
-        invokeLater(this::offerSpooledReportsInDialog);
-    }
-
-    /**
-     * Offers every spooled report in the manual review dialog, deleting each only once
-     * the user actually sent it. Every report is offered, not just the newest: a report
-     * the user dismisses without sending is kept, so offering only the newest would block
-     * all older ones from ever being surfaced (they would linger until evicted by the
-     * cap). Package-visible and free of the event dispatch thread so the per-file
-     * delete-only-when-sent branching can be exercised directly.
-     */
-    void offerSpooledReportsInDialog() {
-        for (File file : spool.list()) {
-            try {
-                String json = spool.read(file);
-                if (dialogOpener.openAndConfirmSent(json))
-                    spool.delete(file);
-            } catch (IOException e) {
-                log.log(WARNING, "Cannot read spooled crash report " + file, e);
-            }
         }
     }
 
@@ -192,33 +133,5 @@ public class CrashReporter implements CrashHandler {
                 log.log(WARNING, "Cannot send spooled crash report " + file, e);
             }
         }
-    }
-
-    /**
-     * The production {@link DialogOpener}: shows the {@link SendErrorReportDialog} on the
-     * RouteConverter frame and reports whether the user sent the report. Returns false
-     * with no frame yet (a very early crash): the report is spooled and offered on the
-     * next successful launch instead.
-     */
-    private static boolean showSendErrorReportDialog(String json) {
-        RouteConverter instance = RouteConverter.getInstance();
-        if (instance == null || instance.getFrame() == null)
-            return false;
-
-        SendErrorReportDialog dialog = new SendErrorReportDialog(json);
-        dialog.showWithPreferences();
-        return dialog.isSent();
-    }
-
-    /**
-     * Returns true for the first caller in this session, false afterwards, so at most
-     * one report dialog is opened.
-     */
-    static boolean claimDialogSlot() {
-        return dialogShown.compareAndSet(false, true);
-    }
-
-    static void resetForTesting() {
-        dialogShown.set(false);
     }
 }

--- a/route-converter-gui/src/test/java/slash/navigation/converter/gui/helpers/CrashReporterTest.java
+++ b/route-converter-gui/src/test/java/slash/navigation/converter/gui/helpers/CrashReporterTest.java
@@ -20,7 +20,6 @@
 
 package slash.navigation.converter.gui.helpers;
 
-import org.junit.After;
 import org.junit.Test;
 import slash.common.log.CrashReportSpool;
 import slash.navigation.feedback.domain.CrashReportSender;
@@ -32,35 +31,8 @@ import java.util.List;
 
 import static java.nio.file.Files.createTempDirectory;
 import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
 
 public class CrashReporterTest {
-
-    @After
-    public void tearDown() {
-        CrashReporter.resetForTesting();
-    }
-
-    @Test
-    public void testOnlyOneDialogPerSession() {
-        CrashReporter.resetForTesting();
-
-        // the first captured crash claims the single dialog slot
-        assertTrue(CrashReporter.claimDialogSlot());
-        // further crashes in the same session only spool -- no second dialog
-        assertFalse(CrashReporter.claimDialogSlot());
-        assertFalse(CrashReporter.claimDialogSlot());
-    }
-
-    @Test
-    public void testResetReopensSlot() {
-        CrashReporter.resetForTesting();
-        assertTrue(CrashReporter.claimDialogSlot());
-
-        CrashReporter.resetForTesting();
-        assertTrue(CrashReporter.claimDialogSlot());
-    }
 
     private static class RecordingSender extends CrashReportSender {
         final List<String> sent = new ArrayList<>();
@@ -97,6 +69,19 @@ public class CrashReporterTest {
     }
 
     @Test
+    public void testOptOutOfferSpooledReportsDoesNothing() throws IOException {
+        CrashReportSpool spool = spoolWithReports(3);
+        RecordingSender sender = new RecordingSender(true);
+        CrashReporter reporter = new CrashReporter(spool, sender, () -> false, () -> "http://localhost/");
+
+        // opted out: the backlog is neither sent nor offered in a dialog -- it just stays spooled
+        reporter.offerSpooledReports();
+
+        assertEquals("opted out sends nothing", 0, sender.sent.size());
+        assertEquals("opted out keeps the whole backlog spooled", 3, spool.list().size());
+    }
+
+    @Test
     public void testOptedInSendsAndDeletesOnSuccess() throws IOException {
         CrashReportSpool spool = spoolWithReports(2);
         RecordingSender sender = new RecordingSender(true);
@@ -118,38 +103,5 @@ public class CrashReporterTest {
 
         assertEquals(2, sender.sent.size());
         assertEquals("a failed send must leave the report for the next launch", 2, spool.list().size());
-    }
-
-    @Test
-    public void testManualDialogDeletesOnlyReportsTheUserSent() throws IOException {
-        CrashReportSpool spool = spoolWithReports(3);
-        RecordingSender sender = new RecordingSender(true);
-        // the injected opener stands in for the Swing dialog: the user "sends" only the
-        // n:1 report and dismisses the rest
-        CrashReporter.DialogOpener opener = json -> json.contains("\"n\":1");
-        CrashReporter reporter = new CrashReporter(spool, sender, () -> false, () -> "http://localhost/", opener);
-
-        reporter.offerSpooledReportsInDialog();
-
-        assertEquals("only the sent report is deleted; dismissed ones are kept", 2, spool.list().size());
-        assertEquals("the manual path never uses the silent sender", 0, sender.sent.size());
-    }
-
-    @Test
-    public void testManualDialogOffersEveryReportAndDismissedKeepsAll() throws IOException {
-        CrashReportSpool spool = spoolWithReports(3);
-        RecordingSender sender = new RecordingSender(true);
-        List<String> opened = new ArrayList<>();
-        CrashReporter.DialogOpener opener = json -> {
-            opened.add(json);
-            return false;
-        };
-        CrashReporter reporter = new CrashReporter(spool, sender, () -> false, () -> "http://localhost/", opener);
-
-        reporter.offerSpooledReportsInDialog();
-
-        assertEquals("every spooled report is offered, not just the newest", 3, opened.size());
-        assertEquals("a report the user dismisses is kept for a later offer", 3, spool.list().size());
-        assertEquals(0, sender.sent.size());
     }
 }


### PR DESCRIPTION
Answering **No** to the crash-telemetry question opted out of silent sending but still auto-opened the SendErrorReport review dialog for **every** spooled report — so a backlog of N previous crashes produced **N stacked dialogs** on startup (reported in the wild: 3 dialogs from 3 spooled crashes).

Make opt-out mean fully quiet: reports are spooled to disk but nothing is sent and **no dialog is opened automatically** — neither the startup backlog nor a fresh in-session crash. Opted-in behaviour is unchanged (silent background send). The manual **Help → Send Error Report** path is untouched.

Removes the now-dead auto-dialog machinery (`DialogOpener`, `offerSpooledReportsInDialog`, the one-dialog-per-session latch) and updates the tests.

## Tests
`CrashReporterTest` — 4/4 green: opt-out sends nothing / offers nothing (backlog retained), opted-in sends+deletes on success, opted-in failure retains.