### PR TITLE
Times from Departure action: dialog + menu wiring (ETA from departure, 3/3)

### DIFF
--- a/route-converter-gui/src/main/java/slash/navigation/converter/gui/actions/AddDepartureTimeToPositionsAction.java
+++ b/route-converter-gui/src/main/java/slash/navigation/converter/gui/actions/AddDepartureTimeToPositionsAction.java
@@ -1,0 +1,37 @@
+/*
+    This file is part of BaseRouteConverter.
+
+    BaseRouteConverter is free software; you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation; either version 2 of the License, or
+    (at your option) any later version.
+
+    BaseRouteConverter is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with BaseRouteConverter; if not, write to the Free Software
+    Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
+
+    Copyright (C) 2007 Christian Pesch. All Rights Reserved.
+*/
+
+package slash.navigation.converter.gui.actions;
+
+import slash.navigation.converter.gui.dialogs.DepartureTimeDialog;
+import slash.navigation.gui.actions.FrameAction;
+
+/**
+ * Opens a {@link DepartureTimeDialog} to set a departure time and fill each position
+ * of the current route with its arrival time computed from the routing durations.
+ *
+ * @author Christian Pesch
+ */
+
+public class AddDepartureTimeToPositionsAction extends FrameAction {
+    public void run() {
+        new DepartureTimeDialog().showWithPreferences();
+    }
+}

--- a/route-converter-gui/src/main/java/slash/navigation/converter/gui/dialogs/DepartureTimeDialog.form
+++ b/route-converter-gui/src/main/java/slash/navigation/converter/gui/dialogs/DepartureTimeDialog.form
@@ -1,0 +1,81 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<form xmlns="http://www.intellij.com/uidesigner/form/" version="1" bind-to-class="slash.navigation.converter.gui.dialogs.DepartureTimeDialog">
+  <grid id="cbd77" binding="contentPane" layout-manager="GridLayoutManager" row-count="3" column-count="1" same-size-horizontally="false" same-size-vertically="false" hgap="-1" vgap="-1">
+    <margin top="10" left="10" bottom="10" right="10"/>
+    <constraints>
+      <xy x="48" y="54" width="480" height="140"/>
+    </constraints>
+    <properties/>
+    <border type="none"/>
+    <children>
+      <grid id="a1001" layout-manager="GridLayoutManager" row-count="1" column-count="2" same-size-horizontally="false" same-size-vertically="false" hgap="-1" vgap="-1">
+        <margin top="0" left="0" bottom="0" right="0"/>
+        <constraints>
+          <grid row="0" column="0" row-span="1" col-span="1" vsize-policy="3" hsize-policy="3" anchor="0" fill="3" indent="0" use-parent-layout="false"/>
+        </constraints>
+        <properties/>
+        <border type="none"/>
+        <children>
+          <component id="a1002" class="javax.swing.JLabel" binding="labelDeparture">
+            <constraints>
+              <grid row="0" column="0" row-span="1" col-span="1" vsize-policy="0" hsize-policy="0" anchor="8" fill="0" indent="0" use-parent-layout="false"/>
+            </constraints>
+            <properties>
+              <text value=""/>
+            </properties>
+          </component>
+          <component id="a1003" class="javax.swing.JTextField" binding="textFieldDeparture">
+            <constraints>
+              <grid row="0" column="1" row-span="1" col-span="1" vsize-policy="0" hsize-policy="6" anchor="8" fill="1" indent="0" use-parent-layout="false">
+                <preferred-size width="200" height="-1"/>
+              </grid>
+            </constraints>
+            <properties/>
+          </component>
+        </children>
+      </grid>
+      <grid id="a1004" layout-manager="GridLayoutManager" row-count="1" column-count="1" same-size-horizontally="false" same-size-vertically="false" hgap="-1" vgap="-1">
+        <margin top="0" left="0" bottom="0" right="0"/>
+        <constraints>
+          <grid row="1" column="0" row-span="1" col-span="1" vsize-policy="3" hsize-policy="3" anchor="0" fill="3" indent="0" use-parent-layout="false">
+            <minimum-size width="-1" height="10"/>
+          </grid>
+        </constraints>
+        <properties/>
+        <border type="none"/>
+        <children/>
+      </grid>
+      <grid id="a1005" layout-manager="GridLayoutManager" row-count="1" column-count="3" same-size-horizontally="false" same-size-vertically="false" hgap="-1" vgap="-1">
+        <margin top="0" left="0" bottom="0" right="0"/>
+        <constraints>
+          <grid row="2" column="0" row-span="1" col-span="1" vsize-policy="1" hsize-policy="3" anchor="0" fill="3" indent="0" use-parent-layout="false"/>
+        </constraints>
+        <properties/>
+        <border type="none"/>
+        <children>
+          <component id="a1006" class="javax.swing.JButton" binding="buttonOk">
+            <constraints>
+              <grid row="0" column="0" row-span="1" col-span="1" vsize-policy="0" hsize-policy="3" anchor="0" fill="1" indent="0" use-parent-layout="false"/>
+            </constraints>
+            <properties>
+              <text resource-bundle="slash/navigation/converter/gui/RouteConverter" key="ok"/>
+            </properties>
+          </component>
+          <hspacer id="a1007">
+            <constraints>
+              <grid row="0" column="1" row-span="1" col-span="1" vsize-policy="1" hsize-policy="6" anchor="0" fill="1" indent="0" use-parent-layout="false"/>
+            </constraints>
+          </hspacer>
+          <component id="a1008" class="javax.swing.JButton" binding="buttonCancel">
+            <constraints>
+              <grid row="0" column="2" row-span="1" col-span="1" vsize-policy="0" hsize-policy="3" anchor="0" fill="1" indent="0" use-parent-layout="false"/>
+            </constraints>
+            <properties>
+              <text resource-bundle="slash/navigation/converter/gui/RouteConverter" key="cancel"/>
+            </properties>
+          </component>
+        </children>
+      </grid>
+    </children>
+  </grid>
+</form>

--- a/route-converter-gui/src/main/java/slash/navigation/converter/gui/dialogs/DepartureTimeDialog.java
+++ b/route-converter-gui/src/main/java/slash/navigation/converter/gui/dialogs/DepartureTimeDialog.java
@@ -1,0 +1,244 @@
+/*
+    This file is part of BaseRouteConverter.
+
+    BaseRouteConverter is free software; you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation; either version 2 of the License, or
+    (at your option) any later version.
+
+    BaseRouteConverter is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with BaseRouteConverter; if not, write to the Free Software
+    Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
+
+    Copyright (C) 2007 Christian Pesch. All Rights Reserved.
+*/
+
+package slash.navigation.converter.gui.dialogs;
+
+import com.intellij.uiDesigner.core.GridConstraints;
+import com.intellij.uiDesigner.core.GridLayoutManager;
+import com.intellij.uiDesigner.core.Spacer;
+import slash.common.helpers.DateTimeParserException;
+import slash.common.helpers.DateTimeParserFormatter;
+import slash.common.io.Transfer;
+import slash.common.type.CompactCalendar;
+import slash.navigation.common.NavigationPosition;
+import slash.navigation.converter.gui.BaseRouteConverter;
+import slash.navigation.converter.gui.models.PositionsModel;
+import slash.navigation.gui.SimpleDialog;
+import slash.navigation.gui.actions.DialogAction;
+
+import javax.swing.*;
+import java.awt.*;
+import java.awt.event.WindowAdapter;
+import java.awt.event.WindowEvent;
+import java.lang.reflect.Method;
+import java.util.Calendar;
+import java.util.ResourceBundle;
+import java.util.TimeZone;
+
+import static java.awt.event.KeyEvent.VK_ESCAPE;
+import static java.text.MessageFormat.format;
+import static javax.swing.JComponent.WHEN_ANCESTOR_OF_FOCUSED_COMPONENT;
+import static javax.swing.KeyStroke.getKeyStroke;
+import static slash.common.type.CompactCalendar.fromMillis;
+import static slash.common.type.CompactCalendar.fromMillisAndTimeZone;
+import static slash.navigation.gui.helpers.JMenuHelper.setMnemonic;
+import static slash.navigation.gui.helpers.WindowHelper.showError;
+
+/**
+ * Dialog to enter a departure time; on confirmation fills every position of the
+ * current route with its arrival time via {@link slash.navigation.converter.gui.helpers.PositionAugmenter#addDepartureTimes}.
+ *
+ * @author Christian Pesch
+ */
+
+public class DepartureTimeDialog extends SimpleDialog {
+    private JPanel contentPane;
+    private JLabel labelDeparture;
+    private JTextField textFieldDeparture;
+    private JButton buttonOk;
+    private JButton buttonCancel;
+
+    public DepartureTimeDialog() {
+        super(BaseRouteConverter.getInstance().getFrame(), "departure-time");
+        setTitle(BaseRouteConverter.getBundle().getString("departure-time-dialog-title"));
+        setContentPane(contentPane);
+        setModal(true);
+        getRootPane().setDefaultButton(buttonOk);
+
+        labelDeparture.setText(BaseRouteConverter.getBundle().getString("departure-time-label"));
+        textFieldDeparture.setText(getPrefillText());
+
+        buttonOk.addActionListener(new DialogAction(this) {
+            public void run() {
+                ok();
+            }
+        });
+
+        setMnemonic(buttonCancel, "cancel-mnemonic");
+        buttonCancel.addActionListener(new DialogAction(this) {
+            public void run() {
+                cancel();
+            }
+        });
+
+        setDefaultCloseOperation(DO_NOTHING_ON_CLOSE);
+        addWindowListener(new WindowAdapter() {
+            public void windowClosing(WindowEvent e) {
+                cancel();
+            }
+        });
+
+        contentPane.registerKeyboardAction(new DialogAction(this) {
+            public void run() {
+                cancel();
+            }
+        }, getKeyStroke(VK_ESCAPE, 0), WHEN_ANCESTOR_OF_FOCUSED_COMPONENT);
+    }
+
+    private DateTimeParserFormatter getDateTimeFormat() {
+        String timeZoneId = BaseRouteConverter.getInstance().getTimeZone().getTimeZoneId();
+        return Transfer.getDateTimeFormat(timeZoneId);
+    }
+
+    private String getPrefillText() {
+        PositionsModel positionsModel = BaseRouteConverter.getInstance().getConvertPanel().getPositionsModel();
+        if (positionsModel.getRowCount() > 0) {
+            NavigationPosition first = positionsModel.getPosition(0);
+            if (first.hasTime())
+                return getDateTimeFormat().format(first.getTime());
+        }
+
+        // otherwise prefill today at 09:00 in the application's configured time zone
+        TimeZone timeZone = BaseRouteConverter.getInstance().getTimeZone().getTimeZone();
+        Calendar calendar = Calendar.getInstance(timeZone);
+        calendar.set(Calendar.HOUR_OF_DAY, 9);
+        calendar.set(Calendar.MINUTE, 0);
+        calendar.set(Calendar.SECOND, 0);
+        calendar.set(Calendar.MILLISECOND, 0);
+        return getDateTimeFormat().format(fromMillis(calendar.getTimeInMillis()));
+    }
+
+    private void ok() {
+        DateTimeParserFormatter formatter = getDateTimeFormat();
+        CompactCalendar departure;
+        try {
+            Calendar parsed = formatter.parse(textFieldDeparture.getText(), null);
+            departure = fromMillisAndTimeZone(parsed.getTimeInMillis(), "UTC");
+        } catch (DateTimeParserException e) {
+            JFrame frame = BaseRouteConverter.getInstance().getFrame();
+            showError(frame, format(BaseRouteConverter.getBundle().getString("date-time-format-error"),
+                    textFieldDeparture.getText(), formatter.getPatternInfo()), frame.getTitle());
+            return; // keep the dialog open and change nothing
+        }
+
+        dispose();
+        BaseRouteConverter.getInstance().getPositionAugmenter().addDepartureTimes(departure);
+    }
+
+    private void cancel() {
+        dispose();
+    }
+
+    {
+// GUI initializer generated by IntelliJ IDEA GUI Designer
+// >>> IMPORTANT!! <<<
+// DO NOT EDIT OR ADD ANY CODE HERE!
+        $$$setupUI$$$();
+    }
+
+    /**
+     * Method generated by IntelliJ IDEA GUI Designer
+     * >>> IMPORTANT!! <<<
+     * DO NOT edit this method OR call it in your code!
+     *
+     * @noinspection ALL
+     */
+    private void $$$setupUI$$$() {
+        contentPane = new JPanel();
+        contentPane.setLayout(new GridLayoutManager(3, 1, new Insets(10, 10, 10, 10), -1, -1));
+        final JPanel panelFields = new JPanel();
+        panelFields.setLayout(new GridLayoutManager(1, 2, new Insets(0, 0, 0, 0), -1, -1));
+        contentPane.add(panelFields, new GridConstraints(0, 0, 1, 1, GridConstraints.ANCHOR_CENTER, GridConstraints.FILL_BOTH, GridConstraints.SIZEPOLICY_CAN_SHRINK | GridConstraints.SIZEPOLICY_CAN_GROW, GridConstraints.SIZEPOLICY_CAN_SHRINK | GridConstraints.SIZEPOLICY_CAN_GROW, null, null, null, 0, false));
+        labelDeparture = new JLabel();
+        labelDeparture.setText("");
+        panelFields.add(labelDeparture, new GridConstraints(0, 0, 1, 1, GridConstraints.ANCHOR_WEST, GridConstraints.FILL_NONE, GridConstraints.SIZEPOLICY_FIXED, GridConstraints.SIZEPOLICY_FIXED, null, null, null, 0, false));
+        textFieldDeparture = new JTextField();
+        panelFields.add(textFieldDeparture, new GridConstraints(0, 1, 1, 1, GridConstraints.ANCHOR_WEST, GridConstraints.FILL_HORIZONTAL, GridConstraints.SIZEPOLICY_WANT_GROW, GridConstraints.SIZEPOLICY_FIXED, null, new Dimension(200, -1), null, 0, false));
+        final JPanel panelGap = new JPanel();
+        panelGap.setLayout(new GridLayoutManager(1, 1, new Insets(0, 0, 0, 0), -1, -1));
+        contentPane.add(panelGap, new GridConstraints(1, 0, 1, 1, GridConstraints.ANCHOR_CENTER, GridConstraints.FILL_BOTH, GridConstraints.SIZEPOLICY_CAN_SHRINK | GridConstraints.SIZEPOLICY_CAN_GROW, GridConstraints.SIZEPOLICY_CAN_SHRINK | GridConstraints.SIZEPOLICY_CAN_GROW, null, new Dimension(-1, 10), null, 0, false));
+        final JPanel panelButtons = new JPanel();
+        panelButtons.setLayout(new GridLayoutManager(1, 3, new Insets(0, 0, 0, 0), -1, -1));
+        contentPane.add(panelButtons, new GridConstraints(2, 0, 1, 1, GridConstraints.ANCHOR_CENTER, GridConstraints.FILL_BOTH, GridConstraints.SIZEPOLICY_CAN_SHRINK | GridConstraints.SIZEPOLICY_CAN_GROW, 1, null, null, null, 0, false));
+        buttonOk = new JButton();
+        this.$$$loadButtonText$$$(buttonOk, this.$$$getMessageFromBundle$$$("slash/navigation/converter/gui/RouteConverter", "ok"));
+        panelButtons.add(buttonOk, new GridConstraints(0, 0, 1, 1, GridConstraints.ANCHOR_CENTER, GridConstraints.FILL_HORIZONTAL, GridConstraints.SIZEPOLICY_CAN_SHRINK | GridConstraints.SIZEPOLICY_CAN_GROW, GridConstraints.SIZEPOLICY_FIXED, null, null, null, 0, false));
+        final Spacer spacer1 = new Spacer();
+        panelButtons.add(spacer1, new GridConstraints(0, 1, 1, 1, GridConstraints.ANCHOR_CENTER, GridConstraints.FILL_HORIZONTAL, GridConstraints.SIZEPOLICY_WANT_GROW, 1, null, null, null, 0, false));
+        buttonCancel = new JButton();
+        this.$$$loadButtonText$$$(buttonCancel, this.$$$getMessageFromBundle$$$("slash/navigation/converter/gui/RouteConverter", "cancel"));
+        panelButtons.add(buttonCancel, new GridConstraints(0, 2, 1, 1, GridConstraints.ANCHOR_CENTER, GridConstraints.FILL_HORIZONTAL, GridConstraints.SIZEPOLICY_CAN_SHRINK | GridConstraints.SIZEPOLICY_CAN_GROW, GridConstraints.SIZEPOLICY_FIXED, null, null, null, 0, false));
+    }
+
+    private static Method $$$cachedGetBundleMethod$$$ = null;
+
+    /**
+     * @noinspection ALL
+     */
+    private String $$$getMessageFromBundle$$$(String path, String key) {
+        ResourceBundle bundle;
+        try {
+            Class<?> thisClass = this.getClass();
+            if ($$$cachedGetBundleMethod$$$ == null) {
+                Class<?> dynamicBundleClass = thisClass.getClassLoader().loadClass("com.intellij.DynamicBundle");
+                $$$cachedGetBundleMethod$$$ = dynamicBundleClass.getMethod("getBundle", String.class, Class.class);
+            }
+            bundle = (ResourceBundle) $$$cachedGetBundleMethod$$$.invoke(null, path, thisClass);
+        } catch (Exception e) {
+            bundle = ResourceBundle.getBundle(path);
+        }
+        return bundle.getString(key);
+    }
+
+    /**
+     * @noinspection ALL
+     */
+    private void $$$loadButtonText$$$(AbstractButton component, String text) {
+        StringBuffer result = new StringBuffer();
+        boolean haveMnemonic = false;
+        char mnemonic = '\0';
+        int mnemonicIndex = -1;
+        for (int i = 0; i < text.length(); i++) {
+            if (text.charAt(i) == '&') {
+                i++;
+                if (i == text.length()) break;
+                if (!haveMnemonic && text.charAt(i) != '&') {
+                    haveMnemonic = true;
+                    mnemonic = text.charAt(i);
+                    mnemonicIndex = result.length();
+                }
+            }
+            result.append(text.charAt(i));
+        }
+        component.setText(result.toString());
+        if (haveMnemonic) {
+            component.setMnemonic(mnemonic);
+            component.setDisplayedMnemonicIndex(mnemonicIndex);
+        }
+    }
+
+    /**
+     * @noinspection ALL
+     */
+    public JComponent $$$getRootComponent$$$() {
+        return contentPane;
+    }
+
+}

--- a/route-converter-gui/src/main/java/slash/navigation/converter/gui/helpers/FrameMenu.java
+++ b/route-converter-gui/src/main/java/slash/navigation/converter/gui/helpers/FrameMenu.java
@@ -81,6 +81,7 @@ public class FrameMenu {
         completeMenu.add(createItem("add-address"));
         completeMenu.add(createItem("add-speed"));
         completeMenu.add(createItem("add-time"));
+        completeMenu.add(createItem("add-departure-time"));
         completeMenu.add(createItem("add-number"));
         positionMenu.add(completeMenu);
         positionMenu.add(createItem("snap-to-road"));

--- a/route-converter-gui/src/main/java/slash/navigation/converter/gui/helpers/PositionsTablePopupMenu.java
+++ b/route-converter-gui/src/main/java/slash/navigation/converter/gui/helpers/PositionsTablePopupMenu.java
@@ -53,6 +53,7 @@ public class PositionsTablePopupMenu extends AbstractTablePopupMenu {
         completeMenu.add(createItem("add-address"));
         completeMenu.add(createItem("add-speed"));
         completeMenu.add(createItem("add-time"));
+        completeMenu.add(createItem("add-departure-time"));
         completeMenu.add(createItem("add-number"));
         menu.add(completeMenu);
         menu.add(createItem("snap-to-road"));

--- a/route-converter-gui/src/main/java/slash/navigation/converter/gui/panels/ConvertPanel.java
+++ b/route-converter-gui/src/main/java/slash/navigation/converter/gui/panels/ConvertPanel.java
@@ -341,6 +341,7 @@ public class ConvertPanel implements PanelInTab {
         actionManager.register("add-address", new AddAddressToPositionsAction());
         actionManager.register("add-speed", new AddSpeedToPositionsAction());
         actionManager.register("add-time", new AddTimeToPositionsAction());
+        actionManager.register("add-departure-time", new AddDepartureTimeToPositionsAction());
         actionManager.register("add-number", new AddNumberToPositionsAction());
         actionManager.register("split-positionlist", new SplitPositionListAction(getPositionsView(), positionsModel, getFormatAndRoutesModel()));
         actionManager.register("import-positionlist", new ImportPositionListAction(this));
@@ -707,6 +708,7 @@ public class ConvertPanel implements PanelInTab {
         actionManager.enable("add-address", existsASelectedPosition);
         actionManager.enable("add-speed", existsASelectedPosition);
         actionManager.enable("add-time", existsASelectedPosition);
+        actionManager.enable("add-departure-time", existsMoreThanOnePosition);
         actionManager.enable("add-number", existsASelectedPosition);
         actionManager.enable("split-positionlist", existsASelectedPosition && supportsMultipleRoutes);
 


### PR DESCRIPTION
## Summary
- Add `AddDepartureTimeToPositionsAction` (action key `add-departure-time`) that opens a modal `DepartureTimeDialog`.
- `DepartureTimeDialog`: single date+time field + OK/Cancel (reuses `ok`/`cancel`), modeled on `AddUrlDialog` with a hand-authored `.form` + `$$$setupUI$$$()` kept in sync (IntelliJ GUI-designer round-trip).
  - **Prefill:** position 0's time if it `hasTime()`, else today 09:00 in the app time zone.
  - **Parse:** app time zone via `Transfer.getDateTimeFormat(timeZoneId)`, converting to a UTC `CompactCalendar` — exactly like the DATE_TIME column editor in `PositionsModelCallbackImpl`. On an unparseable entry, shows `date-time-format-error` and keeps the dialog open, changing nothing.
  - **On OK:** calls `PositionAugmenter.addDepartureTimes(departure)` (#173).
- Register the action in `ConvertPanel`, enabled only on **≥ 2 positions** (reuses the existing `existsMoreThanOnePosition` predicate).
- Add the item to the "Complete…" submenu of `FrameMenu` and `PositionsTablePopupMenu`, right after "Time".

## Why
Final step (3/3) of the ETA-from-departure feature (parent tracker #166; pure seam #172, model method + i18n #173). This wires the UI to the already-merged model method and translations — no model or i18n changes here.

## Test plan
- `./mvnw -pl common-navigation,route-converter-gui -am test` → **BUILD SUCCESS, 234 tests, 0 failures/0 errors** (JDK 21), including `ResourceBundleTest` (i18n consistency).
- **Manual:** load a multi-point route, calculate with a time-returning profile (Car Fast). Complete… → **Times from Departure…**, enter `09:00`. DATE_TIME column shows increasing clock times; position 0 = `09:00`; values = departure + cumulative routing duration. Save as GPX → times written; Undo reverts all in one step.
- **Manual (guard):** on a route with no routing times (StraightLine, or before calculation), the action shows `add-departure-time-error` and changes nothing.
- **Manual (enablement):** item disabled with fewer than 2 positions.

Closes #174.
