### PR TITLE
Fix map right-click New/Delete using stale focus context

### DIFF
--- a/mapsforge-mapview/src/main/java/slash/navigation/mapview/mapsforge/helpers/MapViewPopupMenu.java
+++ b/mapsforge-mapview/src/main/java/slash/navigation/mapview/mapsforge/helpers/MapViewPopupMenu.java
@@ -49,10 +49,10 @@ public class MapViewPopupMenu extends MouseAdapter {
     }
 
     public void mousePressed(MouseEvent e) {
-        if (isLeftMouseButton(e)) {
-            ActionManager actionManager = Application.getInstance().getContext().getActionManager();
-            actionManager.setLocalName(MAP);
+        ActionManager actionManager = Application.getInstance().getContext().getActionManager();
+        actionManager.setLocalName(MAP);
 
+        if (isLeftMouseButton(e)) {
             boolean shiftKey = e.isShiftDown();
             boolean altKey = e.isAltDown();
             boolean ctrlKey = e.isControlDown();
@@ -70,3 +70,4 @@ public class MapViewPopupMenu extends MouseAdapter {
         }
     }
 }
+


### PR DESCRIPTION
Closes #157.

## Summary
- `MapViewPopupMenu.mousePressed` now sets the `MAP` local action context unconditionally at the top of the method, instead of only inside the left-mouse-button branch.
- This mirrors `AbstractTablePopupMenu.mousePressed`, which already sets its `localName` unconditionally.

## Why
The mapsforge map's right-click popup items **New** and **Delete** are global, locally-dispatched actions (`new-position` / `delete`) that route to a per-context delegate based on `ActionManager.getLocalName()`. The right-mouse-button branch of `MapViewPopupMenu.mousePressed` never called `setLocalName(MAP)`, so after clicking a row in the position list (which sets `POSITIONS`), right-clicking the map and choosing New/Delete still dispatched against the `POSITIONS` context — inserting the new position at the map center (`BaseRouteConverter.getMapCenter()` fallback) instead of the right-clicked coordinate, and similarly misrouting Delete. A prior left-click on the map worked around this because the left-click branch does set `MAP`. Regressed by the switch to global dispatched actions for New/Delete (previously the popup called the map's `add-position` action directly).

## Risk
Low. The change only affects context selection before dispatch; the dispatch mechanism (`GlobalAction.run()`), the coordinate-capture path, and all other map popup actions (`select-position`, `center-here`, `zoom-in`, `zoom-out`, `snap-to-road`) are unchanged. The online JavaFX8 browser map uses a separate JS-based context menu and is unaffected.

## Test plan
- `mvn -q -pl mapsforge-mapview -am install` stays green.
- Manual: switch the position list to Route, click a list row, then right-click the map and choose New — verify the position lands at the clicked (snapped) coordinate, not the map center, with no prior left-click on the map. Repeat for Delete on the nearest position to the click.
- Regression: Ctrl+left-click New, left-click select, and existing map interactions still behave as before.

🤖 Builder.

---
**Builder stats** · model `sonnet` · confidence `0.95` · 1m 19s across 1 round(s) · 1 file op(s)
[Workflow run](http://127.0.0.1:3000/cpesch/RouteConverter/actions/runs/10518)