### PR TITLE
bump brouter 1.7.8 → 1.7.10

### DIFF
--- a/brouter/pom.xml
+++ b/brouter/pom.xml
@@ -11,7 +11,7 @@
     </parent>
 
     <properties>
-        <brouter.version>1.7.8</brouter.version>
+        <brouter.version>1.7.10</brouter.version>
     </properties>
 
     <dependencies>

--- a/route-converter-cmdline/pom.xml
+++ b/route-converter-cmdline/pom.xml
@@ -12,7 +12,7 @@
 
     <properties>
         <!-- keep in sync with brouter/pom.xml: the analyze BRouter length seam reuses these -->
-        <brouter.version>1.7.8</brouter.version>
+        <brouter.version>1.7.10</brouter.version>
     </properties>
 
     <dependencies>


### PR DESCRIPTION
Ships upstream v1.7.10 (17 Jul 2026, [4d2639af](https://github.com/abrensch/brouter/commit/4d2639af)). The BRouter engine reads `lookupversion` dynamically from `lookups.dat`, so 1.7.8 already accepted v11 segment files given a matching profile bundle — but staying current avoids drift and picks up v1.7.9's pseudo way/node tag database + kinematic class updates.

**Companion:** rc-thirdparty [PR #1](https://git.routeconverter.com/rc/rc-thirdparty/pulls/1) registers the SHA-256s of the 10 new artifact files at `mvn.routeconverter.com`.

**Trigger:** `granada.gpx` routing incident 2026-07-19 — brouter.de had moved segment files to lookupversion 11 while local `~/.routeconverter/brouter/profiles/lookups.dat` still declared version 10, so every routed leg red-lined with `datafile W5_N35.rd5 not found`. Upstream tracking prevents this recurring.

**Verified locally:** `mvn -pl brouter,route-converter-cmdline -am test` → BUILD SUCCESS, all tests green on Java 21.0.11.

**Not in scope here** (separate follow-ups):
- The `brouter` git submodule pin on rc-meta advances to `v1.7.10` — deliberately not bumped from this PR per rc-meta AGENTS submodule rule; maintainer batches.
- The 5 pre-existing malformed `maven-metadata.xml` files at mvn.routeconverter.com were rebuilt from directory truth in the same host session (also adds the missing 1.7.8 to the version list). No repo change.