### PR TITLE
[maintainer] Flag implausible-detour routing legs in orange (routed distance ≫ straight-line)

### DIFF
--- a/mapsforge-mapview/src/main/java/slash/navigation/mapview/mapsforge/models/RouteQuality.java
+++ b/mapsforge-mapview/src/main/java/slash/navigation/mapview/mapsforge/models/RouteQuality.java
@@ -19,15 +19,10 @@
 */
 package slash.navigation.mapview.mapsforge.models;
 
-import org.mapsforge.core.model.LatLong;
-import slash.navigation.common.NavigationPosition;
-
-import java.util.List;
-
 /**
- * A container for a {@link List} of {@link LatLong} and the {@link RouteQuality} of the route they present.
+ * The render quality of a routed route leg.
  *
  * @author Christian Pesch
  */
-public record IntermediateRoute(List<NavigationPosition> positions, RouteQuality quality) {
-}
+
+public enum RouteQuality {Valid, Detour, Invalid}

--- a/mapsforge-mapview/src/main/java/slash/navigation/mapview/mapsforge/models/RouteQuality.java
+++ b/mapsforge-mapview/src/main/java/slash/navigation/mapview/mapsforge/models/RouteQuality.java
@@ -24,5 +24,4 @@ package slash.navigation.mapview.mapsforge.models;
  *
  * @author Christian Pesch
  */
-
 public enum RouteQuality {Valid, Detour, Invalid}

--- a/mapsforge-mapview/src/main/java/slash/navigation/mapview/mapsforge/models/RouteQualityClassifier.java
+++ b/mapsforge-mapview/src/main/java/slash/navigation/mapview/mapsforge/models/RouteQualityClassifier.java
@@ -30,7 +30,6 @@ import static slash.navigation.mapview.mapsforge.models.RouteQuality.Valid;
  *
  * @author Christian Pesch
  */
-
 public class RouteQualityClassifier {
     private static final double DETOUR_RATIO = 5.0;
     private static final double DETOUR_MIN_EXCESS_METERS = 1000.0;

--- a/mapsforge-mapview/src/main/java/slash/navigation/mapview/mapsforge/models/RouteQualityClassifier.java
+++ b/mapsforge-mapview/src/main/java/slash/navigation/mapview/mapsforge/models/RouteQualityClassifier.java
@@ -1,0 +1,52 @@
+/*
+    This file is part of RouteConverter.
+
+    RouteConverter is free software; you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation; either version 2 of the License, or
+    (at your option) any later version.
+
+    RouteConverter is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with RouteConverter; if not, write to the Free Software
+    Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
+
+    Copyright (C) 2007 Christian Pesch. All Rights Reserved.
+*/
+package slash.navigation.mapview.mapsforge.models;
+
+import static slash.navigation.mapview.mapsforge.models.RouteQuality.Detour;
+import static slash.navigation.mapview.mapsforge.models.RouteQuality.Invalid;
+import static slash.navigation.mapview.mapsforge.models.RouteQuality.Valid;
+
+/**
+ * Classifies a routed route leg as {@link RouteQuality#Valid}, {@link RouteQuality#Detour} or
+ * {@link RouteQuality#Invalid} by comparing the routed distance to the straight-line distance
+ * between its endpoints.
+ *
+ * @author Christian Pesch
+ */
+
+public class RouteQualityClassifier {
+    private static final double DETOUR_RATIO = 5.0;
+    private static final double DETOUR_MIN_EXCESS_METERS = 1000.0;
+
+    private RouteQualityClassifier() {
+    }
+
+    public static RouteQuality classify(boolean routable, Double straightLineMeters, Double routedMeters) {
+        if (!routable)
+            return Invalid;
+
+        if (straightLineMeters != null && straightLineMeters > 0 && routedMeters != null &&
+                routedMeters / straightLineMeters > DETOUR_RATIO &&
+                (routedMeters - straightLineMeters) > DETOUR_MIN_EXCESS_METERS)
+            return Detour;
+
+        return Valid;
+    }
+}

--- a/mapsforge-mapview/src/main/java/slash/navigation/mapview/mapsforge/renderer/RouteRenderer.java
+++ b/mapsforge-mapview/src/main/java/slash/navigation/mapview/mapsforge/renderer/RouteRenderer.java
@@ -32,6 +32,8 @@ import slash.navigation.mapview.mapsforge.MapsforgeMapView;
 import slash.navigation.mapview.mapsforge.lines.Line;
 import slash.navigation.mapview.mapsforge.lines.Polyline;
 import slash.navigation.mapview.mapsforge.models.IntermediateRoute;
+import slash.navigation.mapview.mapsforge.models.RouteQuality;
+import slash.navigation.mapview.mapsforge.models.RouteQualityClassifier;
 import slash.navigation.mapview.mapsforge.updater.PairWithLayer;
 import slash.navigation.routing.DownloadFuture;
 import slash.navigation.routing.RoutingResult;
@@ -219,7 +221,12 @@ public class RouteRenderer {
             mapView.removeLayer(layer);
             pairWithLayer.setLayer(null);
 
-            Polyline polyline = new Polyline(mapView.asLatLong(intermediateRoute.positions()), intermediateRoute.valid() ? paint : getRouteNotValidPaint(), mapView.getTileSize());
+            Paint routePaint = switch (intermediateRoute.quality()) {
+                case Valid -> paint;
+                case Detour -> getDetourPaint();
+                case Invalid -> getRouteNotValidPaint();
+            };
+            Polyline polyline = new Polyline(mapView.asLatLong(intermediateRoute.positions()), routePaint, mapView.getTileSize());
             pairWithLayer.setLayer(polyline);
             mapView.addLayer(polyline);
         }
@@ -244,17 +251,29 @@ public class RouteRenderer {
         return paint;
     }
 
+    private Paint getDetourPaint() {
+        Paint paint = graphicFactory.createPaint();
+        paint.setColor(0xFFFFA500);
+        paint.setStrokeWidth(getRouteLineWidth());
+        return paint;
+    }
+
     private IntermediateRoute calculateRoute(RoutingService routingService, DownloadFuture future, PairWithLayer pairWithLayer) {
         List<NavigationPosition> positions = new ArrayList<>();
         positions.add(pairWithLayer.getFirst());
 
         RoutingResult result = calculateResult(routingService, future, pairWithLayer);
-        if (result.validity().equals(Valid)) {
+        boolean routable = result.validity().equals(Valid);
+        Double routedMeters = result.distanceAndTime() != null ? result.distanceAndTime().distance() : null;
+        Double straightLineMeters = pairWithLayer.getFirst().calculateDistance(pairWithLayer.getSecond());
+        RouteQuality quality = RouteQualityClassifier.classify(routable, straightLineMeters, routedMeters);
+
+        if (!quality.equals(RouteQuality.Invalid)) {
             positions.addAll(result.positions());
             pairWithLayer.setDistanceAndTime(result.distanceAndTime());
         }
         positions.add(pairWithLayer.getSecond());
-        return new IntermediateRoute(positions, result.validity().equals(Valid));
+        return new IntermediateRoute(positions, quality);
     }
 
     private RoutingResult calculateResult(RoutingService routingService, DownloadFuture future, PairWithLayer pairWithLayer) {

--- a/mapsforge-mapview/src/test/java/slash/navigation/mapview/mapsforge/models/RouteQualityClassifierTest.java
+++ b/mapsforge-mapview/src/test/java/slash/navigation/mapview/mapsforge/models/RouteQualityClassifierTest.java
@@ -1,0 +1,67 @@
+/*
+    This file is part of RouteConverter.
+
+    RouteConverter is free software; you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation; either version 2 of the License, or
+    (at your option) any later version.
+
+    RouteConverter is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with RouteConverter; if not, write to the Free Software
+    Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
+
+    Copyright (C) 2007 Christian Pesch. All Rights Reserved.
+*/
+package slash.navigation.mapview.mapsforge.models;
+
+import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+import static slash.navigation.mapview.mapsforge.models.RouteQualityClassifier.classify;
+
+/**
+ * Tests for {@link RouteQualityClassifier}.
+ *
+ * @author Christian Pesch
+ */
+public class RouteQualityClassifierTest {
+
+    @Test
+    public void notRoutableIsInvalidRegardlessOfDistances() {
+        assertEquals(RouteQuality.Invalid, classify(false, 229.0, 108120.0));
+        assertEquals(RouteQuality.Invalid, classify(false, null, null));
+    }
+
+    @Test
+    public void hugeDetourIsDetour() {
+        // granada.gpx case: ratio ~= 472, excess ~= 108 km
+        assertEquals(RouteQuality.Detour, classify(true, 229.0, 108120.0));
+    }
+
+    @Test
+    public void matchingStraightLineAndRoutedDistanceIsValid() {
+        // trekking case
+        assertEquals(RouteQuality.Valid, classify(true, 229.0, 229.0));
+    }
+
+    @Test
+    public void ratioAboveThresholdButBelowAbsoluteFloorIsValid() {
+        assertEquals(RouteQuality.Valid, classify(true, 150.0, 900.0));
+    }
+
+    @Test
+    public void zeroOrNullStraightLineDistanceIsValid() {
+        assertEquals(RouteQuality.Valid, classify(true, 0.0, 108120.0));
+        assertEquals(RouteQuality.Valid, classify(true, null, 108120.0));
+    }
+
+    @Test
+    public void nullRoutedDistanceIsValid() {
+        assertEquals(RouteQuality.Valid, classify(true, 229.0, null));
+    }
+}


### PR DESCRIPTION
## Summary

Implemented issue #186: flag implausible-detour routing legs in orange on the map.

**New files:**
- `mapsforge-mapview/.../models/RouteQuality.java` — new enum `{Valid, Detour, Invalid}`.
- `mapsforge-mapview/.../models/RouteQualityClassifier.java` — pure classifier `classify(boolean routable, Double straightLineMeters, Double routedMeters)` with constants `DETOUR_RATIO = 5.0` and `DETOUR_MIN_EXCESS_METERS = 1000.0`, exactly per the locked spec: `Invalid` if not routable; else `Detour` if `routedMeters/straightLineMeters > 5.0` and `routedMeters - straightLineMeters > 1000.0` (guarding null/zero straight-line and null routed distance); else `Valid`.
- `mapsforge-mapview/.../models/RouteQualityClassifierTest.java` — JUnit 4 test covering all six required cases (not-routable, granada detour, trekking valid, ratio-above-but-excess-below-floor, zero/null straight-line, null routed).

**Modified files:**
- `IntermediateRoute.java` — replaced `boolean valid` with `RouteQuality quality`.
- `RouteRenderer.java`:
  - `calculateRoute` now computes `straightLineMeters` (from `pairWithLayer.getFirst().calculateDistance(...)`) and `routedMeters` (from `result.distanceAndTime().distance()`), classifies via `RouteQualityClassifier.classify`, and includes routed positions/sets distance-and-time whenever quality is not `Invalid` (i.e. for both `Valid` and `Detour`).
  - Added `getDetourPaint()` mirroring `getRouteNotValidPaint()` with opaque orange `0xFFFFA500`.
  - The paint decision at the polyline construction site is now a 3-way `switch` over `RouteQuality`: `Valid` → normal route paint, `Detour` → orange, `Invalid` → red.

No other code paths referenced `IntermediateRoute.valid()`, so the change is self-contained to these files, as scoped by the issue (map polyline only; no position-table/time-column changes, no preferences UI, no changes to BRouter's `Validity` derivation).

**Note on verification:** This sandboxed run has no mechanism to approve non-trivial Bash commands (even `java -version` / `./mvnw` were blocked), so I could not execute `./mvnw -pl mapsforge-mapview -am test`. I instead did a careful manual review of the diff for correctness (exhaustive enum switch, null-safety in the classifier matching all six spec'd test cases, and confirming the positions-inclusion condition `!quality.equals(Invalid)` is logically equivalent to the original `result.validity().equals(Valid)` check for the `Valid`/`Invalid` cases, extended to also include positions for `Detour`). The maintainer should run the test suite before merge to confirm a clean compile/green build.


Source issue: cpesch/RouteConverter#186

---
**Builder stats** · model `sonnet` · confidence `0` · 3m 0s across 1 round(s) · 5 file op(s)
[Workflow run](http://127.0.0.1:3000/cpesch/RouteConverter/actions/runs/12474)

<!-- issue-body-sha:32cd62b885ab -->