### PR TITLE
Fix FilesUrlTest failing on Windows CI (drive-letter path portability)

### DIFF
--- a/common/src/test/java/slash/common/io/FilesUrlTest.java
+++ b/common/src/test/java/slash/common/io/FilesUrlTest.java
@@ -74,7 +74,9 @@ public class FilesUrlTest {
         // spaces are illegal in a URI -> file fallback keeps leniency of the old new URL(String)
         URL url = toUrl("/some/dir/with space/track.gpx");
         assertEquals("file", url.getProtocol());
-        assertEquals(new File("/some/dir/with space/track.gpx"), new File(url.toURI()));
+        // compare absolute forms: new File(url.toURI()) round-trips to getAbsoluteFile(), which on
+        // Windows carries a drive letter while a bare "/some/..." File stays drive-relative
+        assertEquals(new File("/some/dir/with space/track.gpx").getAbsoluteFile(), new File(url.toURI()));
     }
 
     @Test


### PR DESCRIPTION
`FilesUrlTest.toUrlFallsBackToFileForBareAndSpaceBearingPaths` fails on the Windows CI runner (surfaced by the nightly/master prerelease build):

```
expected:<\some\dir\with space\track.gpx> but was:<D:\some\dir\with space\track.gpx>
```

The test compared `new File("/some/dir/with space/track.gpx")` (drive-relative on Windows) against `new File(url.toURI())`, which round-trips through `toURI()` to an **absolute** path carrying a drive letter. Equal on Unix, unequal on Windows.

Fix: call `getAbsoluteFile()` on the expected `File` so both sides are absolute. `Files.toUrl` behaviour is unchanged and correct; this is a test-portability fix only (no-op on Unix). Verified locally: `FilesUrlTest` 7/7 green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
