### PR TITLE
docs(release-prepare): update backlog pointer to specs/OPEN-TASKS.md

### DIFF
--- a/.github/workflows/release-prepare.yml
+++ b/.github/workflows/release-prepare.yml
@@ -20,7 +20,7 @@ name: Release prepare
 # Tag push from step 2 fires release.yml automatically.
 #
 # See rc-meta/specs/00018-release-automation-3.4.md Phase 4 automation
-# and rc-meta/specs/00026.3-open-tasks.md MR-§9 for the one-time
+# and rc-meta/specs/OPEN-TASKS.md MR-§9 for the one-time
 # secret-provisioning steps.
 
 on:


### PR DESCRIPTION
The rc-meta canonical backlog was renamed `00026.3-open-tasks.md` → `specs/OPEN-TASKS.md` (rc-meta commit `8deb340`). This fixes the now-stale comment reference in `release-prepare.yml`'s one-time secret-provisioning note. Comment-only; no workflow behavior change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)