### PR TITLE
Fix OpenStreetMap tile block: send a policy-compliant User-Agent

### DIFF
--- a/googlemaps/src/main/java/slash/navigation/googlemaps/GoogleService.java
+++ b/googlemaps/src/main/java/slash/navigation/googlemaps/GoogleService.java
@@ -47,7 +47,6 @@ import static slash.navigation.common.Bearing.calculateBearing;
 import static slash.navigation.googlemaps.GoogleMapsServer.getGoogleMapsServer;
 import static slash.navigation.googlemaps.GoogleUtil.unmarshalElevation;
 import static slash.navigation.googlemaps.GoogleUtil.unmarshalGeocode;
-import static slash.navigation.rest.HttpRequest.USER_AGENT;
 
 /**
  * Encapsulates REST access to the Google Elevation and Geocoding API Services.
@@ -83,9 +82,7 @@ public class GoogleService extends BaseGeocodingService implements ElevationServ
     }
 
     private Get get(String url) {
-        Get get = new Get(url);
-        get.setUserAgent(USER_AGENT);
-        return get;
+        return new Get(url);
     }
 
     private void checkForError(String url, String status) throws ServiceUnavailableException {

--- a/mapsforge-maps/src/main/java/slash/navigation/maps/mapsforge/models/OpenStreetMap.java
+++ b/mapsforge-maps/src/main/java/slash/navigation/maps/mapsforge/models/OpenStreetMap.java
@@ -36,6 +36,6 @@ public class OpenStreetMap extends TileDownloadMap {
 
     public OpenStreetMap() {
         super("OpenStreetMap Default Map", OPENSTREETMAP_URL, true, INSTANCE, retrieveCopyrightText("OpenStreetMap"));
-        getTileSource().setUserAgent("RouteConverter Map Client/" + System.getProperty("rest", "3.0"));
+        getTileSource().setUserAgent("RouteConverter/" + System.getProperty("rest", "3.0") + " (+https://www.routeconverter.com/)");
     }
 }

--- a/mapsforge-maps/src/main/java/slash/navigation/maps/mapsforge/models/TileServerMapSource.java
+++ b/mapsforge-maps/src/main/java/slash/navigation/maps/mapsforge/models/TileServerMapSource.java
@@ -31,8 +31,6 @@ import java.net.URL;
 import java.util.Locale;
 import java.util.prefs.Preferences;
 
-import static slash.navigation.rest.HttpRequest.USER_AGENT;
-
 /**
  * A {@link OnlineTileSource} that is configured from a {@link TileServer}.
  *
@@ -55,7 +53,8 @@ public class TileServerMapSource extends AbstractTileSource {
     public TileServerMapSource(TileServer tileServer) {
         super(getHostNames(tileServer), 80);
         this.tileServer = tileServer;
-        setUserAgent(!tileServer.active() ? "RouteConverter Map Client /" + System.getProperty("rest", "3.0") : USER_AGENT);
+        // Identify compliantly to tile providers (esp. OpenStreetMap's usage policy); never masquerade as a browser
+        setUserAgent("RouteConverter/" + System.getProperty("rest", "3.0") + " (+https://www.routeconverter.com/)");
         setTimeoutConnect(30 * 1000);
         setTimeoutRead(120 * 1000);
     }

--- a/rest/src/main/java/slash/navigation/rest/HttpRequest.java
+++ b/rest/src/main/java/slash/navigation/rest/HttpRequest.java
@@ -58,7 +58,6 @@ import static slash.common.helpers.ExceptionHelper.getLocalizedMessage;
 
 public abstract class HttpRequest {
     public static final String APPLICATION_JSON = "application/json";
-    public static final String USER_AGENT = "Mozilla/5.0 (Windows NT 6.1; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/114.0.0.0 Safari/537.36";
 
     private final Logger log;
     private final HttpClientBuilder clientBuilder = HttpClientBuilder.create();


### PR DESCRIPTION
## Problem

OpenStreetMap online maps stopped rendering — the map area fills with OSM's
**403 "Access blocked — App is not following the tile usage policy"** tile
(osm.wiki/Blocked). Reported via error report #1322.

OSM enforces its [tile usage policy](https://operations.osmfoundation.org/policies/tiles/)
(since 2025) and blocks clients that **masquerade as a browser** or fail to
identify themselves. RouteConverter's *active* catalog tile servers sent a
spoofed desktop-Chrome User-Agent (`Mozilla/5.0 … Chrome/114 … Safari/537.36`),
which the policy explicitly forbids → OSM blocked us.

## Fix

Identify honestly everywhere; never spoof a browser:

- **Tiles** now send `RouteConverter/<version> (+https://www.routeconverter.com/)`
  with a contact URL, as the policy requests — in `OpenStreetMap` and
  `TileServerMapSource` (drops the `active → browser UA` branch).
- **Removed** the shared `HttpRequest.USER_AGENT` Mozilla/Chrome constant and
  `GoogleService`'s override; Google elevation/geocoding calls fall back to the
  existing `RouteConverter REST Client/<version>` identity set in the
  `HttpRequest` constructor.

## Notes

- This behavior change applies to **all** active catalog tile servers, not just
  OSM. If any commercial provider in the catalog actually requires a browser UA,
  it will now receive the RouteConverter UA — flag it and it can get a
  per-server override.
- Reaches users only once released; already-installed clients stay blocked until
  then. The server-side catalog (`urlPattern`) repoint remains the interim lever
  for existing installs.

## Testing

`BUILD SUCCESS` + all tests green across `rest`, `googlemaps`, `mapsforge-maps`
on Java 21.

🤖 Generated with [Claude Code](https://claude.com/claude-code)