### PR TITLE
Map popup: use isPopupTrigger() on press + release

### DIFF
--- a/mapsforge-mapview/src/main/java/slash/navigation/mapview/mapsforge/helpers/MapViewPopupMenu.java
+++ b/mapsforge-mapview/src/main/java/slash/navigation/mapview/mapsforge/helpers/MapViewPopupMenu.java
@@ -47,9 +47,14 @@ public class MapViewPopupMenu extends MouseAdapter {
         component.addMouseListener(this);
     }
 
-    public void mousePressed(MouseEvent e) {
+    private ActionManager getActionManager() {
         ActionManager actionManager = Application.getInstance().getContext().getActionManager();
         actionManager.setLocalName(MAP);
+        return actionManager;
+    }
+
+    public void mousePressed(MouseEvent e) {
+        ActionManager actionManager = getActionManager();
 
         if (e.isPopupTrigger()) {
             popupMenu.show(component, e.getX(), e.getY());
@@ -72,11 +77,9 @@ public class MapViewPopupMenu extends MouseAdapter {
     }
 
     public void mouseReleased(MouseEvent e) {
-        ActionManager actionManager = Application.getInstance().getContext().getActionManager();
-        actionManager.setLocalName(MAP);
+        ActionManager actionManager = getActionManager();
 
         if (e.isPopupTrigger())
             popupMenu.show(component, e.getX(), e.getY());
     }
 }
-

--- a/mapsforge-mapview/src/main/java/slash/navigation/mapview/mapsforge/helpers/MapViewPopupMenu.java
+++ b/mapsforge-mapview/src/main/java/slash/navigation/mapview/mapsforge/helpers/MapViewPopupMenu.java
@@ -29,7 +29,6 @@ import java.awt.event.MouseAdapter;
 import java.awt.event.MouseEvent;
 
 import static javax.swing.SwingUtilities.isLeftMouseButton;
-import static javax.swing.SwingUtilities.isRightMouseButton;
 import static slash.navigation.mapview.mapsforge.models.LocalNames.MAP;
 
 /**
@@ -49,10 +48,15 @@ public class MapViewPopupMenu extends MouseAdapter {
     }
 
     public void mousePressed(MouseEvent e) {
-        if (isLeftMouseButton(e)) {
-            ActionManager actionManager = Application.getInstance().getContext().getActionManager();
-            actionManager.setLocalName(MAP);
+        ActionManager actionManager = Application.getInstance().getContext().getActionManager();
+        actionManager.setLocalName(MAP);
 
+        if (e.isPopupTrigger()) {
+            popupMenu.show(component, e.getX(), e.getY());
+            return;
+        }
+
+        if (isLeftMouseButton(e)) {
             boolean shiftKey = e.isShiftDown();
             boolean altKey = e.isAltDown();
             boolean ctrlKey = e.isControlDown();
@@ -64,9 +68,15 @@ public class MapViewPopupMenu extends MouseAdapter {
                 actionManager.run("new-position");
             else if (!shiftKey && altKey && ctrlKey)
                 actionManager.run("delete");
-
-        } else if (isRightMouseButton(e)) {
-            popupMenu.show(component, e.getX(), e.getY());
         }
     }
+
+    public void mouseReleased(MouseEvent e) {
+        ActionManager actionManager = Application.getInstance().getContext().getActionManager();
+        actionManager.setLocalName(MAP);
+
+        if (e.isPopupTrigger())
+            popupMenu.show(component, e.getX(), e.getY());
+    }
 }
+


### PR DESCRIPTION
Follow-up to #157 (forum thread 4138). `MapViewPopupMenu` decided to show the map context menu with `isRightMouseButton(e)` on `mousePressed` only. `isPopupTrigger()` is the platform-correct gesture — it fires on press on some platforms (macOS/most X11) and on release on others (Windows). `AbstractTablePopupMenu` already does this correctly; this aligns the map popup with that idiom.

## Summary
- Check `e.isPopupTrigger()` in `mousePressed` (in addition to the existing left-button modifier shortcuts) and show the popup menu when true, skipping the left-button dispatch for that gesture.
- Add a `mouseReleased` handler that also shows the popup on `isPopupTrigger()`.
- Drop the now-unused `isRightMouseButton` import; `isLeftMouseButton` stays.

## Why
`isPopupTrigger()` is true on exactly one of press/release per platform, so the popup shows once, with no double-show, and reliably on every platform (previously right-click-to-open only worked because it happened to coincide with `isRightMouseButton` on press).

## Risk
Behaviour change on macOS: `Ctrl`+left-click is the OS popup trigger there, so it now opens the context menu instead of directly running New — this is the intended, accepted behaviour per the linked spec, consistent with the table popup and OS convention. Windows/Linux left-button modifier shortcuts (select/extend/new/delete) are unchanged since their triggers are never `isPopupTrigger()` on a left-button event.

Closes #159.

🤖 Builder.

---
**Builder stats** · model `sonnet` · confidence `0.95` · 1m 3s across 1 round(s) · 1 file op(s)
[Workflow run](http://127.0.0.1:3000/cpesch/RouteConverter/actions/runs/10532)