### PR TITLE
Add ArrivalTimeCalculator seam + test (ETA from departure, 1/3)

### DIFF
--- a/common-navigation/src/main/java/slash/navigation/common/ArrivalTimeCalculator.java
+++ b/common-navigation/src/main/java/slash/navigation/common/ArrivalTimeCalculator.java
@@ -1,0 +1,60 @@
+/*
+    This file is part of RouteConverter.
+
+    RouteConverter is free software; you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation; either version 2 of the License, or
+    (at your option) any later version.
+
+    RouteConverter is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with RouteConverter; if not, write to the Free Software
+    Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
+
+    Copyright (C) 2007 Christian Pesch. All Rights Reserved.
+*/
+package slash.navigation.common;
+
+import slash.common.type.CompactCalendar;
+
+import static slash.common.type.CompactCalendar.fromMillis;
+
+/**
+ * Calculates each position's arrival time of day from a single departure time
+ * and the routing durations already calculated as cumulative milliseconds from
+ * the start of the route.
+ *
+ * @author Christian Pesch
+ */
+
+public class ArrivalTimeCalculator {
+
+    /**
+     * Calculates the arrival time of day for each position.
+     * <p>
+     * arrival[i] = departure + cumulativeMillisFromStart[i]. cumulativeMillisFromStart[0]
+     * is expected to be 0, so arrival[0] equals departure exactly. Date roll-over across
+     * midnight is handled since the result is built with {@link CompactCalendar#fromMillis}.
+     *
+     * @param departure                 the departure time; must not be null
+     * @param cumulativeMillisFromStart the cumulative milliseconds from the start of the
+     *                                  route to each position
+     * @return the arrival time of day for each position
+     * @throws IllegalArgumentException if departure is null
+     */
+    public static CompactCalendar[] calculateArrivalTimes(CompactCalendar departure, long[] cumulativeMillisFromStart) {
+        if (departure == null)
+            throw new IllegalArgumentException("departure must not be null");
+
+        CompactCalendar[] arrivalTimes = new CompactCalendar[cumulativeMillisFromStart.length];
+        for (int i = 0; i < cumulativeMillisFromStart.length; i++) {
+            arrivalTimes[i] = fromMillis(departure.getTimeInMillis() + cumulativeMillisFromStart[i]);
+        }
+        return arrivalTimes;
+    }
+}
+

--- a/common-navigation/src/test/java/slash/navigation/common/ArrivalTimeCalculatorTest.java
+++ b/common-navigation/src/test/java/slash/navigation/common/ArrivalTimeCalculatorTest.java
@@ -1,0 +1,85 @@
+/*
+    This file is part of RouteConverter.
+
+    RouteConverter is free software; you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation; either version 2 of the License, or
+    (at your option) any later version.
+
+    RouteConverter is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with RouteConverter; if not, write to the Free Software
+    Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
+
+    Copyright (C) 2007 Christian Pesch. All Rights Reserved.
+*/
+package slash.navigation.common;
+
+import org.junit.Test;
+import slash.common.type.CompactCalendar;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static slash.common.type.CompactCalendar.fromMillis;
+
+/**
+ * Tests {@link ArrivalTimeCalculator}.
+ *
+ * @author Christian Pesch
+ */
+
+public class ArrivalTimeCalculatorTest {
+
+    @Test
+    public void calculatesArrivalTimesFromCumulativeMillis() {
+        CompactCalendar departure = fromMillis(9 * 3600 * 1000L);
+        long[] cumulativeMillisFromStart = {0, 3_600_000, 7_200_000};
+
+        CompactCalendar[] arrivalTimes = ArrivalTimeCalculator.calculateArrivalTimes(departure, cumulativeMillisFromStart);
+
+        assertEquals(3, arrivalTimes.length);
+        assertEquals(departure, arrivalTimes[0]);
+        assertEquals(fromMillis(10 * 3600 * 1000L), arrivalTimes[1]);
+        assertEquals(fromMillis(11 * 3600 * 1000L), arrivalTimes[2]);
+    }
+
+    @Test
+    public void singlePositionArrivesAtDeparture() {
+        CompactCalendar departure = fromMillis(0);
+
+        CompactCalendar[] arrivalTimes = ArrivalTimeCalculator.calculateArrivalTimes(departure, new long[]{0});
+
+        assertEquals(1, arrivalTimes.length);
+        assertEquals(departure, arrivalTimes[0]);
+    }
+
+    @Test
+    public void emptyInputReturnsEmptyArray() {
+        CompactCalendar[] arrivalTimes = ArrivalTimeCalculator.calculateArrivalTimes(fromMillis(0), new long[0]);
+
+        assertEquals(0, arrivalTimes.length);
+    }
+
+    @Test
+    public void departureCrossingMidnightRollsDateForward() {
+        long departureMillis = (23 * 3600 + 30 * 60) * 1000L;
+        CompactCalendar departure = fromMillis(departureMillis);
+        long[] cumulativeMillisFromStart = {0, 3_600_000};
+
+        CompactCalendar[] arrivalTimes = ArrivalTimeCalculator.calculateArrivalTimes(departure, cumulativeMillisFromStart);
+
+        assertEquals(departureMillis, arrivalTimes[0].getTimeInMillis());
+        assertEquals(departureMillis + 3_600_000, arrivalTimes[1].getTimeInMillis());
+        assertFalse(arrivalTimes[0].sameDay(arrivalTimes[1]));
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void nullDepartureThrowsIllegalArgumentException() {
+        ArrivalTimeCalculator.calculateArrivalTimes(null, new long[]{0});
+    }
+}
+


### PR DESCRIPTION
Closes #172.

## Summary
- Add a pure `ArrivalTimeCalculator.calculateArrivalTimes(departure, cumulativeMillisFromStart)` to `common-navigation`, deriving each position's arrival time-of-day from a departure time and the already-calculated cumulative routing duration.
- Add `ArrivalTimeCalculatorTest` covering same-day arrivals, a single position, empty input, midnight roll-over, and a null-departure guard.

## Why
Step 1 of 3 towards support request #1323 (mail triage): let the user set a departure time and see each waypoint's arrival time-of-day. This PR ships only the headless, pure arithmetic seam that steps 2-3 build on; no GUI, action, dialog, menu, `PositionAugmenter`, or i18n changes (those are #166b/#166c).

## Risk
Low — adds one new pure class + one new test class in `common-navigation`; no existing code is touched and no other module is affected.

🤖 Builder.

---
**Builder stats** · model `sonnet` · confidence `0.95` · 1m 41s across 1 round(s) · 2 file op(s)
[Workflow run](http://127.0.0.1:3000/cpesch/RouteConverter/actions/runs/12152)