### PR TITLE
Publish UpdateCatalog.jar + read datasources creds from env (#161)

### DIFF
--- a/.github/workflows/_build-linux-mac.yml
+++ b/.github/workflows/_build-linux-mac.yml
@@ -102,6 +102,10 @@ jobs:
           cp RouteConverterMac/target/RouteConverterMac-x64-app.zip artefacts/
           cp RouteConverterMac/target/RouteConverterMac-aarch64-app.zip artefacts/
           cp RouteConverterCmdLine/target/RouteConverterCmdLine.* artefacts/
+          # Internal ops tool consumed by the rc-meta update-catalog timer
+          # (keeps the brouter-segments checksum set current, #155/#156/#161).
+          # Not user-facing, so it is published unsigned like a plain jar.
+          cp download-tools/target/UpdateCatalog.jar artefacts/
           cp TimeAlbumProLinux/target/TimeAlbumProLinux.* artefacts/
           cp TimeAlbumProMac/target/TimeAlbumProMac-x64-app.zip artefacts/
           cp TimeAlbumProMac/target/TimeAlbumProMac-aarch64-app.zip artefacts/

--- a/download-tools/src/main/java/slash/navigation/download/tools/UpdateCatalog.java
+++ b/download-tools/src/main/java/slash/navigation/download/tools/UpdateCatalog.java
@@ -368,11 +368,20 @@ public class UpdateCatalog extends BaseDownloadTool {
     private void run(String[] args) throws Exception {
         CommandLine line = parseCommandLine(args);
         setId(line.getOptionValue(ID_ARGUMENT));
-        setDataSourcesServer(line.getOptionValue(DATASOURCES_SERVER_ARGUMENT));
-        setDataSourcesUserName(line.getOptionValue(DATASOURCES_USERNAME_ARGUMENT));
-        setDataSourcesPassword(line.getOptionValue(DATASOURCES_PASSWORD_ARGUMENT));
+        // Server and credentials may come from the environment instead of the
+        // command line, so a scheduled runner (e.g. a systemd unit) can inject
+        // them via EnvironmentFile without the password landing in the process
+        // argv / journal command line (GitHub #161).
+        setDataSourcesServer(optionOrEnv(line, DATASOURCES_SERVER_ARGUMENT, "DATASOURCES_SERVER"));
+        setDataSourcesUserName(optionOrEnv(line, DATASOURCES_USERNAME_ARGUMENT, "DATASOURCES_USERNAME"));
+        setDataSourcesPassword(optionOrEnv(line, DATASOURCES_PASSWORD_ARGUMENT, "DATASOURCES_PASSWORD"));
         mirror = new java.io.File(line.getOptionValue(MIRROR_ARGUMENT));
         update();
+    }
+
+    private static String optionOrEnv(CommandLine line, String option, String envName) {
+        String value = line.getOptionValue(option);
+        return value != null ? value : System.getenv(envName);
     }
 
     @SuppressWarnings("AccessStaticViaInstance")


### PR DESCRIPTION
Follow-up to #155/#156; implements #161.

The rc-meta `update-catalog` timer runs `UpdateCatalog` daily to keep the `brouter-segments-4` checksum set current. Two changes make that operable:

**1. Publish `UpdateCatalog.jar` to the prerelease channel.**
`_build-linux-mac.yml` "Stage artefacts" now copies `download-tools/target/UpdateCatalog.jar` alongside `RouteConverterCmdLine.jar`, so it reaches `https://releases.routeconverter.com/prerelease/UpdateCatalog.jar` (where the timer host fetches it). Published **unsigned** — it's an internal ops tool, not a user download, so it stays out of the SignPath jar list.

**2. `UpdateCatalog` reads creds from the environment.**
`run()` now falls back to `DATASOURCES_SERVER` / `DATASOURCES_USERNAME` / `DATASOURCES_PASSWORD` env vars when the matching `--server/--username/--password` option is absent (small `optionOrEnv` helper). A systemd unit can inject them via `EnvironmentFile` so the password never lands in `java`'s argv (`ps` / journal). CLI args still take precedence — existing invocations are unchanged.

Verified: `./mvnw -pl download-tools -am package` builds `UpdateCatalog.jar` (Main-Class `slash.navigation.download.tools.UpdateCatalog`).

After merge, the rc-meta phase-33 unit can drop `--username/--password` from its `ExecStart` and rely on the injected env (small rc-meta follow-up).

Closes #161.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
