### PR TITLE
Fix color-picker jank (spec 00015) + add reset-to-default color buttons

### DIFF
--- a/mapsforge-mapview/src/main/java/slash/navigation/mapview/mapsforge/renderer/NonSelectedPositionListsRenderer.java
+++ b/mapsforge-mapview/src/main/java/slash/navigation/mapview/mapsforge/renderer/NonSelectedPositionListsRenderer.java
@@ -36,8 +36,9 @@ import slash.navigation.mapview.mapsforge.lines.Polyline;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.concurrent.atomic.AtomicBoolean;
 
-import static slash.common.helpers.ThreadHelper.invokeInAwtEventQueue;
+import static javax.swing.SwingUtilities.invokeLater;
 import static slash.navigation.base.RouteCharacteristics.Route;
 import static slash.navigation.base.RouteCharacteristics.Waypoints;
 import static slash.navigation.mapview.mapsforge.helpers.ColorHelper.asRGBA;
@@ -68,6 +69,7 @@ public class NonSelectedPositionListsRenderer {
     private final IntegerModel trackLineWidthModel;
     private final GraphicFactory graphicFactory;
     private final GroupLayer layer = new GroupLayer();
+    private final AtomicBoolean updatePending = new AtomicBoolean(false);
     private Bitmap waypointIcon;
 
     public NonSelectedPositionListsRenderer(MapsforgeMapView mapView, PositionListsModel positionListsModel,
@@ -88,28 +90,40 @@ public class NonSelectedPositionListsRenderer {
     }
 
     public void update() {
-        invokeInAwtEventQueue(new Runnable() {
-            public void run() {
-                // GroupLayer.draw()/onDestroy() iterate the plain ArrayList layers under
-                // synchronized(this) on the render thread; hold the same monitor while we
-                // clear and repopulate here on the EDT to avoid a ConcurrentModificationException
-                synchronized (layer) {
-                    layer.layers.clear();
-
-                    List<BaseRoute> routes = positionListsModel.getRoutes();
-                    BaseRoute selectedRoute = positionListsModel.getSelectedRoute();
-                    if (routes != null) {
-                        for (BaseRoute route : routes) {
-                            if (route == null || route == selectedRoute)
-                                continue;
-                            addPositionList(route);
-                        }
-                    }
-                }
-
-                layer.requestRedraw();
-            }
+        // The route/track/waypoint color pickers (JColorChooser) and line-width spinners
+        // fire a flood of change events while dragged, each reaching here via the map view's
+        // repaintPositionListListener. Coalesce them: schedule a single deferred rebuild on
+        // the EDT instead of running a full clear+repopulate synchronously per event - the
+        // synchronous version (spec 00015 as shipped) janks the Options color dialog when a
+        // multi-list file is loaded. The rebuild reads the latest model state, so collapsing
+        // several pending requests into one loses nothing.
+        if (!updatePending.compareAndSet(false, true))
+            return;
+        invokeLater(() -> {
+            updatePending.set(false);
+            rebuild();
         });
+    }
+
+    private void rebuild() {
+        // GroupLayer.draw()/onDestroy() iterate the plain ArrayList layers under
+        // synchronized(this) on the render thread; hold the same monitor while we
+        // clear and repopulate here on the EDT to avoid a ConcurrentModificationException
+        synchronized (layer) {
+            layer.layers.clear();
+
+            List<BaseRoute> routes = positionListsModel.getRoutes();
+            BaseRoute selectedRoute = positionListsModel.getSelectedRoute();
+            if (routes != null) {
+                for (BaseRoute route : routes) {
+                    if (route == null || route == selectedRoute)
+                        continue;
+                    addPositionList(route);
+                }
+            }
+        }
+
+        layer.requestRedraw();
     }
 
     @SuppressWarnings("unchecked")

--- a/mapsforge-mapview/src/test/java/slash/navigation/mapview/mapsforge/renderer/NonSelectedPositionListsRendererTest.java
+++ b/mapsforge-mapview/src/test/java/slash/navigation/mapview/mapsforge/renderer/NonSelectedPositionListsRendererTest.java
@@ -20,11 +20,76 @@
 package slash.navigation.mapview.mapsforge.renderer;
 
 import org.junit.Test;
+import org.mapsforge.core.graphics.GraphicFactory;
+import slash.navigation.base.BaseRoute;
+import slash.navigation.converter.gui.models.ColorModel;
+import slash.navigation.converter.gui.models.PositionListsModel;
+import slash.navigation.gui.models.IntegerModel;
+import slash.navigation.mapview.mapsforge.MapsforgeMapView;
 
+import javax.swing.event.ListDataListener;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import static java.awt.EventQueue.invokeAndWait;
 import static org.junit.Assert.assertEquals;
+import static org.mockito.Mockito.mock;
 import static slash.navigation.mapview.mapsforge.renderer.NonSelectedPositionListsRenderer.lighten;
 
 public class NonSelectedPositionListsRendererTest {
+
+    /**
+     * A {@link PositionListsModel} with no routes that counts how often the renderer reads it -
+     * one read per actual rebuild. No routes means the rebuild touches no other collaborator.
+     */
+    private static class CountingPositionListsModel implements PositionListsModel {
+        final AtomicInteger reads = new AtomicInteger();
+        public List<BaseRoute> getRoutes() { reads.incrementAndGet(); return new ArrayList<>(); }
+        public BaseRoute getSelectedRoute() { return null; }
+        public void addListDataListener(ListDataListener l) { }
+        public void removeListDataListener(ListDataListener l) { }
+    }
+
+    private NonSelectedPositionListsRenderer newRenderer(PositionListsModel model) {
+        return new NonSelectedPositionListsRenderer(mock(MapsforgeMapView.class), model,
+                mock(ColorModel.class), mock(ColorModel.class),
+                mock(IntegerModel.class), mock(IntegerModel.class), mock(GraphicFactory.class));
+    }
+
+    @Test
+    public void updateDefersTheRebuildInsteadOfRunningItOnTheEventThread() throws Exception {
+        CountingPositionListsModel model = new CountingPositionListsModel();
+        NonSelectedPositionListsRenderer renderer = newRenderer(model);
+
+        // spec 00015 regression: a color/line-width change reaches update() on the EDT; the
+        // rebuild must NOT run synchronously inside that event (it janks the Options dialog),
+        // so no read has happened yet by the time the event returns
+        invokeAndWait(() -> {
+            renderer.update();
+            assertEquals("rebuild must be deferred, not run inline during the change event",
+                    0, model.reads.get());
+        });
+
+        invokeAndWait(() -> { });   // drain the EDT so the deferred rebuild runs
+        assertEquals("deferred rebuild runs exactly once after the event returns",
+                1, model.reads.get());
+    }
+
+    @Test
+    public void rapidUpdatesCoalesceIntoASingleRebuild() throws Exception {
+        CountingPositionListsModel model = new CountingPositionListsModel();
+        NonSelectedPositionListsRenderer renderer = newRenderer(model);
+
+        // simulate a JColorChooser drag: many update() calls within one EDT event
+        invokeAndWait(() -> {
+            for (int i = 0; i < 50; i++)
+                renderer.update();
+        });
+
+        invokeAndWait(() -> { });   // drain the EDT
+        assertEquals("50 rapid updates must coalesce into a single rebuild", 1, model.reads.get());
+    }
 
     @Test
     public void factorZeroKeepsTheColor() {

--- a/mapview/src/main/java/slash/navigation/converter/gui/models/ColorModel.java
+++ b/mapview/src/main/java/slash/navigation/converter/gui/models/ColorModel.java
@@ -64,6 +64,10 @@ public class ColorModel {
         }
     }
 
+    public Color getDefaultColor() {
+        return new Color(decodeInt(defaultValue), true);
+    }
+
     public void setColor(Color color) {
         preferences.put(preferencesPrefix + COLOR_SUFFIX, toString(color));
         fireChanged();

--- a/route-converter-gui/src/main/java/slash/navigation/converter/gui/dialogs/OptionsDialog.java
+++ b/route-converter-gui/src/main/java/slash/navigation/converter/gui/dialogs/OptionsDialog.java
@@ -36,6 +36,7 @@ import slash.navigation.converter.gui.BaseRouteConverter;
 import slash.navigation.converter.gui.helpers.CheckBoxPreferencesSynchronizer;
 import slash.navigation.converter.gui.helpers.MapViewImplementation;
 import slash.navigation.converter.gui.helpers.RoutingServiceFacade;
+import slash.navigation.converter.gui.models.ColorModel;
 import slash.navigation.converter.gui.models.FixMapMode;
 import slash.navigation.converter.gui.renderer.*;
 import slash.navigation.elevation.ElevationService;
@@ -588,15 +589,9 @@ public class OptionsDialog extends SimpleDialog {
         radioButtonV1000UTC.setSelected(!ColumbusV1000Device.getUseLocalTimeZone());
         radioButtonV1000LocalTime.addChangeListener(e -> ColumbusV1000Device.setUseLocalTimeZone(radioButtonV1000LocalTime.isSelected()));
 
-        colorChooserRoute.setColor(r.getMapPreferencesModel().getRouteColorModel().getColor());
-        reducePanels(colorChooserRoute);
-        colorChooserRoute.getSelectionModel().addChangeListener(e -> r.getMapPreferencesModel().getRouteColorModel().setColor(colorChooserRoute.getColor()));
-        colorChooserTrack.setColor(r.getMapPreferencesModel().getTrackColorModel().getColor());
-        reducePanels(colorChooserTrack);
-        colorChooserTrack.getSelectionModel().addChangeListener(e -> r.getMapPreferencesModel().getTrackColorModel().setColor(colorChooserTrack.getColor()));
-        colorChooserWaypoint.setColor(r.getMapPreferencesModel().getWaypointColorModel().getColor());
-        reducePanels(colorChooserWaypoint);
-        colorChooserWaypoint.getSelectionModel().addChangeListener(e -> r.getMapPreferencesModel().getWaypointColorModel().setColor(colorChooserWaypoint.getColor()));
+        setupColorChooser(colorChooserRoute, r.getMapPreferencesModel().getRouteColorModel());
+        setupColorChooser(colorChooserTrack, r.getMapPreferencesModel().getTrackColorModel());
+        setupColorChooser(colorChooserWaypoint, r.getMapPreferencesModel().getWaypointColorModel());
         lineWidthSpinnerRoute.setModel(new SpinnerNumberModel(r.getMapPreferencesModel().getRouteLineWidthModel().getInteger().intValue(), 1, 20, 1));
         lineWidthSpinnerRoute.addChangeListener(e -> r.getMapPreferencesModel().getRouteLineWidthModel().setInteger((Integer) lineWidthSpinnerRoute.getValue()));
         lineWidthSpinnerTrack.setModel(new SpinnerNumberModel(r.getMapPreferencesModel().getTrackLineWidthModel().getInteger().intValue(), 1, 20, 1));
@@ -643,6 +638,30 @@ public class OptionsDialog extends SimpleDialog {
                     "\u6837\u672c(S)", "HSV(H)", "HSL(L)"
             )
     );
+
+    private void setupColorChooser(JColorChooser chooser, ColorModel colorModel) {
+        chooser.setColor(colorModel.getColor());
+        reducePanels(chooser);
+        chooser.getSelectionModel().addChangeListener(e -> colorModel.setColor(chooser.getColor()));
+
+        // add a right-aligned "reset to default color" button directly below the chooser:
+        // wrap the chooser in place (keeping its original grid cell) so the button sits
+        // beneath it. Clicking it sets the chooser to the model's built-in default, which
+        // propagates to the model - and on to the map - via the selection listener above.
+        JButton resetButton = new JButton(getBundle().getString("reset-color"));
+        resetButton.addActionListener(e -> chooser.setColor(colorModel.getDefaultColor()));
+
+        Container parent = chooser.getParent();
+        GridConstraints constraints = ((GridLayoutManager) parent.getLayout()).getConstraintsForComponent(chooser);
+        parent.remove(chooser);
+
+        JPanel buttons = new JPanel(new FlowLayout(FlowLayout.RIGHT, 0, 0));
+        buttons.add(resetButton);
+        JPanel wrapper = new JPanel(new BorderLayout());
+        wrapper.add(chooser, BorderLayout.CENTER);
+        wrapper.add(buttons, BorderLayout.SOUTH);
+        parent.add(wrapper, constraints);
+    }
 
     private void reducePanels(JColorChooser chooser) {
         chooser.setPreviewPanel(new JPanel());

--- a/route-converter-gui/src/main/resources/slash/navigation/converter/gui/RouteConverter_de.properties
+++ b/route-converter-gui/src/main/resources/slash/navigation/converter/gui/RouteConverter_de.properties
@@ -460,6 +460,7 @@ track-color=Trackfarbe:
 track-line-width=Tracklinienbreite:
 waypoint-tab=Wegpunkt
 waypoint-color=Wegpunktfarbe:
+reset-color=Auf Standardfarbe zurücksetzen
 travel-mode=Plane Routen:
 travel-mode-bicycling=Mit dem Fahrrad
 travel-mode-driving=Mit dem Auto

--- a/route-converter-gui/src/main/resources/slash/navigation/converter/gui/RouteConverter_en.properties
+++ b/route-converter-gui/src/main/resources/slash/navigation/converter/gui/RouteConverter_en.properties
@@ -448,6 +448,7 @@ track-color=Track color:
 track-line-width=Track line width:
 waypoint-tab=Waypoint
 waypoint-color=Waypoint color:
+reset-color=Reset to default color
 travel-mode=Plan routes for:
 travel-mode-bicycling=Bicycling
 travel-mode-driving=Driving


### PR DESCRIPTION
Two independent changes, one commit each.

## 1. `fix(mapview)`: coalesce non-selected-list rebuilds — unjank color picking
Spec 00015 wired `NonSelectedPositionListsRenderer.update()` into the map view's `repaintPositionListListener`, which fires on every route/track/waypoint **color** and **line-width** change. `update()` rebuilt the whole gray overlay **synchronously on the EDT** (`invokeInAwtEventQueue` runs inline when already on the EDT), so a `JColorChooser` drag — a flood of change events — did one full clear+repopulate *per event*. With a multi-list file loaded, the Options color dialog janked.

Fix: schedule a **single deferred rebuild** on the EDT (`AtomicBoolean` guard + `invokeLater`), dropping redundant pending requests. The rebuild reads the latest model state, so collapsing several into one loses nothing — mirroring the decoupling the selected-route rebuild already gets from `UpdateDecoupler`.

**Tests:** two regression tests — a 50-event drag goes from **50 rebuilds → 1**; both fail on the pre-fix inline version, pass with the fix.

## 2. `feat(options)`: reset-to-default color button per chooser
Each of the Route/Track/Waypoint color choosers gets a right-aligned **"Reset to default color"** button directly below it. Clicking it sets the chooser to the model's built-in default, which propagates to the `ColorModel` — and on to the map — via the existing selection listener.
- `ColorModel.getDefaultColor()`
- `OptionsDialog.setupColorChooser(chooser, model)` — wraps each chooser in place, button beneath
- new `reset-color` bundle key (EN + DE)

## Validation
- `mapsforge-mapview` suite green on JDK 21 (7/7 incl. the 2 new tests); negative check confirms the tests catch the regression.
- Full reactor packages successfully.
- Launched the app (11-track sample): color-drag is smooth; reset buttons snap each chooser to its default and update the map.

🤖 Generated with [Claude Code](https://claude.com/claude-code)