### PR TITLE
docs(AGENTS): document jar-only test-skip flags

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -22,6 +22,13 @@ source ~/.sdkman/bin/sdkman-init.sh && sdk use java 21   # pin may vary; `ls ~/.
 # run the app (build the runnable Linux jar, then launch it):
 ./mvnw --batch-mode -pl RouteConverterLinux -am package
 java -jar RouteConverterLinux/target/RouteConverterLinux.jar
+
+# just want the jar? skip the (flaky, network-dependent) tests with the project's
+# OWN properties — plain -DskipTests is IGNORED (surefire binds <skipTests> to
+# ${skip.unit.tests}), and -Dmaven.test.skip breaks the build because ~18 modules
+# depend on sibling test-jars:
+./mvnw --batch-mode -pl RouteConverterLinux -am package \
+  -Dskip.unit.tests=true -Dskip.integration.tests=true
 ```
 
 Integration tests are split by Maven profile: `./mvnw -Phermetic-integration-test verify`


### PR DESCRIPTION
Building just the runnable jar (per the existing `package` command) runs the full test suite, including flaky network ITs (`ReadIT`, `UrlFormatTest`) that fail without connectivity. This documents the project-specific way to skip them:

```sh
./mvnw --batch-mode -pl RouteConverterLinux -am package \
  -Dskip.unit.tests=true -Dskip.integration.tests=true
```

Also records two non-obvious pitfalls hit while working locally:
- plain `-DskipTests` is **ignored** — surefire binds `<skipTests>` to `${skip.unit.tests}` in the root pom.
- `-Dmaven.test.skip=true` **breaks the reactor** — ~18 modules depend on sibling `test-jar`s, which aren't built when test compilation is skipped.

🤖 Generated with [Claude Code](https://claude.com/claude-code)