### PR TITLE
CI: also publish SnapshotCatalog.jar (#162 follow-up)

### DIFF
--- a/.github/workflows/_build-linux-mac.yml
+++ b/.github/workflows/_build-linux-mac.yml
@@ -102,9 +102,12 @@ jobs:
           cp RouteConverterMac/target/RouteConverterMac-x64-app.zip artefacts/
           cp RouteConverterMac/target/RouteConverterMac-aarch64-app.zip artefacts/
           cp RouteConverterCmdLine/target/RouteConverterCmdLine.* artefacts/
-          # Internal ops tool consumed by the rc-meta update-catalog timer
+          # Internal ops tools consumed by the rc-meta update-catalog timer
           # (keeps the brouter-segments checksum set current, #155/#156/#161).
-          # Not user-facing, so it is published unsigned like a plain jar.
+          # UpdateCatalog only *updates* a catalog that SnapshotCatalog must
+          # download locally first, so both jars ship. Not user-facing, so they
+          # are published unsigned like a plain jar.
+          cp download-tools/target/SnapshotCatalog.jar artefacts/
           cp download-tools/target/UpdateCatalog.jar artefacts/
           cp TimeAlbumProLinux/target/TimeAlbumProLinux.* artefacts/
           cp TimeAlbumProMac/target/TimeAlbumProMac-x64-app.zip artefacts/


### PR DESCRIPTION
Follow-up to #162. The rc-meta `update-catalog` timer runs `SnapshotCatalog` **before** `UpdateCatalog` — `UpdateCatalog.loadDataSource` reads the catalog from a *local* snapshot dir, so it must be downloaded first. #162 only published `UpdateCatalog.jar`; this adds `SnapshotCatalog.jar` to the same "Stage artefacts" step (unsigned internal ops tool).

Found when enabling the phase-33 timer on the host: `IllegalArgumentException: Unknown data source: brouter-segments-4` because no local snapshot existed.

Verified: `./mvnw -pl download-tools -am package` produces `SnapshotCatalog.jar` (Main-Class `slash.navigation.download.tools.SnapshotCatalog`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
