### PR TITLE
Fix Java-update dialog linking to outdated Adoptium (Java 17) URL

### DIFF
--- a/route-converter-gui/src/main/java/slash/navigation/converter/gui/helpers/UpdateChecker.java
+++ b/route-converter-gui/src/main/java/slash/navigation/converter/gui/helpers/UpdateChecker.java
@@ -199,7 +199,8 @@ public class UpdateChecker {
     private void offerJavaUpdate(Window window, UpdateResult result) {
         String message = format(BaseRouteConverter.getBundle().getString("confirm-java-update"),
                 result.getMyJavaVersion(), result.getLatestJavaVersion());
-        showUpdateMessage(window, message, "https://adoptium.net/de/temurin/releases?version=17");
+        int javaMajor = new Version(result.getLatestJavaVersion()).getMajor();
+        showUpdateMessage(window, message, "https://adoptium.net/temurin/releases/?version=" + javaMajor);
     }
 
     public void implicitCheck(final Window window) {


### PR DESCRIPTION
The in-app "a newer Java is available" dialog hardcoded
`https://adoptium.net/de/temurin/releases?version=17` — so it pointed users at
**Java 17** even while offering a newer **Java 21** build, and forced the German
(`/de/`) locale regardless of the user's language.

Fix: derive the major version from the Java version actually being offered
(`result.getLatestJavaVersion()`), so the link always matches the dialog, and drop
the hardcoded locale. This self-updates when the toolchain retargets to Java 25.

```java
int javaMajor = new Version(result.getLatestJavaVersion()).getMajor();
showUpdateMessage(window, message, "https://adoptium.net/temurin/releases/?version=" + javaMajor);
```

Reported on the forum (companion to the website download-page link fix, which is already live).

🤖 Generated with [Claude Code](https://claude.com/claude-code)