### PR TITLE
fix(i18n): English fallback for keys missing in the active locale (fixes Save As crash)

### DIFF
--- a/common-gui/src/main/java/slash/navigation/gui/helpers/CombinedResourceBundle.java
+++ b/common-gui/src/main/java/slash/navigation/gui/helpers/CombinedResourceBundle.java
@@ -39,11 +39,18 @@ public class CombinedResourceBundle extends ResourceBundle {
 
     public void load() {
         bundleNames.forEach(bundleName -> {
-            ResourceBundle bundle = getBundle(bundleName);
-            Enumeration<String> keysEnumeration = bundle.getKeys();
-            ArrayList<String> keysList = list(keysEnumeration);
-            keysList.forEach(key -> resources.put(key, bundle.getString(key)));
+            // Load English first as a fallback, then let the active-locale bundle override
+            // it. There is no no-suffix base bundle (English lives in *_en.properties), so a
+            // key present only in the English bundle would otherwise have no fallback and
+            // throw MissingResourceException for every other locale - e.g. the list-none /
+            // list-and / list-more keys used by DialogStrings on a German UI.
+            merge(getBundle(bundleName, Locale.ENGLISH));
+            merge(getBundle(bundleName));
         });
+    }
+
+    private void merge(ResourceBundle bundle) {
+        list(bundle.getKeys()).forEach(key -> resources.put(key, bundle.getString(key)));
     }
 
     public Object handleGetObject(String key) {

--- a/common-gui/src/test/java/slash/navigation/gui/helpers/CombinedResourceBundleTest.java
+++ b/common-gui/src/test/java/slash/navigation/gui/helpers/CombinedResourceBundleTest.java
@@ -24,6 +24,7 @@ import org.junit.Test;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
+import java.util.Locale;
 import java.util.MissingResourceException;
 
 import static java.util.Arrays.asList;
@@ -38,6 +39,8 @@ import static org.junit.Assert.*;
 public class CombinedResourceBundleTest {
     private static final String BUNDLE_1 = "slash.navigation.gui.helpers.testbundle1";
     private static final String BUNDLE_2 = "slash.navigation.gui.helpers.testbundle2";
+    // testbundle3 has _en and _de variants (no no-suffix base), mirroring the app bundles
+    private static final String BUNDLE_3 = "slash.navigation.gui.helpers.testbundle3";
 
     private static CombinedResourceBundle load(String... bundleNames) {
         CombinedResourceBundle bundle = new CombinedResourceBundle(asList(bundleNames));
@@ -67,6 +70,23 @@ public class CombinedResourceBundleTest {
         Collections.sort(keys);
 
         assertEquals(asList("key.a", "key.b", "key.shared"), keys);
+    }
+
+    @Test
+    public void englishActsAsFallbackForKeysMissingInTheActiveLocale() {
+        Locale previous = Locale.getDefault();
+        try {
+            Locale.setDefault(Locale.GERMAN);
+            CombinedResourceBundle bundle = load(BUNDLE_3);
+
+            // key present only in the *_en bundle must fall back to English, not throw
+            assertEquals("english-value", bundle.getString("only.in.english"));
+            // active-locale keys still resolve, and override English on shared keys
+            assertEquals("german-value", bundle.getString("only.in.german"));
+            assertEquals("german-shared", bundle.getString("shared.key"));
+        } finally {
+            Locale.setDefault(previous);
+        }
     }
 
     @Test

--- a/common-gui/src/test/resources/slash/navigation/gui/helpers/testbundle3_de.properties
+++ b/common-gui/src/test/resources/slash/navigation/gui/helpers/testbundle3_de.properties
@@ -1,0 +1,2 @@
+only.in.german=german-value
+shared.key=german-shared

--- a/common-gui/src/test/resources/slash/navigation/gui/helpers/testbundle3_en.properties
+++ b/common-gui/src/test/resources/slash/navigation/gui/helpers/testbundle3_en.properties
@@ -1,0 +1,2 @@
+only.in.english=english-value
+shared.key=english-shared

--- a/route-converter-gui/src/main/resources/slash/navigation/converter/gui/RouteConverter_de.properties
+++ b/route-converter-gui/src/main/resources/slash/navigation/converter/gui/RouteConverter_de.properties
@@ -723,6 +723,11 @@ previous=&Vorherige
 next=&Nächste
 finish=&Abschließen
 country-code-none=<kein>
+
+# dialog list formatting (slash.navigation.gui.helpers.DialogStrings)
+list-none=keine
+list-and=und
+list-more=und {0} weitere
 send-error-report-title=Sende Fehlerbericht
 send-error-report-log=Für Deinen Fehlerbericht an den RouteConverter-Dienst wird die folgende Information übermittelt:
 send-error-report-description=Bitte füge eine Beschreibung hinzu, wann der Fehler auftrat und wie er reproduziert werden kann:


### PR DESCRIPTION
## Symptom
Save As (and any dialog going through `DialogStrings.asDialogString`) crashes on a non-English UI:

```
MissingResourceException: Can't find resource for bundle
  slash.navigation.gui.helpers.CombinedResourceBundle, key list-none
    at DialogStrings.asDialogString(DialogStrings.java:54)
    at FileOperations.saveFiles(FileOperations.java:216)
    at ...SaveAsAction.run(SaveAsAction.java:42)
```

## Root cause
`CombinedResourceBundle.load()` copied keys only from the **active-locale** bundle. English lives in `*_en.properties` and there is **no no-suffix base bundle**, so a key present only in the English bundle has no fallback → `MissingResourceException` for every non-English locale. The `list-none` / `list-and` / `list-more` keys (added with spec 00016, consumed by `DialogStrings`) existed only in `RouteConverter_en.properties`, so every German/French/… user crashed on Save As.

## Fix
- `CombinedResourceBundle.load()`: load English first as a fallback layer, then overlay the active locale. Any key missing in the active locale now degrades to English instead of throwing. This closes the whole class of "translated-in-en-only" crashes, not just `list-*`.
- Add the German translations for the three `list-*` keys (`keine` / `und` / `und {0} weitere`) so the German UI shows German, not the English fallback.
- Regression test `englishActsAsFallbackForKeysMissingInTheActiveLocale` (+ `testbundle3_en`/`_de` fixtures). It reproduces the exact `MissingResourceException` on the pre-fix loader and passes with the fix.

## Validation
`common-gui` `CombinedResourceBundleTest` — 6/6 green on JDK 21; verified the new test fails (same exception as the report) when the fix is reverted.

🤖 Generated with [Claude Code](https://claude.com/claude-code)