### PR TITLE
Remove compiler warnings: retire deprecated APIs + fix hand-written unchecked (spec 00017)

### DIFF
--- a/common-gui/src/main/java/slash/navigation/gui/Application.java
+++ b/common-gui/src/main/java/slash/navigation/gui/Application.java
@@ -86,7 +86,7 @@ public abstract class Application {
     public Locale getLocale() {
         String language = preferences.get(PREFERRED_LANGUAGE_PREFERENCE, "");
         String country = preferences.get(PREFERRED_COUNTRY_PREFERENCE, "");
-        return new Locale(language, country);
+        return Locale.of(language, country);
     }
 
     public void setLocale(Locale locale) {
@@ -102,7 +102,7 @@ public abstract class Application {
     private static void initializeLocale(Preferences preferences) {
         String language = preferences.get(PREFERRED_LANGUAGE_PREFERENCE, Locale.getDefault().getLanguage());
         String country = preferences.get(PREFERRED_COUNTRY_PREFERENCE, Locale.getDefault().getCountry());
-        Locale.setDefault(new Locale(language, country));
+        Locale.setDefault(Locale.of(language, country));
     }
 
     private static ResourceBundle initializeBundles(List<String> bundleNames) {

--- a/common-gui/src/main/java/slash/navigation/gui/ApplicationContext.java
+++ b/common-gui/src/main/java/slash/navigation/gui/ApplicationContext.java
@@ -29,6 +29,7 @@ import javax.help.HelpSet;
 import javax.help.HelpSetException;
 import javax.swing.*;
 import java.net.MalformedURLException;
+import java.net.URI;
 import java.net.URL;
 import java.util.ResourceBundle;
 
@@ -83,7 +84,7 @@ public class ApplicationContext {
 
     public HelpBroker getHelpBroker() throws HelpSetException, MalformedURLException {
         if (broker == null) {
-            HelpSet helpSet = new HelpSet(Application.class.getClassLoader(), new URL(helpBrokerUrl));
+            HelpSet helpSet = new HelpSet(Application.class.getClassLoader(), URI.create(helpBrokerUrl).toURL());
             broker = helpSet.createHelpBroker();
         }
         return broker;

--- a/common-gui/src/main/java/slash/navigation/gui/helpers/WindowHelper.java
+++ b/common-gui/src/main/java/slash/navigation/gui/helpers/WindowHelper.java
@@ -176,7 +176,6 @@ public class WindowHelper {
     public static void handleOutOfMemoryError(OutOfMemoryError e) {
         // get some air to breath
         System.gc();
-        System.runFinalization();
 
         final long limitBefore = getMaximumMemory();
         final long limitAfter = limitBefore * 2;

--- a/common/src/main/java/slash/common/helpers/LocaleHelper.java
+++ b/common/src/main/java/slash/common/helpers/LocaleHelper.java
@@ -29,25 +29,25 @@ import java.util.Locale;
 
 public class LocaleHelper {
     // for language support which is not defined by a constant in Locale
-    public static final Locale ARABIA = new Locale("ar", "SA");
-    public static final Locale BRAZIL = new Locale("pt", "BR");
-    public static final Locale CATALAN = new Locale("ca", "ES");
-    public static final Locale CZECH = new Locale("cs", "CZ");
-    public static final Locale CROATIA = new Locale("hr", "HR");
-    public static final Locale DENMARK = new Locale("da", "DK");
-    public static final Locale FINLAND = new Locale("fi", "FI");
-    public static final Locale HUNGARY = new Locale("hu", "HU");
+    public static final Locale ARABIA = Locale.of("ar", "SA");
+    public static final Locale BRAZIL = Locale.of("pt", "BR");
+    public static final Locale CATALAN = Locale.of("ca", "ES");
+    public static final Locale CZECH = Locale.of("cs", "CZ");
+    public static final Locale CROATIA = Locale.of("hr", "HR");
+    public static final Locale DENMARK = Locale.of("da", "DK");
+    public static final Locale FINLAND = Locale.of("fi", "FI");
+    public static final Locale HUNGARY = Locale.of("hu", "HU");
     public static final Locale LATVIAN = Locale.forLanguageTag("lv");
-    public static final Locale NEDERLANDS = new Locale("nl", "NL");
-    public static final Locale NORWAY_BOKMAL = new Locale("nb", "NO");
-    public static final Locale POLAND = new Locale("pl", "PL");
-    public static final Locale PORTUGAL = new Locale("pt", "PT");
-    public static final Locale RUSSIA = new Locale("ru", "RU");
-    public static final Locale SERBIA = new Locale("sr", "SR");
-    public static final Locale SLOVAKIA = new Locale("sk", "SK");
-    public static final Locale SPAIN = new Locale("es", "ES");
+    public static final Locale NEDERLANDS = Locale.of("nl", "NL");
+    public static final Locale NORWAY_BOKMAL = Locale.of("nb", "NO");
+    public static final Locale POLAND = Locale.of("pl", "PL");
+    public static final Locale PORTUGAL = Locale.of("pt", "PT");
+    public static final Locale RUSSIA = Locale.of("ru", "RU");
+    public static final Locale SERBIA = Locale.of("sr", "SR");
+    public static final Locale SLOVAKIA = Locale.of("sk", "SK");
+    public static final Locale SPAIN = Locale.of("es", "ES");
     public static final Locale TAMIL = Locale.forLanguageTag("ta");
-    public static final Locale TURKEY = new Locale("tr", "TR");
-    public static final Locale UKRAINE = new Locale("uk", "UA");
-    public static final Locale UZBEKISTAN = new Locale("uz", "UZ");
+    public static final Locale TURKEY = Locale.of("tr", "TR");
+    public static final Locale UKRAINE = Locale.of("uk", "UA");
+    public static final Locale UZBEKISTAN = Locale.of("uz", "UZ");
 }

--- a/common/src/main/java/slash/common/io/Files.java
+++ b/common/src/main/java/slash/common/io/Files.java
@@ -24,6 +24,7 @@ import slash.common.type.CompactCalendar;
 
 import java.io.*;
 import java.net.MalformedURLException;
+import java.net.URI;
 import java.net.URISyntaxException;
 import java.net.URL;
 import java.nio.file.LinkOption;
@@ -194,19 +195,27 @@ public class Files {
         return null;
     }
 
+    /**
+     * Converts a URL or local (possibly relative or space-bearing) path string
+     * to a {@link URL}, falling back to file semantics when the string is not a
+     * valid absolute URI. Replaces the deprecated {@code new URL(String)}.
+     */
+    public static URL toUrl(String urlOrPath) throws MalformedURLException {
+        try {
+            return new URI(urlOrPath).toURL();
+        } catch (URISyntaxException | IllegalArgumentException e) {
+            // fallback from URL to file (relative paths, spaces, ...)
+            return new File(urlOrPath).toURI().toURL();
+        }
+    }
+
     public static List<URL> toUrls(String... urls) {
         List<URL> result = new ArrayList<>(urls.length);
         for (String url : urls) {
             try {
-                result.add(new URL(url));
+                result.add(toUrl(url));
             } catch (MalformedURLException e) {
-
-                // fallback from URL to file
-                try {
-                    result.add(new File(url).toURI().toURL());
-                } catch (MalformedURLException e1) {
-                    // intentionally left empty
-                }
+                // intentionally left empty
             }
         }
         return result;

--- a/common/src/main/java/slash/common/jarinjar/ClassPathExtender.java
+++ b/common/src/main/java/slash/common/jarinjar/ClassPathExtender.java
@@ -23,6 +23,7 @@ import java.io.File;
 import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
 import java.net.MalformedURLException;
+import java.net.URI;
 import java.net.URL;
 import java.net.URLClassLoader;
 
@@ -53,7 +54,7 @@ public class ClassPathExtender {
     }
 
     public void addJarInJar(String fileName) throws MalformedURLException, NoSuchMethodException, InvocationTargetException, IllegalAccessException {
-        addURL(new URL(JAR_IN_JAR_PROTOCOL + fileName));
+        addURL(URI.create(JAR_IN_JAR_PROTOCOL + fileName).toURL());
     }
 
     public void addExternalFile(File file) throws MalformedURLException, NoSuchMethodException, InvocationTargetException, IllegalAccessException {

--- a/common/src/test/java/slash/common/io/FilesUrlTest.java
+++ b/common/src/test/java/slash/common/io/FilesUrlTest.java
@@ -63,6 +63,21 @@ public class FilesUrlTest {
     }
 
     @Test
+    public void toUrlKeepsAbsoluteUrls() throws Exception {
+        assertEquals("http", toUrl("http://host/x.gpx").getProtocol());
+    }
+
+    @Test
+    public void toUrlFallsBackToFileForBareAndSpaceBearingPaths() throws Exception {
+        // absolute local path, no scheme -> not an absolute URI -> file fallback
+        assertEquals("file", toUrl("/some/dir/track.gpx").getProtocol());
+        // spaces are illegal in a URI -> file fallback keeps leniency of the old new URL(String)
+        URL url = toUrl("/some/dir/with space/track.gpx");
+        assertEquals("file", url.getProtocol());
+        assertEquals(new File("/some/dir/with space/track.gpx"), new File(url.toURI()));
+    }
+
+    @Test
     public void reverseReturnsTheUrlsInReverseOrder() throws Exception {
         URL a = new URL("http://host/a");
         URL b = new URL("http://host/b");

--- a/download-tools/src/main/java/slash/navigation/download/tools/MirrorCatalog.java
+++ b/download-tools/src/main/java/slash/navigation/download/tools/MirrorCatalog.java
@@ -22,7 +22,7 @@ package slash.navigation.download.tools;
 import org.apache.commons.cli.CommandLine;
 import org.apache.commons.cli.CommandLineParser;
 import org.apache.commons.cli.DefaultParser;
-import org.apache.commons.cli.HelpFormatter;
+import org.apache.commons.cli.help.HelpFormatter;
 import org.apache.commons.cli.Option;
 import org.apache.commons.cli.Options;
 import org.apache.commons.cli.ParseException;
@@ -169,17 +169,21 @@ public class MirrorCatalog {
         CommandLineParser parser = new DefaultParser();
         Options options = new Options();
         options.addOption(Option.builder().argName(SNAPSHOT_ARGUMENT).numberOfArgs(1).required().longOpt(SNAPSHOT_ARGUMENT)
-                .desc("Path to snapshot datasources directory").build());
+                .desc("Path to snapshot datasources directory").get());
         options.addOption(Option.builder().argName(MIRROR_ARGUMENT).numberOfArgs(1).required().longOpt(MIRROR_ARGUMENT)
-                .desc("Path to local mirror root").build());
+                .desc("Path to local mirror root").get());
         options.addOption(Option.builder().argName(ID_ARGUMENT).hasArgs().longOpt(ID_ARGUMENT)
-                .desc("Restrict to a specific datasource id (repeatable)").build());
+                .desc("Restrict to a specific datasource id (repeatable)").get());
         options.addOption(Option.builder().longOpt(DRY_RUN_ARGUMENT)
-                .desc("Print wget commands without running them").build());
+                .desc("Print wget commands without running them").get());
         try {
             return parser.parse(options, args);
         } catch (ParseException e) {
-            new HelpFormatter().printHelp(MirrorCatalog.class.getSimpleName(), options);
+            try {
+                HelpFormatter.builder().get().printHelp(MirrorCatalog.class.getSimpleName(), null, options, null, false);
+            } catch (IOException ignored) {
+                // help output is best-effort
+            }
             throw e;
         }
     }

--- a/download-tools/src/main/java/slash/navigation/download/tools/ScanWebsite.java
+++ b/download-tools/src/main/java/slash/navigation/download/tools/ScanWebsite.java
@@ -21,6 +21,7 @@ package slash.navigation.download.tools;
 
 
 import org.apache.commons.cli.*;
+import org.apache.commons.cli.help.HelpFormatter;
 import slash.navigation.datasources.DataSource;
 import slash.navigation.datasources.DataSourceManager;
 import slash.navigation.datasources.File;
@@ -327,32 +328,35 @@ public class ScanWebsite extends BaseDownloadTool {
         CommandLineParser parser = new DefaultParser();
         Options options = new Options();
         options.addOption(Option.builder().argName(ID_ARGUMENT).hasArgs().required().longOpt(ID_ARGUMENT).
-                desc("ID of the data source").build());
+                desc("ID of the data source").get());
         options.addOption(Option.builder().argName(URL_ARGUMENT).numberOfArgs(1).longOpt(URL_ARGUMENT).
-                desc("URL to scan for resources (overrides <source url> from datasource XML)").build());
+                desc("URL to scan for resources (overrides <source url> from datasource XML)").get());
         options.addOption(Option.builder().argName(BASE_URL_ARGUMENT).numberOfArgs(1).longOpt(BASE_URL_ARGUMENT).
-                desc("URL to use as a base for resources").build());
+                desc("URL to use as a base for resources").get());
         options.addOption(Option.builder().argName(LEVEL_ARGUMENT).numberOfArgs(1).longOpt(LEVEL_ARGUMENT).
-                desc("Maximum recursion depth").build());
+                desc("Maximum recursion depth").get());
         options.addOption(Option.builder().argName(EXTENSION_ARGUMENT).hasArgs().longOpt(EXTENSION_ARGUMENT).
-                desc("Extensions to scan for").build());
+                desc("Extensions to scan for").get());
         options.addOption(Option.builder().argName(INCLUDE_ARGUMENT).hasArgs().longOpt(INCLUDE_ARGUMENT).
-                desc("Regex for resources to include").build());
+                desc("Regex for resources to include").get());
         options.addOption(Option.builder().argName(EXCLUDE_ARGUMENT).hasArgs().longOpt(EXCLUDE_ARGUMENT).
-                desc("Regex for resources to exclude").build());
+                desc("Regex for resources to exclude").get());
         options.addOption(Option.builder().argName(TYPE_ARGUMENT).numberOfArgs(1).longOpt(TYPE_ARGUMENT).
-                desc("Type of the resources").build());
+                desc("Type of the resources").get());
         options.addOption(Option.builder().argName(DATASOURCES_SERVER_ARGUMENT).numberOfArgs(1).longOpt(DATASOURCES_SERVER_ARGUMENT).
-                desc("Data sources server").build());
+                desc("Data sources server").get());
         options.addOption(Option.builder().argName(DATASOURCES_USERNAME_ARGUMENT).numberOfArgs(1).longOpt(DATASOURCES_USERNAME_ARGUMENT).
-                desc("Data sources server user name").build());
+                desc("Data sources server user name").get());
         options.addOption(Option.builder().argName(DATASOURCES_PASSWORD_ARGUMENT).numberOfArgs(1).longOpt(DATASOURCES_PASSWORD_ARGUMENT).
-                desc("Data sources server password").build());
+                desc("Data sources server password").get());
         try {
             return parser.parse(options, args);
         } catch (ParseException e) {
-            HelpFormatter formatter = new HelpFormatter();
-            formatter.printHelp(getClass().getSimpleName(), options);
+            try {
+                HelpFormatter.builder().get().printHelp(getClass().getSimpleName(), null, options, null, false);
+            } catch (IOException ignored) {
+                // help output is best-effort
+            }
             throw e;
         }
     }

--- a/download-tools/src/main/java/slash/navigation/download/tools/SnapshotCatalog.java
+++ b/download-tools/src/main/java/slash/navigation/download/tools/SnapshotCatalog.java
@@ -20,6 +20,7 @@
 package slash.navigation.download.tools;
 
 import org.apache.commons.cli.*;
+import org.apache.commons.cli.help.HelpFormatter;
 import slash.navigation.datasources.DataSource;
 import slash.navigation.datasources.DataSourceManager;
 import slash.navigation.datasources.Edition;
@@ -106,14 +107,17 @@ public class SnapshotCatalog extends BaseDownloadTool {
         CommandLineParser parser = new DefaultParser();
         Options options = new Options();
         options.addOption(Option.builder().argName(DATASOURCES_SERVER_ARGUMENT).numberOfArgs(1).longOpt("server").
-                desc("Data sources server").build());
+                desc("Data sources server").get());
         options.addOption(Option.builder().argName(RESET_ARGUMENT).longOpt("reset").
-                desc("Reset local snapshot").build());
+                desc("Reset local snapshot").get());
         try {
             return parser.parse(options, args);
         } catch (ParseException e) {
-            HelpFormatter formatter = new HelpFormatter();
-            formatter.printHelp(getClass().getSimpleName(), options);
+            try {
+                HelpFormatter.builder().get().printHelp(getClass().getSimpleName(), null, options, null, false);
+            } catch (IOException ignored) {
+                // help output is best-effort
+            }
             throw e;
         }
     }

--- a/download-tools/src/main/java/slash/navigation/download/tools/UpdateCatalog.java
+++ b/download-tools/src/main/java/slash/navigation/download/tools/UpdateCatalog.java
@@ -21,6 +21,7 @@ package slash.navigation.download.tools;
 
 import jakarta.xml.bind.JAXBException;
 import org.apache.commons.cli.*;
+import org.apache.commons.cli.help.HelpFormatter;
 import slash.navigation.common.BoundingBox;
 import slash.navigation.datasources.*;
 import slash.navigation.datasources.binding.*;
@@ -362,20 +363,23 @@ public class UpdateCatalog extends BaseDownloadTool {
         CommandLineParser parser = new DefaultParser();
         Options options = new Options();
         options.addOption(Option.builder().argName(ID_ARGUMENT).hasArgs().required().longOpt("id").
-                desc("ID of the data source").build());
+                desc("ID of the data source").get());
         options.addOption(Option.builder().argName(DATASOURCES_SERVER_ARGUMENT).numberOfArgs(1).longOpt("server").
-                desc("Data sources server").build());
+                desc("Data sources server").get());
         options.addOption(Option.builder().argName(DATASOURCES_USERNAME_ARGUMENT).numberOfArgs(1).longOpt("username").
-                desc("Data sources server user name").build());
+                desc("Data sources server user name").get());
         options.addOption(Option.builder().argName(DATASOURCES_PASSWORD_ARGUMENT).numberOfArgs(1).longOpt("password").
-                desc("Data sources server password").build());
+                desc("Data sources server password").get());
         options.addOption(Option.builder().argName(MIRROR_ARGUMENT).numberOfArgs(1).required().longOpt("mirror").
-                desc("Filesystem path to mirror resources").build());
+                desc("Filesystem path to mirror resources").get());
         try {
             return parser.parse(options, args);
         } catch (ParseException e) {
-            HelpFormatter formatter = new HelpFormatter();
-            formatter.printHelp(getClass().getSimpleName(), options);
+            try {
+                HelpFormatter.builder().get().printHelp(getClass().getSimpleName(), null, options, null, false);
+            } catch (IOException ignored) {
+                // help output is best-effort
+            }
             throw e;
         }
     }

--- a/mapsforge-maps/src/main/java/slash/navigation/maps/mapsforge/models/TileServerMapSource.java
+++ b/mapsforge-maps/src/main/java/slash/navigation/maps/mapsforge/models/TileServerMapSource.java
@@ -26,6 +26,7 @@ import org.mapsforge.map.layer.download.tilesource.OnlineTileSource;
 import slash.navigation.maps.tileserver.TileServer;
 
 import java.net.MalformedURLException;
+import java.net.URI;
 import java.net.URL;
 import java.util.Locale;
 import java.util.prefs.Preferences;
@@ -90,6 +91,6 @@ public class TileServerMapSource extends AbstractTileSource {
                 .fmt();
         if(getApiKey() != null)
             url += ("?apikey=" + getApiKey());
-        return new URL(url);
+        return URI.create(url).toURL();
     }
 }

--- a/navigation-formats/src/main/java/slash/navigation/base/BaseRoute.java
+++ b/navigation-formats/src/main/java/slash/navigation/base/BaseRoute.java
@@ -503,6 +503,7 @@ public abstract class BaseRoute<P extends BaseNavigationPosition, F extends Base
         return 0;
     }
 
+    @SuppressWarnings("unchecked") // P[] cast from toArray is safe: positions are all of type P
     public void sort(Comparator<P> comparator) {
         List<P> positions = getPositions();
         P[] sorted = (P[]) positions.toArray(new BaseNavigationPosition[0]);

--- a/navigation-formats/src/main/java/slash/navigation/base/NavigationFormatParser.java
+++ b/navigation-formats/src/main/java/slash/navigation/base/NavigationFormatParser.java
@@ -46,6 +46,7 @@ import static java.io.File.separatorChar;
 import static java.lang.Math.min;
 import static java.lang.String.format;
 import static slash.common.io.Files.getExtension;
+import static slash.common.io.Files.toUrl;
 import static slash.common.io.Transfer.ceiling;
 import static slash.common.type.CompactCalendar.UTC;
 import static slash.common.type.CompactCalendar.fromCalendar;
@@ -214,7 +215,7 @@ public class NavigationFormatParser {
         public void parse(String urlString) throws IOException {
             // replace CWD with current working directory for easier testing
             urlString = urlString.replace("CWD", new File(".").getCanonicalPath()).replace(separatorChar, '/');
-            URL url = new URL(urlString);
+            URL url = toUrl(urlString);
             byte[] bytes;
             try (InputStream inputStream = url.openStream()) {
                 bytes = inputStream.readAllBytes();
@@ -303,7 +304,7 @@ public class NavigationFormatParser {
         }
 
         if (isGoogleMapsProfileUrl(url)) {
-            url = new URL(url.toExternalForm() + "&output=kml");
+            url = toUrl(url.toExternalForm() + "&output=kml");
             formats = new ArrayList<>(formats);
             formats.add(0, new Kml22Format());
         }

--- a/profileview/pom.xml
+++ b/profileview/pom.xml
@@ -10,29 +10,6 @@
         <relativePath>../pom.xml</relativePath>
     </parent>
 
-    <build>
-        <plugins>
-            <plugin>
-                <groupId>org.codehaus.mojo</groupId>
-                <artifactId>native2ascii-maven-plugin</artifactId>
-                <executions>
-                    <execution>
-                        <goals>
-                            <goal>resources</goal>
-                        </goals>
-                        <configuration>
-                            <srcDir>src/main/resources</srcDir>
-                            <encoding>UTF-8</encoding>
-                            <includes>
-                                <include>**/LocalizationBundle*.properties</include>
-                            </includes>
-                        </configuration>
-                    </execution>
-                </executions>
-            </plugin>
-        </plugins>
-    </build>
-
     <dependencies>
         <dependency>
             <groupId>${project.groupId}</groupId>

--- a/proxy-tools/src/main/java/slash/navigation/rest/tools/CheckProxy.java
+++ b/proxy-tools/src/main/java/slash/navigation/rest/tools/CheckProxy.java
@@ -20,6 +20,7 @@
 package slash.navigation.rest.tools;
 
 import org.apache.commons.cli.*;
+import org.apache.commons.cli.help.HelpFormatter;
 import org.apache.hc.client5.http.auth.AuthScope;
 import org.apache.hc.client5.http.auth.UsernamePasswordCredentials;
 import org.apache.hc.client5.http.classic.methods.HttpGet;
@@ -57,14 +58,17 @@ public class CheckProxy {
         CommandLineParser parser = new DefaultParser();
         Options options = new Options();
         options.addOption(Option.builder().argName(USERNAME_ARGUMENT).numberOfArgs(1).longOpt("username").
-                desc("Username for the proxy authentication").build());
+                desc("Username for the proxy authentication").get());
         options.addOption(Option.builder().argName(PASSWORD_ARGUMENT).numberOfArgs(1).longOpt("password").
-                desc("Password for the proxy authentication").build());
+                desc("Password for the proxy authentication").get());
         try {
             return parser.parse(options, args);
         } catch (ParseException e) {
-            HelpFormatter formatter = new HelpFormatter();
-            formatter.printHelp(getClass().getSimpleName(), options);
+            try {
+                HelpFormatter.builder().get().printHelp(getClass().getSimpleName(), null, options, null, false);
+            } catch (IOException ignored) {
+                // help output is best-effort
+            }
             throw e;
         }
     }

--- a/route-catalog/src/main/java/slash/navigation/routes/local/LocalCategory.java
+++ b/route-catalog/src/main/java/slash/navigation/routes/local/LocalCategory.java
@@ -29,6 +29,7 @@ import slash.navigation.routes.Route;
 import java.io.*;
 import java.net.MalformedURLException;
 import java.net.URISyntaxException;
+import java.net.URI;
 import java.net.URL;
 import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
@@ -104,7 +105,7 @@ public class LocalCategory implements Category {
         File newParent;
         String newName = encodeFileName(name);
         try {
-            newParent = parent != null ? new File(new URL(parent.getHref()).toURI()) : directory.getParentFile();
+            newParent = parent != null ? new File(new URI(parent.getHref())) : directory.getParentFile();
         } catch (URISyntaxException e) {
             throw new IOException(format("Cannot rename %s in %s to %s", directory, parent, name));
         }

--- a/route-catalog/src/main/java/slash/navigation/routes/local/LocalRoute.java
+++ b/route-catalog/src/main/java/slash/navigation/routes/local/LocalRoute.java
@@ -36,6 +36,7 @@ import java.util.Objects;
 
 import static java.lang.String.format;
 import static slash.common.io.Files.toFile;
+import static slash.common.io.Files.toUrl;
 import static slash.common.io.Transfer.encodeFileName;
 
 /**
@@ -82,7 +83,7 @@ public class LocalRoute implements Route {
     }
 
     public void update(Category parent, String description) throws IOException {
-        File category = toFile(new URL(parent.getHref()));
+        File category = toFile(toUrl(parent.getHref()));
         File newName = new File(category, encodeFileName(description));
         if (newName.exists())
             throw new DuplicateNameException(format("%s %s already exists", newName.isDirectory() ? "Category" : "Route", description), newName.getAbsolutePath());

--- a/route-converter-gui/src/main/java/slash/navigation/converter/gui/helpers/AbstractTablePopupMenu.java
+++ b/route-converter-gui/src/main/java/slash/navigation/converter/gui/helpers/AbstractTablePopupMenu.java
@@ -84,13 +84,13 @@ public abstract class AbstractTablePopupMenu {
             // dispatch event again as a left mouse click for selections
             // (do not try to spare one of the three events)
             table.dispatchEvent(new MouseEvent((Component) e.getSource(), MOUSE_PRESSED, e.getWhen(),
-                    BUTTON1_MASK, e.getX(), e.getY(),
+                    BUTTON1_DOWN_MASK, e.getX(), e.getY(),
                     e.getClickCount(), false));
             table.dispatchEvent(new MouseEvent((Component) e.getSource(), MOUSE_RELEASED, e.getWhen(),
-                    BUTTON1_MASK, e.getX(), e.getY(),
+                    BUTTON1_DOWN_MASK, e.getX(), e.getY(),
                     e.getClickCount(), false));
             table.dispatchEvent(new MouseEvent((Component) e.getSource(), MOUSE_CLICKED, e.getWhen(),
-                    BUTTON1_MASK, e.getX(), e.getY(),
+                    BUTTON1_DOWN_MASK, e.getX(), e.getY(),
                     e.getClickCount(), false));
         }
     }

--- a/route-converter-gui/src/main/java/slash/navigation/converter/gui/helpers/LocalRouteDistanceAndTimeFiller.java
+++ b/route-converter-gui/src/main/java/slash/navigation/converter/gui/helpers/LocalRouteDistanceAndTimeFiller.java
@@ -46,6 +46,7 @@ import java.util.logging.Logger;
 
 import static java.util.concurrent.TimeUnit.SECONDS;
 import static slash.common.io.Files.toFile;
+import static slash.common.io.Files.toUrl;
 
 /**
  * Fills the {@link RouteDistanceAndTimeCache} for routes of the local catalog by
@@ -161,7 +162,7 @@ public class LocalRouteDistanceAndTimeFiller {
 
     private static DistanceAndTime parseLocalRoute(String url) {
         try {
-            File file = toFile(new URL(url));
+            File file = toFile(toUrl(url));
             if (file == null || !file.exists())
                 return null;
 

--- a/route-converter-gui/src/main/java/slash/navigation/converter/gui/models/RecentUrlsModel.java
+++ b/route-converter-gui/src/main/java/slash/navigation/converter/gui/models/RecentUrlsModel.java
@@ -109,7 +109,7 @@ public class RecentUrlsModel {
             String urlString = preferences.get(RECENT_URL_PREFERENCE + c, null);
             if (urlString != null) {
                 try {
-                    URL url = new URL(urlString);
+                    URL url = Files.toUrl(urlString);
                     File file = Files.toFile(url);
                     if (file == null || file.exists())
                         result.add(0, url);

--- a/route-converter-gui/src/main/java/slash/navigation/converter/gui/panels/BrowsePanel.java
+++ b/route-converter-gui/src/main/java/slash/navigation/converter/gui/panels/BrowsePanel.java
@@ -71,6 +71,7 @@ import java.io.File;
 import java.io.FileNotFoundException;
 import java.io.IOException;
 import java.lang.reflect.Method;
+import java.net.URI;
 import java.net.URL;
 import java.util.ArrayList;
 import java.util.Collection;
@@ -367,7 +368,7 @@ public class BrowsePanel implements PanelInTab {
             urlString = route.route().getUrl();
             if (urlString == null)
                 return;
-            url = new URL(urlString);
+            url = URI.create(urlString).toURL();
         } catch (Throwable t) {
             getOperator().handleServiceError(t);
             return;

--- a/route-converter-gui/src/main/java/slash/navigation/converter/gui/panels/ConvertPanel.java
+++ b/route-converter-gui/src/main/java/slash/navigation/converter/gui/panels/ConvertPanel.java
@@ -382,7 +382,11 @@ public class ConvertPanel implements PanelInTab {
         for (PositionTableColumn column : tableColumnModel.getPreparedColumns())
             handleColumnVisibilityUpdate(column);
 
-        comboBoxPositionLists.setModel(formatAndRoutesModel);
+        // FormatAndRoutesModel extends the raw ComboBoxModel; narrow the unchecked
+        // conversion to this assignment rather than the whole initialize() method
+        @SuppressWarnings("unchecked")
+        ComboBoxModel<FormatAndRoutesModel> comboBoxModel = formatAndRoutesModel;
+        comboBoxPositionLists.setModel(comboBoxModel);
         comboBoxPositionLists.setRenderer(new RouteListCellRenderer());
         comboBoxPositionLists.addItemListener(e -> {
             if (e.getStateChange() == SELECTED) {

--- a/route-converter-gui/src/main/java/slash/navigation/converter/gui/panels/PhotoPanel.java
+++ b/route-converter-gui/src/main/java/slash/navigation/converter/gui/panels/PhotoPanel.java
@@ -104,13 +104,18 @@ public class PhotoPanel implements PanelInTab {
     private JComboBox<TagStrategy> comboBoxTagStrategy;
     private JButton buttonTagPhotos;
 
-    private static final ComboBoxModel<FilterPredicate<NavigationPosition>> FILTER_PREDICATE_MODEL =
-            new DefaultComboBoxModel<FilterPredicate<NavigationPosition>>(new FilterPredicate[]{
-                    new TautologyPredicate("All"),
-                    new TagStatePhotoPredicate(Tagged),
-                    new TagStatePhotoPredicate(Taggable),
-                    new TagStatePhotoPredicate(NotTaggable),
-            });
+    private static final ComboBoxModel<FilterPredicate<NavigationPosition>> FILTER_PREDICATE_MODEL = createFilterPredicateModel();
+
+    private static ComboBoxModel<FilterPredicate<NavigationPosition>> createFilterPredicateModel() {
+        // built via addElement instead of the array constructor to avoid the
+        // unavoidable unchecked warning from generic array creation
+        DefaultComboBoxModel<FilterPredicate<NavigationPosition>> model = new DefaultComboBoxModel<>();
+        model.addElement(new TautologyPredicate("All"));
+        model.addElement(new TagStatePhotoPredicate(Tagged));
+        model.addElement(new TagStatePhotoPredicate(Taggable));
+        model.addElement(new TagStatePhotoPredicate(NotTaggable));
+        return model;
+    }
 
     private PositionsModel photosModel;
     private FilteringPositionsModel<NavigationPosition> filteredPhotosModel;
@@ -302,10 +307,10 @@ public class PhotoPanel implements PanelInTab {
     }
 
     private FilterPredicate<NavigationPosition> getFilterPredicatePreference() {
-        FilterPredicate result = FILTER_PREDICATE_MODEL.getElementAt(0);
+        FilterPredicate<NavigationPosition> result = FILTER_PREDICATE_MODEL.getElementAt(0);
         String name = preferences.get(FILTER_PHOTO_PREDICATE_PREFERENCE, result.name());
         for (int i = 0, c = FILTER_PREDICATE_MODEL.getSize(); i < c; i++) {
-            FilterPredicate filterPredicate = FILTER_PREDICATE_MODEL.getElementAt(i);
+            FilterPredicate<NavigationPosition> filterPredicate = FILTER_PREDICATE_MODEL.getElementAt(i);
             if (filterPredicate.name().equals(name)) {
                 result = filterPredicate;
                 break;

--- a/route-converter-gui/src/main/java/slash/navigation/converter/gui/undo/DeleteRoutes.java
+++ b/route-converter-gui/src/main/java/slash/navigation/converter/gui/undo/DeleteRoutes.java
@@ -36,6 +36,7 @@ import java.util.List;
 
 import static java.lang.String.format;
 import static slash.common.io.Files.toFile;
+import static slash.common.io.Files.toUrl;
 
 /**
  * Acts as a {@link UndoableEdit} for deleting {@link RouteModel}s of a {@link UndoCatalogModel}.
@@ -79,7 +80,7 @@ class DeleteRoutes extends AbstractUndoableEdit {
         for (int i = 0; i < categories.size(); i++) {
             String file = files.get(i);
             try {
-                catalogModel.addRoute(categories.get(i), descriptions.get(i), toFile(new URL(file)), urls.get(i), new AddRouteCallback(), false);
+                catalogModel.addRoute(categories.get(i), descriptions.get(i), toFile(toUrl(file)), urls.get(i), new AddRouteCallback(), false);
             } catch (MalformedURLException e) {
                 throw new IllegalStateException(format("Cannot create URL for %s", file));
             }

--- a/route-converter-tools/src/main/java/slash/navigation/converter/tools/FilterResourceBundles.java
+++ b/route-converter-tools/src/main/java/slash/navigation/converter/tools/FilterResourceBundles.java
@@ -20,6 +20,7 @@
 package slash.navigation.converter.tools;
 
 import org.apache.commons.cli.*;
+import org.apache.commons.cli.help.HelpFormatter;
 
 import java.io.FileInputStream;
 import java.io.FileOutputStream;
@@ -71,14 +72,17 @@ public class FilterResourceBundles {
         CommandLineParser parser = new DefaultParser();
         Options options = new Options();
         options.addOption(Option.builder().argName(DEFAULT_ARGUMENT).hasArgs().numberOfArgs(1).required().
-                longOpt("default").desc("Default resource bundle").build());
+                longOpt("default").desc("Default resource bundle").get());
         options.addOption(Option.builder().argName(FILTER_ARGUMENT).hasArgs().numberOfArgs(1).required().
-                longOpt("filter").desc("Resource bundle to filter").build());
+                longOpt("filter").desc("Resource bundle to filter").get());
         try {
             return parser.parse(options, args);
         } catch (ParseException e) {
-            HelpFormatter formatter = new HelpFormatter();
-            formatter.printHelp(getClass().getSimpleName(), options);
+            try {
+                HelpFormatter.builder().get().printHelp(getClass().getSimpleName(), null, options, null, false);
+            } catch (IOException ignored) {
+                // help output is best-effort
+            }
             throw e;
         }
     }

--- a/specs/00017-remove-compiler-warnings.md
+++ b/specs/00017-remove-compiler-warnings.md
@@ -1,8 +1,8 @@
 ---
 name: 00017-remove-compiler-warnings
-status: planned
-phases_done: []
-phases_next: [1, 2]
+status: in-flight
+phases_done: [1, 2]
+phases_next: []
 last_touched: 2026-07-06
 ---
 
@@ -88,15 +88,35 @@ low ROI, or not our source. No enforcement gate this pass (`-Werror` /
 - **Phase 2 — behavior-touching (commit 2):** URL→URI full conversion with
   file-path fallback, per-site unchecked fixes.
 
+## Corrections found during execution
+
+- **URL sites: 12, not 9.** Ground-truth `grep 'new URL('` beat the truncated
+  log dedup: added NavigationFormatParser (x2) and DeleteRoutes.
+- **commons-cli: 6 files, not 4.** CheckProxy (proxy-tools) and
+  FilterResourceBundles (route-converter-tools) were missed in the first pass,
+  caught by the `-Xlint` verify, fixed in P2.
+- **"12 real unchecked" over-counted.** 6 of them live in IntelliJ
+  `$$$setupUI$$$`-generated blocks (PhotoPanel x3, ConvertPanel, ThemeStyleDialog,
+  MapSelector) — treated as generated (out of scope, like ObjectFactory).
+  Genuinely hand-written and fixed: PhotoPanel:108/314, ConvertPanel:385,
+  BaseRoute:508.
+- **FileOperations:119/131 unchecked are pre-existing on master** (raw
+  FormatAndRoutes; method at line 84 already suppresses the sibling site) —
+  the initial baseline undercounted them due to inconsistent `-Xlint`
+  application. Out of scope (same cascade as ConvertPanel:385).
+
 ## Verification
 
-- `mvn -Djacoco.skip clean compile` — the 68 deprecated + 1 missing-dir + 12
-  real unchecked gone from default output; 46 codegen-locale + rawtypes/serial/
-  this-escape unchanged (expected, out of scope).
-- Unit tests green (`navigation-formats` covers parse paths; download-tools CLI
-  help is dev-only, no test asserts exact text).
-- Spot-check: parse a `file:` URL whose path contains a space still round-trips
-  (guards Q3 fallback).
+- Full-reactor `-Xlint:all` compile (temp pom arg, reverted): all targeted
+  buckets now **0** — Locale, URL(String), Option.Builder, old HelpFormatter,
+  runFinalization, missing-source-dir. Remaining unchecked are only generated
+  `setupUI` + pre-existing FileOperations + generated ObjectFactory.
+- New `Files.toUrl` unit tests cover the http-passthrough and the bare/
+  space-bearing-path File fallback (guards the Q3 leniency claim).
+- Unit tests green across all touched modules. Note: `IntegerModelTest.
+  testSetIntegerNegative` is **pre-existing flaky** (default-Locale pollution
+  across tests, execution-order dependent) — reproduced then cleared on both
+  master and this branch; unrelated to these changes.
 
 ## Out of scope / follow-ups
 

--- a/specs/00017-remove-compiler-warnings.md
+++ b/specs/00017-remove-compiler-warnings.md
@@ -1,0 +1,105 @@
+---
+name: 00017-remove-compiler-warnings
+status: planned
+phases_done: []
+phases_next: [1, 2]
+last_touched: 2026-07-06
+---
+
+# 00017 - Remove compiler warnings (Scope A: deprecated APIs + real unchecked)
+
+## Status
+
+Planned. Created July 6, 2026. Scope and every risk decision fixed by the
+maintainer in a grilling session (see Decisions). Delivered on a worktree
+branch off `master` (not the active `spec-00016-p4-joptionpane` WIP), one
+squash PR, two commits.
+
+## Problem
+
+`mvn clean compile` (Java 21, 45 modules) is not warning-clean. Measured
+landscape:
+
+### Default build (no `-Xlint`) — 115 warnings
+| bucket | count | where |
+|---|---|---|
+| deprecated API | 68 | 21 source files |
+| "platform locale" (JAXB codegen) | 46 | generated date/time code, not our source |
+| missing source dir | 1 | profileview native2ascii execution |
+
+### Under `-Xlint:all` — ~450 source warnings (currently hidden)
+| bucket | count |
+|---|---|
+| rawtypes (`found raw type`) | 181 |
+| serial (no `serialVersionUID`) | 83 |
+| this-escape | 57 |
+| unchecked | 28 (16 generated, 12 real) |
+| deprecated API | 68 |
+| redundant cast | 2 |
+
+## Decision: Scope A only
+
+Fix everything the **default** build emits from our own source, plus the 12
+real `unchecked`. Explicitly **out of scope**: rawtypes / serial / this-escape
+(the `-Xlint`-only bulk) and the 46 JAXB-codegen locale warnings — invasive,
+low ROI, or not our source. No enforcement gate this pass (`-Werror` /
+`failOnWarning` impossible without the excluded bulk; deferred to a future spec).
+
+## Grilled decisions (locked)
+
+- **Q1 Scope** → Scope A. Leave rawtypes/serial/this-escape.
+- **Q2 Enforcement** → no gate now.
+- **Q3 `new URL(String)` (×9)** → **full conversion** to `new URI(s).toURL()`.
+  Guard the two file-path-capable sites (NavigationFormatParser.parse,
+  RecentUrlsModel) so a `URISyntaxException` from a space-bearing local path
+  falls back to `new File(s).toURI().toURL()` — preserves old leniency.
+- **Q4 commons-cli 1.11.0 (×37)** → **do both** swaps: `Option.Builder.build()`
+  → `get()`; old `HelpFormatter` → `org.apache.commons.cli.help.HelpFormatter`.
+- **Q5 real unchecked (×12)** → **per-site judgment**: fix generics where local
+  and clean (PhotoPanel, ConvertPanel, ThemeStyleDialog, MapSelector);
+  `@SuppressWarnings("unchecked")` + why-comment on BaseRoute (a real fix there
+  cascades into the excluded 181 rawtypes).
+- **Q6a profileview** → remove the dead `native2ascii` plugin block entirely
+  (no `LocalizationBundle*.properties`, no `resources/` dir there).
+- **Q6b JAXB codegen locale (×46)** → out of scope.
+- **Q7 delivery** → one spec, one worktree branch off master, one squash PR,
+  two commits (mechanical / behavior-touching).
+
+## Work items
+
+### Deprecated API (68)
+- `new Locale(String,String)` → `Locale.of(...)` — LocaleHelper (×21 across sites).
+- `System.runFinalization()` → delete the call — WindowHelper (deprecated for removal).
+- `new URL(String)` → URI conversion (×9) per Q3: NavigationFormatParser (×2),
+  RecentUrlsModel, TileServerMapSource, googlemaps profile-URL append, + others.
+- commons-cli (×37) per Q4: ScanWebsite, UpdateCatalog, SnapshotCatalog, MirrorCatalog.
+
+### Real unchecked (12) — per-site per Q5
+- PhotoPanel (×6), ConvertPanel (×3), ThemeStyleDialog (×1), MapSelector (×1): fix generics.
+- BaseRoute (×1): suppress + comment.
+
+### Build hygiene (1)
+- profileview/pom.xml: remove dead native2ascii execution.
+
+## Phases
+
+- **Phase 1 — mechanical / zero-risk (commit 1):** Locale.of, delete
+  runFinalization, commons-cli both swaps, profileview dead-plugin removal.
+- **Phase 2 — behavior-touching (commit 2):** URL→URI full conversion with
+  file-path fallback, per-site unchecked fixes.
+
+## Verification
+
+- `mvn -Djacoco.skip clean compile` — the 68 deprecated + 1 missing-dir + 12
+  real unchecked gone from default output; 46 codegen-locale + rawtypes/serial/
+  this-escape unchanged (expected, out of scope).
+- Unit tests green (`navigation-formats` covers parse paths; download-tools CLI
+  help is dev-only, no test asserts exact text).
+- Spot-check: parse a `file:` URL whose path contains a space still round-trips
+  (guards Q3 fallback).
+
+## Out of scope / follow-ups
+
+- Enforcement gate (`-Xlint` + `-Werror`) — future spec, needs the bulk cleared first.
+- rawtypes (181) / serial (83) / this-escape (57) — separate invasive campaign.
+- JAXB codegen locale (46) — generator config, risks churning generated output.

--- a/specs/STATUS.md
+++ b/specs/STATUS.md
@@ -7,13 +7,14 @@ Active specs (`proposed`/`planned`/`in-flight`) live in `specs/`; done ones
 (`shipped`/`live`/`retired`) in `specs/done/`. When a spec's status crosses
 that line, `git mv` it to match and rerun this script.
 
-## Active (3) — planned / proposed / in-flight
+## Active (4) — planned / proposed / in-flight
 
 | Spec | Status | Phases done | Phases next | Last touched |
 |------|--------|-------------|-------------|--------------|
 | [00010-migrate-java-17-to-25](./00010-migrate-java-17-to-25.md) | `in-flight` | — | — | 2026-06-13 |
 | [00013-waypoint-icons-from-style](./00013-waypoint-icons-from-style.md) | `proposed` | — | — | 2026-07-03 |
 | [00014-poi-category-overlay](./00014-poi-category-overlay.md) | `proposed` | — | — | 2026-07-03 |
+| [00017-remove-compiler-warnings](./00017-remove-compiler-warnings.md) | `planned` | — | 1, 2 | 2026-07-06 |
 
 ## Done (11) — shipped / live / retired (`specs/done/`)
 

--- a/specs/STATUS.md
+++ b/specs/STATUS.md
@@ -14,7 +14,7 @@ that line, `git mv` it to match and rerun this script.
 | [00010-migrate-java-17-to-25](./00010-migrate-java-17-to-25.md) | `in-flight` | — | — | 2026-06-13 |
 | [00013-waypoint-icons-from-style](./00013-waypoint-icons-from-style.md) | `proposed` | — | — | 2026-07-03 |
 | [00014-poi-category-overlay](./00014-poi-category-overlay.md) | `proposed` | — | — | 2026-07-03 |
-| [00017-remove-compiler-warnings](./00017-remove-compiler-warnings.md) | `planned` | — | 1, 2 | 2026-07-06 |
+| [00017-remove-compiler-warnings](./00017-remove-compiler-warnings.md) | `in-flight` | 1, 2 | — | 2026-07-06 |
 
 ## Done (11) — shipped / live / retired (`specs/done/`)
 


### PR DESCRIPTION
Scope A of spec 00017 — kill every compiler warning emitted from our own source (deprecated APIs + hand-written unchecked). Default `mvn clean compile` goes **115 → 46 warnings**; the remaining 46 are JAXB-generated "platform locale" notes (out of scope).

## Fixed
| bucket | count | how |
|---|---|---|
| `new Locale(a,b)` | 23 | `Locale.of(a,b)` |
| `new URL(String)` | 12 | new `Files.toUrl` (URI + File fallback) / `URI.create().toURL()` / `new URI()` |
| commons-cli `build()` + old `HelpFormatter` | 37 | `get()` + `org.apache.commons.cli.help.HelpFormatter`, across all **6** tool files |
| `System.runFinalization()` (removal) | 1 | deleted |
| `MouseEvent.BUTTON1_MASK` | 3 | `BUTTON1_DOWN_MASK` |
| hand-written `unchecked` | 6 | 2 clean generics fixes, 2 narrow `@SuppressWarnings` |
| profileview dead `native2ascii` | 1 | removed |

Under `-Xlint:all` every targeted bucket is now **0**.

## Key design point (grilled)
`new URL(String)` is lenient with spaces/relative paths; `new URI(s).toURL()` is not. `Files.toUrl` converts via URI and falls back to `new File(s).toURI().toURL()` so file paths with spaces still round-trip. Covered by new unit tests.

## Out of scope (documented in spec)
JAXB codegen locale (46), IntelliJ `$$$setupUI$$$`-generated unchecked, pre-existing FileOperations unchecked, rawtypes/serial/this-escape, enforcement gate.

## Verification
- Full-reactor `-Xlint:all` compile: all targeted buckets 0.
- New `Files.toUrl` tests green; unit tests green across touched modules.
- ⚠️ `MouseEvent.BUTTON1_MASK`→`BUTTON1_DOWN_MASK` is a GUI behavior touch (right-click-without-selection path), untestable headless — **manual UI verification pending**.
- Note: `IntegerModelTest.testSetIntegerNegative` is pre-existing flaky (default-Locale pollution), not from this branch.