### PR TITLE
fix(brouter): keep segments newer than a stale lookups.dat

### DIFF
--- a/brouter/src/main/java/slash/navigation/brouter/BRouter.java
+++ b/brouter/src/main/java/slash/navigation/brouter/BRouter.java
@@ -148,10 +148,17 @@ public class BRouter extends BaseRoutingService {
 
     /**
      * Reads the lookup version bundled with the BRouter library (from {@code lookups.dat}) and
-     * removes any locally cached {@code .rd5} segment whose embedded lookup version differs. Such
-     * segments predate a BRouter format bump and would otherwise make routing fail hard with
+     * removes any locally cached {@code .rd5} segment whose embedded lookup version is <em>older</em>.
+     * Such segments predate a BRouter format bump and would otherwise make routing fail hard with
      * "lookup version mismatch (old rd5?)". Removed segments are re-downloaded on demand by the
      * regular routing path, so this method only deletes and never starts a download itself.
+     * <p>
+     * Segments that are <em>newer</em> than the local {@code lookups.dat} are deliberately kept: that
+     * skew means {@code lookups.dat} itself is stale (the profiles datasource has not caught up with a
+     * BRouter format bump yet, so {@link #refreshLookupsIfStale()} could not update it). Deleting them
+     * would only trigger a re-download of the same newer version on the next routing request and again
+     * on the next launch -- an endless re-download loop of large segment files. We log an actionable
+     * hint instead and leave the segment in place.
      */
     void removeOutdatedSegments() {
         File lookups = new File(getProfilesDirectory(), LOOKUPS_DAT);
@@ -178,6 +185,13 @@ public class BRouter extends BaseRoutingService {
             }
             if (version == expectedVersion)
                 continue;
+
+            if (version > expectedVersion) {
+                log.warning(format("Keeping BRouter segment %s with newer lookup version %d than %s (%d): " +
+                                "the profiles datasource is stale, deleting would only re-download the same version",
+                        file, version, LOOKUPS_DAT, expectedVersion));
+                continue;
+            }
 
             log.warning(format("Removing outdated BRouter segment %s with lookup version %d (expected %d)", file, version, expectedVersion));
             if (!file.delete())

--- a/brouter/src/test/java/slash/navigation/brouter/BRouterRemoveOutdatedSegmentsTest.java
+++ b/brouter/src/test/java/slash/navigation/brouter/BRouterRemoveOutdatedSegmentsTest.java
@@ -46,8 +46,10 @@ public class BRouterRemoveOutdatedSegmentsTest {
     private static final int EXPECTED_VERSION = 11;
     private static final int OUTDATED_VERSION = 10;
 
+    private static final int NEWER_VERSION = 12;
+
     private BRouter router;
-    private File directory, current, outdated;
+    private File directory, current, outdated, newer;
 
     @Before
     public void setUp() throws IOException {
@@ -56,6 +58,7 @@ public class BRouterRemoveOutdatedSegmentsTest {
         writeLookups(new File(directory, "lookups.dat"), EXPECTED_VERSION);
         current = writeSegment(new File(directory, "E0_N0.rd5"), EXPECTED_VERSION);
         outdated = writeSegment(new File(directory, "W5_N0.rd5"), OUTDATED_VERSION);
+        newer = writeSegment(new File(directory, "E5_N0.rd5"), NEWER_VERSION);
 
         DataSource profiles = mock(DataSource.class);
         when(profiles.getDirectory()).thenReturn(DIRECTORY);
@@ -79,6 +82,7 @@ public class BRouterRemoveOutdatedSegmentsTest {
     public void testRemoveOutdatedSegments() {
         assertTrue("segment with matching lookup version must be kept", current.exists());
         assertFalse("segment with outdated lookup version must be removed", outdated.exists());
+        assertTrue("segment newer than a stale lookups.dat must be kept to avoid a re-download loop", newer.exists());
     }
 
     private static void writeLookups(File file, int version) throws IOException {


### PR DESCRIPTION
## Problem (report-1327)

Every route calculation re-downloaded `segments4/E5_N50.rd5` (~180 MB); the user saw it deleted on each program exit.

Root cause: brouter.de bumped rd5 segments to lookup **version 11**, but the local `lookups.dat` was still **version 10** (the profiles datasource had not caught up). `removeOutdatedSegments()` trusted `lookups.dat` as the expected version and deleted the fresh v11 segment at startup as "outdated". The next routing request re-downloaded v11, routing failed with `lookup version mismatch (old rd5?) lookups.dat=10 ...E5_N50.rd5=11`, and the next launch deleted it again — an endless re-download loop.

## Fix

Delete only segments **strictly older** than `lookups.dat` (genuine leftovers from a past format bump). Keep segments **newer** than `lookups.dat` and log an actionable hint that the profiles datasource is stale — deleting would only re-download the same version.

Complements #183 (`refreshLookupsIfStale`), which makes routing succeed once the profiles datasource advertises the v11 `lookups.dat`; this PR stops the wasteful re-download loop in the meantime.

Still required server-side (out of scope): bump `brouter-profiles.xml` to the v11 `lookups.dat` and refresh `brouter-segments-4.xml` checksums to what brouter.de currently serves.

## Test

`BRouterRemoveOutdatedSegmentsTest` extended: a segment newer than a stale `lookups.dat` is kept. `Tests run: 2, Failures: 0`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)