### PR TITLE
BRouter segment catalog drifts: served checksum collapsed to 1 entry (regresses #155) + rd5 HEAD-only sha1 never refreshes

### DIFF
--- a/download-tools/src/main/java/slash/navigation/download/tools/UpdateCatalog.java
+++ b/download-tools/src/main/java/slash/navigation/download/tools/UpdateCatalog.java
@@ -124,6 +124,22 @@ public class UpdateCatalog extends BaseDownloadTool {
         return result.size() > MAX_CHECKSUMS_PER_FILE ? new ArrayList<>(result.subList(0, MAX_CHECKSUMS_PER_FILE)) : result;
     }
 
+    // head() never yields a SHA-1 (see below), so for downloadables this tool only ever HEADs
+    // (anything but .zip/.pbf, e.g. BRouter's nightly-rebuilt .rd5 segment tiles), a historical
+    // checksum that still carries one can never be recomputed/refreshed here. Left in place, a
+    // stale SHA-1 is authoritative in Validator.matches() and permanently fails validation for
+    // freshly rebuilt content once nothing keeps re-adding a matching no-SHA-1 entry (see GitHub
+    // #190). Drop it so validation falls back to size + last-modified + localLaterThanRemote.
+    static List<Checksum> dropSha1(List<Checksum> checksums) {
+        if (checksums == null)
+            return null;
+        List<Checksum> result = new ArrayList<>(checksums.size());
+        for (Checksum checksum : checksums)
+            result.add(checksum.getSHA1() != null ?
+                    new Checksum(checksum.getLastModified(), checksum.getContentLength(), null) : checksum);
+        return result;
+    }
+
     private void updateFile(DatasourceType datasourceType, File file) throws IOException {
         String url = datasourceType.getBaseUrl() + file.getUri();
 
@@ -138,7 +154,10 @@ public class UpdateCatalog extends BaseDownloadTool {
         }
 
         Checksum checksum = download.getFile().getActualChecksum();
-        FileType fileType = createFileType(file.getUri(), mergeChecksums(file.getChecksums(), checksum), null);
+        // only .zip/.pbf get a header-parsing GET below; every other file (e.g. .rd5) is HEAD-only
+        boolean headOnly = !file.getUri().endsWith(DOT_ZIP) && !file.getUri().endsWith(DOT_PBF);
+        List<Checksum> existingChecksums = headOnly ? dropSha1(file.getChecksums()) : file.getChecksums();
+        FileType fileType = createFileType(file.getUri(), mergeChecksums(existingChecksums, checksum), null);
         datasourceType.getFile().add(fileType);
 
         if (file.getUri().endsWith(DOT_ZIP)) {

--- a/download-tools/src/test/java/slash/navigation/download/tools/UpdateCatalogTest.java
+++ b/download-tools/src/test/java/slash/navigation/download/tools/UpdateCatalogTest.java
@@ -1,0 +1,112 @@
+/*
+    This file is part of RouteConverter.
+
+    RouteConverter is free software; you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation; either version 2 of the License, or
+    (at your option) any later version.
+
+    RouteConverter is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with RouteConverter; if not, write to the Free Software
+    Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
+
+    Copyright (C) 2007 Christian Pesch. All Rights Reserved.
+*/
+
+package slash.navigation.download.tools;
+
+import org.junit.Test;
+import slash.navigation.download.Checksum;
+
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNull;
+import static slash.common.type.CompactCalendar.fromMillis;
+import static slash.navigation.download.tools.UpdateCatalog.dropSha1;
+import static slash.navigation.download.tools.UpdateCatalog.mergeChecksums;
+
+/**
+ * Unit tests for {@link UpdateCatalog}'s checksum-merging helpers (GitHub #190).
+ *
+ * @author Christian Pesch
+ */
+public class UpdateCatalogTest {
+
+    private static final long DAY1 = 1_000_000_000_000L;
+    private static final long DAY2 = DAY1 + 86_400_000L;
+
+    // --- dropSha1 ---
+
+    @Test
+    public void dropSha1ReturnsNullForNullList() {
+        assertNull(dropSha1(null));
+    }
+
+    @Test
+    public void dropSha1StripsSha1ButKeepsSizeAndLastModified() {
+        Checksum withSha1 = new Checksum(fromMillis(DAY1), 100L, "deadbeef");
+        List<Checksum> result = dropSha1(Collections.singletonList(withSha1));
+        assertEquals(1, result.size());
+        Checksum stripped = result.get(0);
+        assertEquals(fromMillis(DAY1), stripped.getLastModified());
+        assertEquals(Long.valueOf(100L), stripped.getContentLength());
+        assertNull(stripped.getSHA1());
+    }
+
+    @Test
+    public void dropSha1LeavesChecksumsWithoutSha1Unchanged() {
+        Checksum withoutSha1 = new Checksum(fromMillis(DAY1), 100L, null);
+        List<Checksum> result = dropSha1(Collections.singletonList(withoutSha1));
+        assertEquals(1, result.size());
+        // same instance is reused when there is no SHA-1 to strip
+        assertEquals(withoutSha1, result.get(0));
+    }
+
+    // --- mergeChecksums combined with dropSha1 (GitHub #190 scenario) ---
+
+    @Test
+    public void staleSha1DoesNotSurviveMergeForHeadOnlyDownloadable() {
+        // a historical checksum that (however it got there) still carries a SHA-1 that this
+        // HEAD-only tool can never recompute/refresh
+        Checksum stale = new Checksum(fromMillis(DAY1), 100L, "stale-sha1");
+        Checksum freshlyObserved = new Checksum(fromMillis(DAY2), 200L, null);
+
+        List<Checksum> merged = mergeChecksums(dropSha1(Collections.singletonList(stale)), freshlyObserved);
+
+        assertEquals(2, merged.size());
+        for (Checksum checksum : merged)
+            assertNull(checksum.getSHA1());
+    }
+
+    @Test
+    public void mergeChecksumsWithoutDroppingSha1KeepsStaleSha1() {
+        // without dropSha1, the stale SHA-1 would keep being forwarded forever
+        Checksum stale = new Checksum(fromMillis(DAY1), 100L, "stale-sha1");
+        Checksum freshlyObserved = new Checksum(fromMillis(DAY2), 200L, null);
+
+        List<Checksum> merged = mergeChecksums(Collections.singletonList(stale), freshlyObserved);
+
+        assertEquals(2, merged.size());
+        assertEquals("stale-sha1", merged.get(1).getSHA1());
+    }
+
+    @Test
+    public void mergeChecksumsPrependsLatestAndKeepsHistory() {
+        Checksum c1 = new Checksum(fromMillis(DAY1), 100L, null);
+        Checksum latest = new Checksum(fromMillis(DAY2), 200L, null);
+
+        List<Checksum> merged = mergeChecksums(Arrays.asList(c1), latest);
+
+        assertEquals(2, merged.size());
+        assertEquals(latest, merged.get(0));
+        assertEquals(c1, merged.get(1));
+    }
+}


### PR DESCRIPTION
## Summary

Fixed the client-repo-actionable half of #190 (Defect 2): `UpdateCatalog.updateFile()` only ever issues a `HEAD` request for downloadables that aren't `.zip`/`.pbf` (e.g. BRouter's nightly-rebuilt `.rd5` segment tiles), and a `HEAD` response never carries a SHA-1 (`GetPerformer.extractChecksum()` hardcodes it to `null`). That means this tool can never independently compute or refresh a SHA-1 for those files — so if a historical checksum entry for one of them ever carries a SHA-1 (however it got there), it can never be corrected here. Per `Validator.matches()`, a non-null expected SHA-1 is authoritative and must match exactly; a stale one is a permanent, unrecoverable validation failure for freshly rebuilt content, exactly as described in the issue.

**Change** (`download-tools/.../UpdateCatalog.java`):
- Added `dropSha1(List<Checksum>)`, stripping the SHA-1 (keeping size/last-modified) from any historical checksum that has one.
- In `updateFile()`, apply it to the existing checksum history for HEAD-only downloadables (anything but `.zip`/`.pbf`) before merging in the freshly-observed checksum, so the published history for such files is guaranteed to have `sha1 == null` throughout and `Validator.matches()` deterministically falls back to size + last-modified + `localLaterThanRemote` — the same fallback #155/#156 already rely on for match-any validation. `.zip`/`.pbf` handling is untouched.

Added `UpdateCatalogTest` (no prior unit test existed for this class) covering `dropSha1` in isolation and the combined `dropSha1` + `mergeChecksums` scenario from the issue (a stale SHA-1 that would otherwise be forwarded forever).

**Out of scope for this repo** (left unchanged, per AGENTS.md — the catalog server is a separate codebase requiring its own coordinated change):
- Defect 1: `rc-site`'s `datasources/models.py :: DataSource.fetch_checksums` collapsing the served checksum list to a single latest entry, regressing #155's match-any-known-good design. This is the primary/root-cause defect from the issue title and needs a fix in the `rc-site` repo.
- The "investigate the anomalous `E5_N50` `17:11:22Z` sha1 row provenance" item — confirmed by code inspection that no code path in this repo produces a SHA-1 for `.rd5` files via the daily `UpdateCatalog` timer, so that row's origin is server-side/DB and can't be diagnosed from this repo.

**Note on verification:** the sandbox this task ran in blocks executing `./mvnw`/`java` directly (all such invocations require approval that isn't grantable here), so I couldn't run `./mvnw -pl download-tools -am test`. The changes were manually reviewed for correctness against the existing imports/types (`List`, `Checksum`, `DOT_ZIP`, `DOT_PBF` were already in scope) and follow the same JUnit 4 style as the module's existing tests (`ChecksumTest`, `BaseDownloadToolTest`). Please run the module's test suite in CI/PR review before merge.


Source issue: cpesch/RouteConverter#190

---
**Builder stats** · model `sonnet` · confidence `0` · 9m 5s across 1 round(s) · 2 file op(s)
[Workflow run](http://127.0.0.1:3000/cpesch/RouteConverter/actions/runs/12564)

<!-- issue-body-sha:d0eed561dbb9 -->