### PR TITLE
Fix online map not restored on startup (forum #4140)

### DIFF
--- a/mapsforge-mapview/src/main/java/slash/navigation/mapview/mapsforge/MapsforgeMapView.java
+++ b/mapsforge-mapview/src/main/java/slash/navigation/mapview/mapsforge/MapsforgeMapView.java
@@ -181,6 +181,19 @@ public class MapsforgeMapView extends BaseMapView {
             case DELETE -> this.overlayManager.delete(e.getFirstRow(), e.getLastRow());
         }
     };
+    private final TableModelListener availableMapsListener = e -> {
+        // The online tile-server list loads asynchronously (scanTileServers) after
+        // the first render, so at startup a persisted online map isn't resolvable
+        // yet and the displayed-map model falls back to the OpenStreetMap default.
+        // Once the list arrives, re-apply the persisted selection if it now
+        // resolves to a map that isn't the one currently on screen. Mirrors the
+        // offline re-scan re-apply in RouteConverter#scanLocalMapsAndThemes.
+        if (this.mapsToLayers.isEmpty())
+            return; // not rendered yet — the first render applies what resolves
+        LocalMap displayed = getMapManager().getDisplayedMapModel().getItem();
+        if (displayed != null && !this.mapsToLayers.containsKey(displayed))
+            handleMapAndThemeUpdate(false, false);
+    };
     private final ChangeListener shadedHillsListener = e -> {
         handleShadedHills();
         handleMapAndThemeUpdate(false, false);
@@ -463,6 +476,7 @@ public class MapsforgeMapView extends BaseMapView {
         });
 
         getMapManager().getDisplayedMapModel().addChangeListener(displayedMapListener);
+        getMapManager().getAvailableMapsModel().addTableModelListener(availableMapsListener);
         getMapManager().getAppliedThemeModel().addChangeListener(appliedThemeListener);
         getMapManager().getAppliedThemeStyleModel().addChangeListener(appliedThemeStyleListener);
         mapViewCallback.getTileServerMapManager().getAppliedOverlaysModel().addTableModelListener(appliedOverlayListener);
@@ -727,6 +741,7 @@ public class MapsforgeMapView extends BaseMapView {
 
     public void dispose() {
         getMapManager().getDisplayedMapModel().removeChangeListener(displayedMapListener);
+        getMapManager().getAvailableMapsModel().removeTableModelListener(availableMapsListener);
         getMapManager().getAppliedThemeModel().removeChangeListener(appliedThemeListener);
         getMapManager().getAppliedThemeStyleModel().removeChangeListener(appliedThemeStyleListener);
         mapViewCallback.getTileServerMapManager().getAppliedOverlaysModel().removeTableModelListener(appliedOverlayListener);


### PR DESCRIPTION
## Problem (forum #4140)

For **online maps**, after startup RouteConverter always shows the OpenStreetMap
default map regardless of the persisted selection. Toggling maps once restores
the desired map. If the last-selected map was a **Mapsforge (offline)** map,
startup is correct.

## Root cause

The online tile-server list is populated asynchronously (`scanTileServers`, after
two chained network downloads in `BaseRouteConverter#openMapAndProfileView`). The
map view's first render (`MapsforgeMapView#handleMapAndThemeUpdate`) reads the
persisted displayed map *before* that list exists, so an online selection isn't
resolvable yet and `ItemModel#getItem()` falls back to the OpenStreetMap default.

The **offline** path already recovers from this: `RouteConverter#scanLocalMapsAndThemes`
re-reads the displayed-map model after `scanMaps()` and re-applies it if it changed.
The **online** path had no equivalent re-apply, so the OSM fallback stayed on screen
until the user manually toggled a map (which fires `displayedMapListener` → re-render).

## Fix

A `TableModelListener` on the available-maps model in `MapsforgeMapView`: once the
online list arrives, re-apply the persisted selection if it now resolves to a map
that isn't the one currently on screen. Guarded by `mapsToLayers` so it fires at
most once, and is a no-op for OSM users and the offline path.

15 lines, one file. Compiles clean; verified no regression against a real profile
(persisted online map still loads correctly at startup with the listener present).

Reported: https://forum.routeconverter.com/thread-4140.html