### PR TITLE
ci(macos): gated Developer ID signing + notarisation pipeline

### DIFF
--- a/.github/signing/entitlements.plist
+++ b/.github/signing/entitlements.plist
@@ -1,0 +1,18 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN"
+  "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<!--
+  Hardened Runtime entitlements for the bundled-JRE RouteConverter.app.
+  - allow-jit / allow-unsigned-executable-memory: the JVM JITs bytecode into
+    executable memory pages at runtime.
+  - disable-library-validation: Java dlopen()s third-party dylibs (mapsforge,
+    JNI libs) that are not signed by our Team ID.
+  - allow-dyld-environment-variables: the launcher sets JAVA/DYLD env vars.
+  See rc-meta specs (macOS signing prep).
+-->
+<plist version="1.0"><dict>
+  <key>com.apple.security.cs.allow-jit</key><true/>
+  <key>com.apple.security.cs.allow-unsigned-executable-memory</key><true/>
+  <key>com.apple.security.cs.disable-library-validation</key><true/>
+  <key>com.apple.security.cs.allow-dyld-environment-variables</key><true/>
+</dict></plist>

--- a/.github/workflows/_sign-mac.yml
+++ b/.github/workflows/_sign-mac.yml
@@ -1,0 +1,196 @@
+name: _sign-mac
+
+# Reusable workflow: consumes the unsigned RouteConverterMac-{x64,aarch64}-app.zip
+# artefacts produced by _build-linux-mac.yml, code-signs each RouteConverter.app
+# with a Hardened Runtime on a macos-latest runner, then (creds present)
+# notarises + staples. Re-zips and uploads the signed app zips under a name that
+# does NOT match the caller's prerelease-*/release-* flatten pattern, so publish
+# overlays them explicitly (see prerelease.yml / release.yml).
+#
+# Called by:
+#   - prerelease.yml (signed-artefact: mac-signed-prerelease)
+#   - release.yml    (signed-artefact: mac-signed-release)
+#
+# CREDENTIAL GATE — the whole Apple path is conditional on the four MACOS_*
+# secrets being set:
+#   creds present -> Developer ID Application signing + notarytool + stapler
+#   creds ABSENT  -> ad-hoc signing (--sign -); notarise/staple SKIPPED
+# So this workflow runs green with NO Apple Developer subscription, and flips to
+# real signing the moment the secrets land — no YAML rewrite.
+#
+# codesign is applied inner-out: every nested Mach-O (JRE dylibs/binaries,
+# jnilibs) first, then the .app bundle last with the entitlements. --deep is
+# NEVER used to sign a notarised bundle (notarytool rejects deep-signed nested
+# code); --deep is only used to *verify*.
+#
+# See rc-meta specs (macOS signing prep).
+
+on:
+  workflow_call:
+    inputs:
+      unsigned-artefact:
+        description: 'Name of the artefact holding the unsigned Mac app zips'
+        required: true
+        type: string
+      signed-artefact:
+        description: 'Name for the uploaded signed artefact'
+        required: true
+        type: string
+      retention-days:
+        description: 'Retention in days for the signed artefact'
+        required: false
+        type: number
+        default: 7
+    secrets:
+      MACOS_CERTIFICATE_BASE64:
+        # base64 of the Developer ID Application .p12 (cert + private key)
+        required: false
+      MACOS_CERTIFICATE_PASSWORD:
+        # password used when exporting the .p12
+        required: false
+      MACOS_SIGN_IDENTITY:
+        # "Developer ID Application: Name (TEAMID)"
+        required: false
+      MACOS_NOTARY_PROFILE_B64:
+        # base64 of JSON {"appleId":"..","teamId":"..","password":"app-specific-pw"}
+        required: false
+
+jobs:
+  sign:
+    runs-on: macos-latest
+    steps:
+      - uses: actions/checkout@v5
+
+      - uses: actions/download-artifact@v8
+        with:
+          name: ${{ inputs.unsigned-artefact }}
+          path: unsigned/
+
+      - name: Resolve signing mode
+        id: mode
+        env:
+          CERT_B64: ${{ secrets.MACOS_CERTIFICATE_BASE64 }}
+        run: |
+          if [[ -n "$CERT_B64" ]]; then
+            echo "real=true"  >> "$GITHUB_OUTPUT"
+            echo "::notice::MACOS_CERTIFICATE_BASE64 present -> Developer ID signing + notarisation"
+          else
+            echo "real=false" >> "$GITHUB_OUTPUT"
+            echo "::warning::No Apple certificate secret -> AD-HOC signing, notarisation SKIPPED"
+          fi
+
+      - name: Import Developer ID certificate
+        if: steps.mode.outputs.real == 'true'
+        env:
+          CERT_B64: ${{ secrets.MACOS_CERTIFICATE_BASE64 }}
+          CERT_PW:  ${{ secrets.MACOS_CERTIFICATE_PASSWORD }}
+        run: |
+          set -euo pipefail
+          KEYCHAIN="$RUNNER_TEMP/rc-signing.keychain-db"
+          KC_PW=$(uuidgen)                                   # throwaway keychain password
+          echo "$CERT_B64" | base64 --decode > "$RUNNER_TEMP/cert.p12"
+          security create-keychain -p "$KC_PW" "$KEYCHAIN"
+          security set-keychain-settings -lut 3600 "$KEYCHAIN"   # auto-lock guard
+          security unlock-keychain -p "$KC_PW" "$KEYCHAIN"
+          security import "$RUNNER_TEMP/cert.p12" -k "$KEYCHAIN" \
+            -P "$CERT_PW" -T /usr/bin/codesign
+          # allow codesign to use the key without an interactive prompt
+          security set-key-partition-list -S apple-tool:,apple:,codesign: \
+            -k "$KC_PW" "$KEYCHAIN" >/dev/null
+          # make the temp keychain searchable alongside login.keychain
+          security list-keychains -d user -s "$KEYCHAIN" login.keychain-db
+          rm -f "$RUNNER_TEMP/cert.p12"
+
+      - name: Sign, (notarise), staple
+        env:
+          REAL:         ${{ steps.mode.outputs.real }}
+          IDENTITY:     ${{ secrets.MACOS_SIGN_IDENTITY }}
+          NOTARY_B64:   ${{ secrets.MACOS_NOTARY_PROFILE_B64 }}
+          ENTITLEMENTS: ${{ github.workspace }}/.github/signing/entitlements.plist
+        run: |
+          set -euo pipefail
+          mkdir -p signed
+
+          if [[ "$REAL" == "true" ]]; then
+            SIGN_ID="$IDENTITY"
+            RUNTIME_FLAGS=(--options runtime --timestamp)    # Hardened Runtime + secure timestamp
+            NP="$RUNNER_TEMP/notary.json"
+            echo "$NOTARY_B64" | base64 --decode > "$NP"
+            xcrun notarytool store-credentials rc-notary \
+              --apple-id "$(jq -r .appleId  "$NP")" \
+              --team-id  "$(jq -r .teamId   "$NP")" \
+              --password "$(jq -r .password "$NP")" >/dev/null
+            rm -f "$NP"
+          else
+            SIGN_ID="-"                                      # ad-hoc
+            RUNTIME_FLAGS=(--options runtime)                # no --timestamp for ad-hoc
+          fi
+
+          for arch in x64 aarch64; do
+            zip="unsigned/RouteConverterMac-${arch}-app.zip"
+            [[ -f "$zip" ]] || { echo "::error::missing $zip in ${{ inputs.unsigned-artefact }}"; exit 1; }
+            work="$RUNNER_TEMP/$arch"; rm -rf "$work"; mkdir -p "$work"
+            ditto -x -k "$zip" "$work"
+            APP="$work/RouteConverter.app"
+            [[ -d "$APP" ]] || { echo "::error::no RouteConverter.app inside $zip"; exit 1; }
+
+            # 1) inner Mach-O: JRE dylibs, .jnilib, jspawnhelper
+            find "$APP/Contents" \
+                 \( -name '*.dylib' -o -name '*.jnilib' -o -name 'jspawnhelper' \) \
+                 -type f -print0 \
+              | xargs -0 -I{} codesign --force "${RUNTIME_FLAGS[@]}" \
+                  --sign "$SIGN_ID" --entitlements "$ENTITLEMENTS" {}
+
+            # JRE executables under Contents/bin (java, etc.)
+            if [[ -d "$APP/Contents/bin" ]]; then
+              find "$APP/Contents/bin" -type f -print0 \
+                | xargs -0 -I{} codesign --force "${RUNTIME_FLAGS[@]}" \
+                    --sign "$SIGN_ID" --entitlements "$ENTITLEMENTS" {}
+            fi
+
+            # 1b) Mach-O dylibs EMBEDDED inside the fat jar. notarytool scans
+            # inside jars; sqlite-jdbc (via mapsforge-poi/mbtiles) ships
+            # org/sqlite/native/Mac/{x86_64,aarch64}/libsqlitejdbc.dylib, which
+            # are unsigned Mach-O and would fail notarisation. Extract-sign-repack
+            # each in place, BEFORE the bundle is sealed. Non-Mach-O natives
+            # (Linux .so, Windows .dll) are ignored by notarisation, so skipped.
+            # bash-3.2 safe (macOS default): no mapfile/associative arrays.
+            find "$APP/Contents/Java" -name '*.jar' -type f -print0 \
+            | while IFS= read -r -d '' JAR; do
+                JAR="$(cd "$(dirname "$JAR")" && pwd)/$(basename "$JAR")"   # absolutise for `zip -u`
+                dylibs=$(unzip -Z1 "$JAR" 2>/dev/null | grep -E '\.dylib$' || true)
+                [ -z "$dylibs" ] && continue
+                jtmp="$RUNNER_TEMP/jar-$arch"; rm -rf "$jtmp"; mkdir -p "$jtmp"
+                printf '%s\n' "$dylibs" | while IFS= read -r d; do
+                  [ -z "$d" ] && continue
+                  unzip -o -q "$JAR" "$d" -d "$jtmp"
+                  codesign --force "${RUNTIME_FLAGS[@]}" \
+                    --sign "$SIGN_ID" --entitlements "$ENTITLEMENTS" "$jtmp/$d"
+                  ( cd "$jtmp" && zip -q "$JAR" "$d" )       # replace entry in the jar
+                  echo "signed embedded $d in $(basename "$JAR")"
+                done
+              done
+
+            # 2) the bundle LAST (covers the launcher + Info.plist seal)
+            codesign --force "${RUNTIME_FLAGS[@]}" \
+              --sign "$SIGN_ID" --entitlements "$ENTITLEMENTS" "$APP"
+            codesign --verify --deep --strict --verbose=2 "$APP"
+
+            if [[ "$REAL" == "true" ]]; then
+              # notarytool wants a container, not a raw .app
+              subm="$RUNNER_TEMP/RouteConverterMac-${arch}.zip"
+              ditto -c -k --keepParent "$APP" "$subm"
+              xcrun notarytool submit "$subm" --keychain-profile rc-notary --wait
+              xcrun stapler staple "$APP"
+              xcrun stapler validate "$APP"
+            fi
+
+            ditto -c -k --keepParent "$APP" "signed/RouteConverterMac-${arch}-app.zip"
+          done
+          ls -la signed/
+
+      - uses: actions/upload-artifact@v7
+        with:
+          name: ${{ inputs.signed-artefact }}
+          path: signed/
+          retention-days: ${{ inputs.retention-days }}

--- a/.github/workflows/prerelease.yml
+++ b/.github/workflows/prerelease.yml
@@ -45,8 +45,17 @@ jobs:
       # for release.yml. (rc-meta specs/00043.)
     secrets: inherit
 
+  sign-mac:
+    needs: build-linux-mac
+    uses: ./.github/workflows/_sign-mac.yml
+    with:
+      unsigned-artefact: prerelease-linux-mac
+      signed-artefact:   mac-signed-prerelease
+      retention-days:    7
+    secrets: inherit
+
   publish:
-    needs: [build-linux-mac, build-windows]
+    needs: [build-linux-mac, build-windows, sign-mac]
     runs-on: ubuntu-latest
     steps:
       - uses: actions/download-artifact@v8
@@ -57,6 +66,18 @@ jobs:
         run: |
           mkdir -p artefacts
           find incoming -mindepth 2 -type f -exec mv -t artefacts/ {} +
+          ls -la artefacts/
+      - name: Overlay signed Mac app zips
+        # mac-signed-prerelease is outside the prerelease-* pattern above, so it
+        # is downloaded separately and copied LAST — the signed RouteConverterMac
+        # zips deterministically replace the unsigned ones from build-linux-mac.
+        uses: actions/download-artifact@v8
+        with:
+          name: mac-signed-prerelease
+          path: mac-signed
+      - name: Apply signed Mac overlay
+        run: |
+          cp mac-signed/RouteConverterMac-*-app.zip artefacts/
           ls -la artefacts/
       - name: Configure SSH
         env:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -32,8 +32,17 @@ jobs:
       signing-policy-slug: release-signing   # production cert (rc-meta 00043); requires manual approval in the SignPath app during the build
     secrets: inherit
 
+  sign-mac:
+    needs: build-linux-mac
+    uses: ./.github/workflows/_sign-mac.yml
+    with:
+      unsigned-artefact: release-linux-mac
+      signed-artefact:   mac-signed-release
+      retention-days:    30
+    secrets: inherit
+
   publish:
-    needs: [build-linux-mac, build-windows]
+    needs: [build-linux-mac, build-windows, sign-mac]
     runs-on: ubuntu-latest
     steps:
       - name: Resolve version from tag
@@ -51,6 +60,19 @@ jobs:
         run: |
           mkdir -p artefacts
           find incoming -mindepth 2 -type f -exec mv -t artefacts/ {} +
+          ls -la artefacts/
+      - name: Overlay signed Mac app zips
+        # mac-signed-release is outside the release-* pattern above, so it is
+        # downloaded separately and copied LAST — the signed RouteConverterMac
+        # zips deterministically replace the unsigned ones from build-linux-mac,
+        # BEFORE the *-app.zip -> *.app.zip rename below.
+        uses: actions/download-artifact@v8
+        with:
+          name: mac-signed-release
+          path: mac-signed
+      - name: Apply signed Mac overlay
+        run: |
+          cp mac-signed/RouteConverterMac-*-app.zip artefacts/
           ls -la artefacts/
       - name: Build previous-releases archive (apply *-app.zip rename)
         env:


### PR DESCRIPTION
## What

Prepares the full macOS code-signing + notarisation pipeline so it works the moment an Apple Developer subscription lands — no core rewrite needed.

### New
- **`.github/workflows/_sign-mac.yml`** — reusable workflow, `macos-latest`. Signs each `RouteConverter.app` with a Hardened Runtime + JIT entitlements, then notarises + staples.
- **`.github/signing/entitlements.plist`** — JIT / unsigned-exec-mem / disable-library-validation / dyld-env entitlements for the bundled-JRE Swing app.

### Credential gate (runs green today)
Keys off the `MACOS_*` secrets:
- **present** → real Developer ID signing + `notarytool` + `stapler`
- **absent** → ad-hoc (`--sign -`), notarise/staple skipped

So the pipeline is exercised end-to-end **without an Apple subscription**; paste the 4 secrets later and it flips to real signing with zero YAML edits.

### Signing correctness
- Inner-out: JRE dylibs / `Contents/bin` / `jspawnhelper` first, bundle last. Never `--deep` for signing a notarised bundle.
- **Embedded-jar Mach-O:** `RouteConverterMac.jar` ships `sqlite-jdbc 3.53.2.0` (via `mapsforge-poi`/`mapsforge-mbtiles`) with `org/sqlite/native/Mac/{x86_64,aarch64}/libsqlitejdbc.dylib`. notarytool recurses into jars and would reject these as unsigned nested code — the workflow extract-sign-repacks them before sealing the bundle. bash-3.2-safe.

### Wiring
`sign-mac` job added to `prerelease.yml` + `release.yml`: consumes the unsigned linux-mac artefact, publishes signed app zips under a name **outside** the flatten glob, then publish overlays them over the unsigned ones deterministically (before the `-app.zip` → `.app.zip` rename in release).

## Secrets to add later
`MACOS_CERTIFICATE_BASE64`, `MACOS_CERTIFICATE_PASSWORD`, `MACOS_SIGN_IDENTITY`, `MACOS_NOTARY_PROFILE_B64` (base64 JSON `{appleId, teamId, password}`).

## Test now
Merge → next master push runs the ad-hoc dry-run (pack → sign → verify → overlay) green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)