### PR TITLE
[maintainer] World-map background intermittently blank: race between async download and EDT layer-stack build

### DIFF
--- a/mapsforge-mapview/src/main/java/slash/navigation/mapview/mapsforge/BackgroundMapAttachment.java
+++ b/mapsforge-mapview/src/main/java/slash/navigation/mapview/mapsforge/BackgroundMapAttachment.java
@@ -1,0 +1,47 @@
+/*
+    This file is part of RouteConverter.
+
+    RouteConverter is free software; you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation; either version 2 of the License, or
+    (at your option) any later version.
+
+    RouteConverter is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with RouteConverter; if not, write to the Free Software
+    Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
+
+    Copyright (C) 2007 Christian Pesch. All Rights Reserved.
+*/
+package slash.navigation.mapview.mapsforge;
+
+/**
+ * Decides whether the world-map background layer should be attached as the
+ * base layer, independent of the order in which the async background map
+ * download (Path B) and the EDT map/theme layer-stack build (Path A) run.
+ *
+ * @author Christian Pesch
+ */
+
+public class BackgroundMapAttachment {
+    private BackgroundMapAttachment() {
+    }
+
+    /**
+     * @param layerReady            whether the background layer has been built successfully
+     * @param hasDisplayedMap       whether a map is currently displayed
+     * @param displayedMapIsMapsforge whether the displayed map is of type Mapsforge
+     * @return true iff the world-map background layer should be attached as the base layer now
+     */
+    public static boolean shouldAttachBackground(boolean layerReady, boolean hasDisplayedMap, boolean displayedMapIsMapsforge) {
+        if (!layerReady)
+            return false;
+        if (!hasDisplayedMap)
+            return false;
+        return displayedMapIsMapsforge;
+    }
+}

--- a/mapsforge-mapview/src/main/java/slash/navigation/mapview/mapsforge/MapsforgeMapView.java
+++ b/mapsforge-mapview/src/main/java/slash/navigation/mapview/mapsforge/MapsforgeMapView.java
@@ -484,18 +484,23 @@ public class MapsforgeMapView extends BaseMapView {
 
     public void setBackgroundMap(File backgroundMap) {
         long length = backgroundMap.length();
+        Layer builtLayer;
         try {
             // createBackgroundLayer validates the mapsforge header via new MapFile, so a truncated
             // or wrong-content file (e.g. a stale world.map that never re-downloaded) throws here.
             // Without this guard the exception escaped silently on the EDT and the map just stayed
             // blank with nothing in the log.
-            backgroundLayer = tileLayerFactory.createBackgroundLayer(backgroundMap);
-            handleBackground();
-            log.info(format("Loaded background map %s (%d bytes)", backgroundMap, length));
+            builtLayer = tileLayerFactory.createBackgroundLayer(backgroundMap);
         } catch (Exception e) {
             backgroundLayer = null;
             log.severe(format("Cannot load background map %s (%d bytes): %s", backgroundMap, length, e));
+            return;
         }
+        // the layer is built now; a no-op inside handleBackground() (e.g. no map displayed
+        // yet) must not discard it, since nothing would rebuild it afterwards
+        backgroundLayer = builtLayer;
+        handleBackground();
+        log.info(format("Loaded background map %s (%d bytes)", backgroundMap, length));
     }
 
     public void updateMapAndThemesAfterDirectoryScanning() {
@@ -669,14 +674,14 @@ public class MapsforgeMapView extends BaseMapView {
     }
 
     private void handleBackground() {
-        if (backgroundLayer == null)
-            return;
-
         Layers layers = getLayerManager().getLayers();
-        layers.remove(backgroundLayer);
+        if (backgroundLayer != null)
+            layers.remove(backgroundLayer);
 
         LocalMap map = getMapManager().getDisplayedMapModel().getItem();
-        if (map.getType().equals(Mapsforge))
+        boolean shouldAttach = BackgroundMapAttachment.shouldAttachBackground(backgroundLayer != null,
+                map != null, map != null && map.getType().equals(Mapsforge));
+        if (shouldAttach)
             layers.add(0, backgroundLayer);
     }
 

--- a/mapsforge-mapview/src/test/java/slash/navigation/mapview/mapsforge/BackgroundMapAttachmentTest.java
+++ b/mapsforge-mapview/src/test/java/slash/navigation/mapview/mapsforge/BackgroundMapAttachmentTest.java
@@ -1,0 +1,53 @@
+/*
+    This file is part of RouteConverter.
+
+    RouteConverter is free software; you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation; either version 2 of the License, or
+    (at your option) any later version.
+
+    RouteConverter is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with RouteConverter; if not, write to the Free Software
+    Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
+
+    Copyright (C) 2007 Christian Pesch. All Rights Reserved.
+*/
+package slash.navigation.mapview.mapsforge;
+
+import org.junit.Test;
+
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+import static slash.navigation.mapview.mapsforge.BackgroundMapAttachment.shouldAttachBackground;
+
+/**
+ * Tests for {@link BackgroundMapAttachment}.
+ *
+ * @author Christian Pesch
+ */
+public class BackgroundMapAttachmentTest {
+    @Test
+    public void doesNotAttachWhenLayerNotReady() {
+        assertFalse(shouldAttachBackground(false, true, true));
+    }
+
+    @Test
+    public void doesNotAttachWhenLayerReadyButNoDisplayedMap() {
+        assertFalse(shouldAttachBackground(true, false, false));
+    }
+
+    @Test
+    public void doesNotAttachWhenLayerReadyAndDisplayedMapIsNotMapsforge() {
+        assertFalse(shouldAttachBackground(true, true, false));
+    }
+
+    @Test
+    public void attachesWhenLayerReadyAndDisplayedMapIsMapsforge() {
+        assertTrue(shouldAttachBackground(true, true, true));
+    }
+}


### PR DESCRIPTION
## Summary

Fixed the world-map background race described in issue #184 by decoupling "build" from "attach" in `MapsforgeMapView` and making attachment idempotent/order-independent, per the locked spec.

**`mapsforge-mapview/src/main/java/slash/navigation/mapview/mapsforge/MapsforgeMapView.java`**

- `setBackgroundMap` (`:485`): only nulls `backgroundLayer` when `tileLayerFactory.createBackgroundLayer(...)` itself throws (the mapsforge-header validation failure). Once the layer is built, `handleBackground()` is called but can no longer discard it — the field assignment happens before the call, and any no-op inside `handleBackground()` just leaves the field as-is.
- `handleBackground` (`:676`): now null-guards on `backgroundLayer` (skips the unconditional `layers.remove` only when there's nothing to remove) and null-guards on the displayed map (`map != null`) instead of calling `map.getType()` unconditionally, which previously NPE'd when no map was displayed yet. The attach/no-attach decision is delegated to the new pure helper, and the layer is always removed-then-conditionally-re-added at index 0, so repeated calls from either the download callback or the EDT listeners can't double-add and safely re-attach.

**`mapsforge-mapview/src/main/java/slash/navigation/mapview/mapsforge/BackgroundMapAttachment.java`** (new)

Pure, static `shouldAttachBackground(boolean layerReady, boolean hasDisplayedMap, boolean displayedMapIsMapsforge)` — the testable seam requested in the spec, with no GUI dependencies.

**`mapsforge-mapview/src/test/java/slash/navigation/mapview/mapsforge/BackgroundMapAttachmentTest.java`** (new)

Covers the four required cases: layer not ready; layer ready but no displayed map; layer ready but non-Mapsforge displayed map; layer ready and Mapsforge map displayed.

I verified the two existing `MapsforgeMapViewTest` cases (`testSetBackgroundMapWithCorruptFileDoesNotThrowAndClearsLayer` / `...MissingFile...`) still pass logically unchanged: they exercise the build-failure path, which still nulls `backgroundLayer` in the `catch` block exactly as before.

**Caveat:** this sandbox blocks all shell command execution (even `./mvnw --version`) pending approval that isn't available in this run, so I could not execute `mvn -pl mapsforge-mapview -am test` to confirm green — please run it as part of PR review. I did carefully re-read all edited regions and cross-checked imports (`Layer` was already imported via `org.mapsforge.map.layer.*`), so the change should compile as-is.

No other files were touched; `DownloadManager.executeDownload`, the online JavaFX map view, theme/hillshading handling, and the `mapView == null` retry loop in `applyBackgroundMapWhenReady` were left untouched per the issue's explicit out-of-scope list.


Source issue: cpesch/RouteConverter#184

---
**Builder stats** · model `sonnet` · confidence `0` · 3m 30s across 1 round(s) · 3 file op(s)
[Workflow run](http://127.0.0.1:3000/cpesch/RouteConverter/actions/runs/12434)

<!-- issue-body-sha:ff7ca321e016 -->