### PR TITLE
Validate downloads against any known-good checksum (#155)

### DIFF
--- a/brouter/src/main/java/slash/navigation/brouter/BRouter.java
+++ b/brouter/src/main/java/slash/navigation/brouter/BRouter.java
@@ -414,7 +414,7 @@ public class BRouter extends BaseRoutingService {
         String uri = downloadable.getUri();
         String url = getSegmentsBaseUrl() + uri;
         return downloadManager.queueForDownload(getName() + " Routing Segment: " + uri, url, Action.valueOf(getSegments().getAction()),
-                new FileAndChecksum(createSegmentFile(downloadable.getUri()), downloadable.getLatestChecksum()), null);
+                FileAndChecksum.forChecksums(createSegmentFile(downloadable.getUri()), downloadable.getChecksums()), null);
     }
 
     public void downloadRoutingData(List<MapDescriptor> mapDescriptors) {
@@ -523,7 +523,7 @@ public class BRouter extends BaseRoutingService {
         String uri = downloadable.getUri();
         String url = getProfilesBaseUrl() + uri;
         downloadManager.queueForDownload(getName() + " Routing Profile: " + uri, url, Action.valueOf(getProfiles().getAction()),
-                new FileAndChecksum(createProfileFile(downloadable.getUri()), downloadable.getLatestChecksum()), null);
+                FileAndChecksum.forChecksums(createProfileFile(downloadable.getUri()), downloadable.getChecksums()), null);
     }
 
     public void downloadProfiles() {

--- a/datasource/src/main/java/slash/navigation/datasources/DataSourceManager.java
+++ b/datasource/src/main/java/slash/navigation/datasources/DataSourceManager.java
@@ -245,7 +245,7 @@ public class DataSourceManager {
 
         downloadManager.addOrUpdateInQueue(dataSource.getName() + ": " + downloadable.getUri(),
                 dataSource.getBaseUrl() + downloadable.getUri(), action,
-                new FileAndChecksum(target, downloadable.getLatestChecksum()),
+                FileAndChecksum.forChecksums(target, downloadable.getChecksums()),
                 asFragments(directory, downloadable.getFragments(), action.equals(Extract)));
     }
 
@@ -258,7 +258,7 @@ public class DataSourceManager {
 
         return downloadManager.queueForDownload(dataSource.getName() + ": " + downloadable.getUri(),
                 dataSource.getBaseUrl() + downloadable.getUri(), action,
-                new FileAndChecksum(target, downloadable.getLatestChecksum()),
+                FileAndChecksum.forChecksums(target, downloadable.getChecksums()),
                 asFragments(target, downloadable.getFragments(), false));
     }
 
@@ -271,7 +271,7 @@ public class DataSourceManager {
         for (Fragment<Downloadable> fragment : fragments) {
             String key = fragment.getKey();
             File target = new File(useDirectoryParent ? directory.getParentFile() : directory, key);
-            result.add(new FileAndChecksum(target, fragment.getLatestChecksum()));
+            result.add(FileAndChecksum.forChecksums(target, fragment.getChecksums()));
         }
         return result;
     }

--- a/datasource/src/main/java/slash/navigation/datasources/impl/DataSourceImpl.java
+++ b/datasource/src/main/java/slash/navigation/datasources/impl/DataSourceImpl.java
@@ -128,21 +128,19 @@ public class DataSourceImpl implements DataSource {
 
     public Downloadable getDownloadableBySHA1(String sha1) {
         initialize();
-        for(Downloadable downloadable : downloadableMap.values()) {
-            Checksum checksum = downloadable.getLatestChecksum();
-            if(checksum != null && sha1.equals(checksum.getSHA1()))
-                return downloadable;
-        }
+        for(Downloadable downloadable : downloadableMap.values())
+            for(Checksum checksum : downloadable.getChecksums())
+                if(checksum != null && sha1.equals(checksum.getSHA1()))
+                    return downloadable;
         return null;
     }
 
     public Fragment<Downloadable> getFragmentBySHA1(String sha1) {
         initialize();
-        for(Fragment<Downloadable> fragment : fragmentMap.values()) {
-            Checksum checksum = fragment.getLatestChecksum();
-            if(checksum != null && sha1.equals(checksum.getSHA1()))
-                return fragment;
-        }
+        for(Fragment<Downloadable> fragment : fragmentMap.values())
+            for(Checksum checksum : fragment.getChecksums())
+                if(checksum != null && sha1.equals(checksum.getSHA1()))
+                    return fragment;
         return null;
     }
 

--- a/download-tools/src/main/java/slash/navigation/download/tools/UpdateCatalog.java
+++ b/download-tools/src/main/java/slash/navigation/download/tools/UpdateCatalog.java
@@ -107,6 +107,23 @@ public class UpdateCatalog extends BaseDownloadTool {
         close();
     }
 
+    // Keep the newly-observed checksum plus a bounded history of previously-recorded ones, so a client
+    // that downloaded any recent upstream build still validates (see GitHub #155). Upstreams that rebuild
+    // a file on a schedule (e.g. BRouter segment tiles) change the content hash per build; a single
+    // stored checksum would make every such download look "outdated".
+    static final int MAX_CHECKSUMS_PER_FILE = 30;
+
+    static List<Checksum> mergeChecksums(List<Checksum> existing, Checksum latest) {
+        List<Checksum> result = new ArrayList<>();
+        if (latest != null)
+            result.add(latest);
+        if (existing != null)
+            for (Checksum checksum : existing)
+                if (checksum != null && !result.contains(checksum))
+                    result.add(checksum);
+        return result.size() > MAX_CHECKSUMS_PER_FILE ? new ArrayList<>(result.subList(0, MAX_CHECKSUMS_PER_FILE)) : result;
+    }
+
     private void updateFile(DatasourceType datasourceType, File file) throws IOException {
         String url = datasourceType.getBaseUrl() + file.getUri();
 
@@ -121,7 +138,7 @@ public class UpdateCatalog extends BaseDownloadTool {
         }
 
         Checksum checksum = download.getFile().getActualChecksum();
-        FileType fileType = createFileType(file.getUri(), singletonList(checksum), null);
+        FileType fileType = createFileType(file.getUri(), mergeChecksums(file.getChecksums(), checksum), null);
         datasourceType.getFile().add(fileType);
 
         if (file.getUri().endsWith(DOT_ZIP)) {
@@ -186,7 +203,7 @@ public class UpdateCatalog extends BaseDownloadTool {
         }
 
         Checksum checksum = download.getFile().getActualChecksum();
-        MapType mapType = createMapType(map.getUri(), singletonList(checksum), null);
+        MapType mapType = createMapType(map.getUri(), mergeChecksums(map.getChecksums(), checksum), null);
         datasourceType.getMap().add(mapType);
 
         // GET with range for .zip or .map header
@@ -259,7 +276,7 @@ public class UpdateCatalog extends BaseDownloadTool {
         }
 
         Checksum checksum = download.getFile().getActualChecksum();
-        ThemeType themeType = createThemeType(theme.getUri(), singletonList(checksum), null);
+        ThemeType themeType = createThemeType(theme.getUri(), mergeChecksums(theme.getChecksums(), checksum), null);
         datasourceType.getTheme().add(themeType);
 
         if (theme.getUri().endsWith(DOT_ZIP)) {

--- a/download/src/main/java/slash/navigation/download/FileAndChecksum.java
+++ b/download/src/main/java/slash/navigation/download/FileAndChecksum.java
@@ -20,33 +20,57 @@
 package slash.navigation.download;
 
 import java.io.File;
+import java.util.List;
+
+import static java.util.Collections.emptyList;
+import static java.util.Collections.singletonList;
 
 /**
- * A file, it's expected and actual checksum
+ * A file, its expected and actual checksum.
+ * <p>
+ * A file may carry more than one expected checksum: upstreams that rebuild a file on a schedule
+ * (e.g. the BRouter segment tiles) produce a new content hash per build, so the catalog can record
+ * several known-good checksums for the same URI. A downloaded file is valid if it matches
+ * <em>any</em> of them (see {@link slash.navigation.download.actions.Validator}).
  *
  * @author Christian Pesch
  */
 
 public class FileAndChecksum {
     private final File file;
-    private Checksum expectedChecksum;
+    private List<Checksum> expectedChecksums;
     private Checksum actualChecksum;
 
     public FileAndChecksum(File file, Checksum expectedChecksum) {
         this.file = file;
-        this.expectedChecksum = expectedChecksum;
+        this.expectedChecksums = expectedChecksum != null ? singletonList(expectedChecksum) : emptyList();
+    }
+
+    /**
+     * A file with several known-good expected checksums; the download is valid if it matches any of them.
+     * A static factory rather than a constructor, so the common {@code (file, null)} call sites stay
+     * unambiguous against the {@code (File, Checksum)} constructor.
+     */
+    public static FileAndChecksum forChecksums(File file, List<Checksum> expectedChecksums) {
+        FileAndChecksum result = new FileAndChecksum(file, (Checksum) null);
+        result.expectedChecksums = expectedChecksums != null ? expectedChecksums : emptyList();
+        return result;
     }
 
     public File getFile() {
         return file;
     }
 
+    public List<Checksum> getExpectedChecksums() {
+        return expectedChecksums;
+    }
+
     public Checksum getExpectedChecksum() {
-        return expectedChecksum;
+        return Checksum.getLatestChecksum(expectedChecksums);
     }
 
     public void setExpectedChecksum(Checksum expectedChecksum) {
-        this.expectedChecksum = expectedChecksum;
+        this.expectedChecksums = expectedChecksum != null ? singletonList(expectedChecksum) : emptyList();
     }
 
     public Checksum getActualChecksum() {

--- a/download/src/main/java/slash/navigation/download/actions/Validator.java
+++ b/download/src/main/java/slash/navigation/download/actions/Validator.java
@@ -104,48 +104,56 @@ public class Validator {
         if (file.getFile().isDirectory())
             return true;
 
-        Checksum expected = file.getExpectedChecksum();
-        if (expected == null)
+        List<Checksum> expectedChecksums = file.getExpectedChecksums();
+        if (expectedChecksums.isEmpty())
             return true;
 
         Checksum actual = file.getActualChecksum();
         if (actual == null)
             return false;
 
+        // A file is valid if it matches ANY known-good checksum. Upstreams that rebuild a file on a
+        // schedule (e.g. BRouter segment tiles) produce a new content hash per build, so the catalog
+        // may record several valid checksums for one URI; a download of any of those builds is correct
+        // and must not be re-fetched (see GitHub #155).
+        for (Checksum expected : expectedChecksums)
+            if (matches(expected, actual)) {
+                log.fine(format("%s has valid checksum", file.getFile()));
+                return true;
+            }
+
+        Checksum latest = Checksum.getLatestChecksum(expectedChecksums);
+        log.warning(format("%s has SHA-1 %s / %s bytes but matched none of %d known-good checksum(s) (latest expected SHA-1 %s / %s bytes)",
+                file.getFile(), actual.getSHA1(), actual.getContentLength(), expectedChecksums.size(),
+                latest != null ? latest.getSHA1() : null, latest != null ? latest.getContentLength() : null));
+        return false;
+    }
+
+    private boolean matches(Checksum expected, Checksum actual) {
+        if (expected == null)
+            return true;
+
         boolean contentLengthEquals = expected.getContentLength() == null ||
                 expected.getContentLength().equals(actual.getContentLength());
-        if (!contentLengthEquals)
-            log.warning(format("%s has %d bytes but expected %d", file.getFile(), actual.getContentLength(), expected.getContentLength()));
         boolean sha1Equals = expected.getSHA1() == null ||
                 expected.getSHA1().equals(actual.getSHA1());
-        if (!sha1Equals)
-            log.warning(format("%s has SHA-1 %s but expected %s", file.getFile(), actual.getSHA1(), expected.getSHA1()));
 
-        boolean valid;
-        if (expected.getSHA1() != null) {
+        if (expected.getSHA1() != null)
             // SHA-1 is authoritative: a matching content hash means the file is correct,
             // independent of its last-modified time (the server may not even send one, so a
             // re-downloaded good file routinely has a different mtime than the stored checksum).
             // A mismatching SHA-1 means the file is definitively wrong (see specs/00054).
-            valid = sha1Equals && contentLengthEquals;
-        } else {
-            // no authoritative hash: fall back to size + last-modified, with the "locally later
-            // than remote" heuristic to avoid endless re-downloads when the local file is newer
-            // than the (possibly stale) queued checksum:
-            // - the very first download after a file update, once this process updated the server checksum
-            // - the server checksum was updated but the queue still holds the first download's value
-            boolean lastModifiedEquals = expected.getLastModified() == null ||
-                    expected.getLastModified().equals(actual.getLastModified());
-            if (!lastModifiedEquals)
-                log.warning(format("%s has last modified %s but expected %s", file.getFile(), actual.getLastModified(), expected.getLastModified()));
-            boolean localLaterThanRemote = actual.laterThan(expected);
-            if (localLaterThanRemote)
-                log.info(format("%s is locally later than remote", file.getFile()));
-            valid = lastModifiedEquals && contentLengthEquals || localLaterThanRemote;
-        }
-        if (valid)
-            log.fine(format("%s has valid checksum", file.getFile()));
-        return valid;
+            return sha1Equals && contentLengthEquals;
+
+        // no authoritative hash: fall back to size + last-modified, with the "locally later
+        // than remote" heuristic to avoid endless re-downloads when the local file is newer
+        // than the (possibly stale) queued checksum:
+        // - the very first download after a file update, once this process updated the server checksum
+        // - the server checksum was updated but the queue still holds the first download's value
+        boolean lastModifiedEquals = expected.getLastModified() == null ||
+                expected.getLastModified().equals(actual.getLastModified());
+        boolean localLaterThanRemote = actual.laterThan(expected);
+        return lastModifiedEquals && contentLengthEquals || localLaterThanRemote;
     }
 
     private void determineChecksumsValid() throws IOException {

--- a/download/src/test/java/slash/navigation/download/actions/ValidatorTest.java
+++ b/download/src/test/java/slash/navigation/download/actions/ValidatorTest.java
@@ -209,6 +209,44 @@ public class ValidatorTest {
         assertTrue(v.isChecksumsValid());
     }
 
+    // --- match-any-known-good-checksum (GitHub #155) ---
+
+    @Test
+    public void checksumsValidWhenActualMatchesNonLatestChecksum() throws IOException {
+        // the real file's checksum is present but is NOT the latest in the list; a decoy with a later
+        // last-modified and a wrong SHA-1 would win getLatestChecksum(). Match-any must still validate.
+        Checksum real = Checksum.createChecksum(target, true);
+        assertNotNull(real);
+        Checksum decoyLatest = new Checksum(fromMillis(target.lastModified() + 100000L), 9999L, "wrong-sha1");
+
+        FileAndChecksum fac = FileAndChecksum.forChecksums(target, Arrays.asList(decoyLatest, real));
+        Download d = new Download("desc", "http://example.com/f", Copy, fac, null);
+
+        Validator v = new Validator(d);
+        assertTrue(v.isChecksumsValid());
+    }
+
+    @Test
+    public void checksumsInvalidWhenActualMatchesNoChecksum() throws IOException {
+        Checksum wrong1 = new Checksum(null, target.length() + 1L, "wrong-sha1");
+        Checksum wrong2 = new Checksum(null, target.length() + 2L, "another-wrong-sha1");
+
+        FileAndChecksum fac = FileAndChecksum.forChecksums(target, Arrays.asList(wrong1, wrong2));
+        Download d = new Download("desc", "http://example.com/f", Copy, fac, null);
+
+        Validator v = new Validator(d);
+        assertFalse(v.isChecksumsValid());
+    }
+
+    @Test
+    public void checksumsValidWhenExpectedChecksumsListIsEmpty() throws IOException {
+        FileAndChecksum fac = FileAndChecksum.forChecksums(target, java.util.Collections.<Checksum>emptyList());
+        Download d = new Download("desc", "http://example.com/f", Copy, fac, null);
+
+        Validator v = new Validator(d);
+        assertTrue(v.isChecksumsValid());
+    }
+
     // --- expectedChecksumIsCurrentChecksum ---
 
     @Test

--- a/graphhopper/src/main/java/slash/navigation/graphhopper/GraphHopper.java
+++ b/graphhopper/src/main/java/slash/navigation/graphhopper/GraphHopper.java
@@ -434,7 +434,7 @@ public class GraphHopper extends BaseRoutingService {
         Action action = Action.valueOf(downloadable.getDataSource().getAction());
         File file = action.equals(Extract) ? createDirectory(downloadable) : createFile(downloadable);
         return downloadManager.queueForDownload(getName() + " Routing Data: " + uri, url, action,
-                new FileAndChecksum(file, downloadable.getLatestChecksum()), null);
+                FileAndChecksum.forChecksums(file, downloadable.getChecksums()), null);
     }
 
     public long calculateRemainingDownloadSize(List<MapDescriptor> mapDescriptors) {


### PR DESCRIPTION
Closes #155.

BRouter segment tiles perpetually failed catalog checksum validation. The catalog points clients straight at `brouter.de` (which rebuilds tiles nightly), but validates the downloaded bytes against a single, older catalog snapshot — so every launch re-flagged the file as outdated and re-queued it (non-fatal, but noisy + wasteful). Surfaced by feedback error report #1323.

The schema already allowed several checksums per file (`DownloadableType.checksum` is unbounded), but the read side collapsed the list to `getLatestChecksum()` and the generator only wrote `singletonList()`.

### Changes
- **`FileAndChecksum`** carries a list of expected checksums via a `forChecksums()` static factory; the single-`Checksum` constructor is kept so the many `(file, null)` call sites stay unambiguous. `getExpectedChecksum()` still returns the latest (for size/display).
- **`Validator`** accepts a download if its actual checksum matches **any** known-good entry; the per-checksum SHA-1/size logic (incl. the spec 00054 "later than remote" heuristic) is extracted into `matches()`.
- **Consumers** pass the full list: `BRouter` (segments + profiles), `DataSourceManager` (files + fragments), `GraphHopper`; `DataSourceImpl` SHA-1 lookups scan all checksums.
- **`UpdateCatalog`** appends each newly-observed checksum to the file's existing set (dedup, newest-first, capped at 30) instead of replacing with one.

Single-element lists behave exactly as before, so mirror-served datasources are unaffected.

### Tests
`ValidatorTest` gains match-any / match-none / empty-list cases. Green across `download`, `datasource`, `brouter`, `download-tools`, `graphhopper` (unit tests; ITs not run).

### Not in this PR
The checksum-set only tolerates builds `UpdateCatalog` has already scanned; running it on a cadence keeps the set current. The airtight alternative — mirror the segments onto RouteConverter infra and generate the catalog from the mirrored files (via the existing `MirrorCatalog`) — is noted in #155.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
