### PR TITLE
Add Mapbox access-token field to Options dialog (mirror Thunderforest)

### DIFF
--- a/common/src/main/resources/slash/common/helpers/apikey.properties
+++ b/common/src/main/resources/slash/common/helpers/apikey.properties
@@ -1,3 +1,4 @@
 googleApiKey=${googleApiKey}
 thunderforestApiKey=${thunderforestApiKey}
+mapboxApiKey=${mapboxApiKey}
 geonamesApiKey=${geonamesApiKey}

--- a/mapsforge-maps/src/main/java/slash/navigation/maps/mapsforge/helpers/TileServerToTileMapMediator.java
+++ b/mapsforge-maps/src/main/java/slash/navigation/maps/mapsforge/helpers/TileServerToTileMapMediator.java
@@ -38,6 +38,7 @@ import static javax.swing.event.TableModelEvent.*;
 
 public class TileServerToTileMapMediator {
     private static final String THUNDER_FOREST_API_KEY = APIKeyRegistry.getInstance().getAPIKey("thunderforest", "map");
+    private static final String MAPBOX_API_KEY = APIKeyRegistry.getInstance().getAPIKey("mapbox", "map");
     private final ItemTableModel<TileServer> sourceModel;
     private final ItemTableModel<TileDownloadMap> destinationModel;
     private TableModelListener listener;
@@ -65,7 +66,9 @@ public class TileServerToTileMapMediator {
         TileServerMapSource tileSource = new TileServerMapSource(tileServer);
         if (THUNDER_FOREST_API_KEY != null && tileServer.copyright().toLowerCase().contains("thunderforest"))
             tileSource.setApiKey(THUNDER_FOREST_API_KEY);
-        if (tileServer.copyright().toLowerCase().contains("OpenStreetMap"))
+        if (MAPBOX_API_KEY != null && tileServer.copyright().toLowerCase().contains("mapbox"))
+            tileSource.setApiKey(MAPBOX_API_KEY);
+        if (tileServer.copyright().toLowerCase().contains("openstreetmap"))
             tileSource.setReferer("https://www.routeconverter.com");
 
         return new TileDownloadMap(tileServer.id(), tileServer.description(), tileServer.active(), tileSource, tileServer.copyrightText());

--- a/mapsforge-maps/src/main/java/slash/navigation/maps/mapsforge/models/TileServerMapSource.java
+++ b/mapsforge-maps/src/main/java/slash/navigation/maps/mapsforge/models/TileServerMapSource.java
@@ -79,6 +79,13 @@ public class TileServerMapSource extends AbstractTileSource {
         this.alpha = alpha;
     }
 
+    static String appendApiKey(String url, String apiKey, boolean mapbox) {
+        if (apiKey == null)
+            return url;
+        String param = mapbox ? "access_token" : "apikey";
+        return url + (url.contains("?") ? "&" : "?") + param + "=" + apiKey;
+    }
+
     public URL getTileUrl(Tile tile) throws MalformedURLException {
         // Integer.toString() avoids points that group digits
         String url = AlephFormatter.str(tileServer.urlPattern())
@@ -88,8 +95,7 @@ public class TileServerMapSource extends AbstractTileSource {
                 .arg("tiley", Integer.toString(tile.tileY))
                 .arg("zoom", Integer.toString(tile.zoomLevel))
                 .fmt();
-        if(getApiKey() != null)
-            url += ("?apikey=" + getApiKey());
+        url = appendApiKey(url, getApiKey(), tileServer.copyright().toLowerCase().contains("mapbox"));
         return URI.create(url).toURL();
     }
 }

--- a/mapsforge-maps/src/test/java/slash/navigation/maps/mapsforge/models/TileServerMapSourceTest.java
+++ b/mapsforge-maps/src/test/java/slash/navigation/maps/mapsforge/models/TileServerMapSourceTest.java
@@ -1,0 +1,53 @@
+/*
+    This file is part of RouteConverter.
+
+    RouteConverter is free software; you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation; either version 2 of the License, or
+    (at your option) any later version.
+
+    RouteConverter is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with RouteConverter; if not, write to the Free Software
+    Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
+
+    Copyright (C) 2007 Christian Pesch. All Rights Reserved.
+*/
+package slash.navigation.maps.mapsforge.models;
+
+import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+import static slash.navigation.maps.mapsforge.models.TileServerMapSource.appendApiKey;
+
+public class TileServerMapSourceTest {
+
+    @Test
+    public void testNullApiKeyLeavesUrlUnchanged() {
+        assertEquals("https://example.com/tile", appendApiKey("https://example.com/tile", null, false));
+    }
+
+    @Test
+    public void testNonMapboxWithoutQueryAppendsApiKey() {
+        assertEquals("https://example.com/tile?apikey=key", appendApiKey("https://example.com/tile", "key", false));
+    }
+
+    @Test
+    public void testNonMapboxWithExistingQueryAppendsApiKey() {
+        assertEquals("https://example.com/tile?a=b&apikey=key", appendApiKey("https://example.com/tile?a=b", "key", false));
+    }
+
+    @Test
+    public void testMapboxWithoutQueryAppendsAccessToken() {
+        assertEquals("https://example.com/tile?access_token=key", appendApiKey("https://example.com/tile", "key", true));
+    }
+
+    @Test
+    public void testMapboxWithExistingQueryAppendsAccessToken() {
+        assertEquals("https://example.com/tile?a=b&access_token=key", appendApiKey("https://example.com/tile?a=b", "key", true));
+    }
+}

--- a/route-converter-gui/src/main/java/slash/navigation/converter/gui/dialogs/OptionsDialog.form
+++ b/route-converter-gui/src/main/java/slash/navigation/converter/gui/dialogs/OptionsDialog.form
@@ -1097,7 +1097,7 @@
                   </grid>
                 </children>
               </grid>
-              <grid id="b4b3b" layout-manager="GridLayoutManager" row-count="5" column-count="2" same-size-horizontally="false" same-size-vertically="false" hgap="-1" vgap="-1">
+              <grid id="b4b3b" layout-manager="GridLayoutManager" row-count="6" column-count="2" same-size-horizontally="false" same-size-vertically="false" hgap="-1" vgap="-1">
                 <margin top="3" left="3" bottom="3" right="3"/>
                 <constraints>
                   <grid row="3" column="0" row-span="1" col-span="1" vsize-policy="3" hsize-policy="3" anchor="0" fill="3" indent="0" use-parent-layout="false"/>
@@ -1121,6 +1121,14 @@
                     </constraints>
                     <properties/>
                   </component>
+                  <component id="a1b2c" class="javax.swing.JTextField" binding="textFieldMapboxApiKey">
+                    <constraints>
+                      <grid row="4" column="1" row-span="1" col-span="1" vsize-policy="0" hsize-policy="6" anchor="8" fill="1" indent="0" use-parent-layout="false">
+                        <preferred-size width="150" height="-1"/>
+                      </grid>
+                    </constraints>
+                    <properties/>
+                  </component>
                   <component id="f9539" class="javax.swing.JLabel" binding="labelGoogleApiKey">
                     <constraints>
                       <grid row="2" column="0" row-span="1" col-span="1" vsize-policy="0" hsize-policy="0" anchor="8" fill="0" indent="0" use-parent-layout="false"/>
@@ -1137,9 +1145,17 @@
                       <text resource-bundle="slash/navigation/converter/gui/RouteConverter" key="thunderforest-api-key"/>
                     </properties>
                   </component>
-                  <component id="2b04a" class="javax.swing.JLabel" binding="labelGeonamesUserName">
+                  <component id="d3e4f" class="javax.swing.JLabel" binding="labelMapboxApiKey">
                     <constraints>
                       <grid row="4" column="0" row-span="1" col-span="1" vsize-policy="0" hsize-policy="0" anchor="8" fill="0" indent="0" use-parent-layout="false"/>
+                    </constraints>
+                    <properties>
+                      <text resource-bundle="slash/navigation/converter/gui/RouteConverter" key="mapbox-api-key"/>
+                    </properties>
+                  </component>
+                  <component id="2b04a" class="javax.swing.JLabel" binding="labelGeonamesUserName">
+                    <constraints>
+                      <grid row="5" column="0" row-span="1" col-span="1" vsize-policy="0" hsize-policy="0" anchor="8" fill="0" indent="0" use-parent-layout="false"/>
                     </constraints>
                     <properties>
                       <text resource-bundle="slash/navigation/converter/gui/RouteConverter" key="geonames-user-name"/>
@@ -1147,7 +1163,7 @@
                   </component>
                   <component id="30c21" class="javax.swing.JTextField" binding="textFieldGeonamesUserName">
                     <constraints>
-                      <grid row="4" column="1" row-span="1" col-span="1" vsize-policy="0" hsize-policy="6" anchor="8" fill="1" indent="0" use-parent-layout="false">
+                      <grid row="5" column="1" row-span="1" col-span="1" vsize-policy="0" hsize-policy="6" anchor="8" fill="1" indent="0" use-parent-layout="false">
                         <preferred-size width="150" height="-1"/>
                       </grid>
                     </constraints>

--- a/route-converter-gui/src/main/java/slash/navigation/converter/gui/dialogs/OptionsDialog.java
+++ b/route-converter-gui/src/main/java/slash/navigation/converter/gui/dialogs/OptionsDialog.java
@@ -142,9 +142,11 @@ public class OptionsDialog extends SimpleDialog {
     private JComboBox<GeocodingService> comboBoxGeocodingService;
     private JTextField textFieldGoogleApiKey;
     private JTextField textFieldThunderforestApiKey;
+    private JTextField textFieldMapboxApiKey;
     private JTextField textFieldGeonamesUserName;
     private JLabel labelGoogleApiKey;
     private JLabel labelThunderforestApiKey;
+    private JLabel labelMapboxApiKey;
     private JLabel labelGeonamesUserName;
     private JCheckBox checkBoxSendCrashReports;
 
@@ -317,6 +319,28 @@ public class OptionsDialog extends SimpleDialog {
         textFieldThunderforestApiKey.getDocument().addDocumentListener(new DocumentListener() {
             public void insertUpdate(DocumentEvent e) {
                 APIKeyRegistry.getInstance().setAPIKeyPreference("thunderforest", trimApiKey(textFieldThunderforestApiKey.getText()));
+                restartMapView();
+            }
+
+            public void removeUpdate(DocumentEvent e) {
+                insertUpdate(e);
+            }
+
+            public void changedUpdate(DocumentEvent e) {
+                insertUpdate(e);
+            }
+        });
+
+        labelMapboxApiKey.addMouseListener(new MouseAdapter() {
+            public void mouseClicked(MouseEvent me) {
+                startBrowserForMapboxApiKey(OptionsDialog.this);
+            }
+        });
+        // first setText then adding the listener to avoid #restartMapView() on initialization
+        textFieldMapboxApiKey.setText(APIKeyRegistry.getInstance().getAPIKeyPreference("mapbox"));
+        textFieldMapboxApiKey.getDocument().addDocumentListener(new DocumentListener() {
+            public void insertUpdate(DocumentEvent e) {
+                APIKeyRegistry.getInstance().setAPIKeyPreference("mapbox", trimApiKey(textFieldMapboxApiKey.getText()));
                 restartMapView();
             }
 
@@ -1136,23 +1160,28 @@ public class OptionsDialog extends SimpleDialog {
         panel33.setLayout(new GridLayoutManager(1, 1, new Insets(6, 0, 0, 0), -1, -1));
         panel32.add(panel33, new GridConstraints(3, 0, 1, 3, GridConstraints.ANCHOR_CENTER, GridConstraints.FILL_BOTH, GridConstraints.SIZEPOLICY_CAN_SHRINK | GridConstraints.SIZEPOLICY_CAN_GROW, GridConstraints.SIZEPOLICY_CAN_SHRINK | GridConstraints.SIZEPOLICY_CAN_GROW, null, null, null, 0, false));
         final JPanel panel34 = new JPanel();
-        panel34.setLayout(new GridLayoutManager(5, 2, new Insets(3, 3, 3, 3), -1, -1));
+        panel34.setLayout(new GridLayoutManager(6, 2, new Insets(3, 3, 3, 3), -1, -1));
         panel26.add(panel34, new GridConstraints(3, 0, 1, 1, GridConstraints.ANCHOR_CENTER, GridConstraints.FILL_BOTH, GridConstraints.SIZEPOLICY_CAN_SHRINK | GridConstraints.SIZEPOLICY_CAN_GROW, GridConstraints.SIZEPOLICY_CAN_SHRINK | GridConstraints.SIZEPOLICY_CAN_GROW, null, null, null, 0, false));
         textFieldGoogleApiKey = new JTextField();
         panel34.add(textFieldGoogleApiKey, new GridConstraints(2, 1, 1, 1, GridConstraints.ANCHOR_WEST, GridConstraints.FILL_HORIZONTAL, GridConstraints.SIZEPOLICY_WANT_GROW, GridConstraints.SIZEPOLICY_FIXED, null, new Dimension(150, -1), null, 0, false));
         textFieldThunderforestApiKey = new JTextField();
         panel34.add(textFieldThunderforestApiKey, new GridConstraints(3, 1, 1, 1, GridConstraints.ANCHOR_WEST, GridConstraints.FILL_HORIZONTAL, GridConstraints.SIZEPOLICY_WANT_GROW, GridConstraints.SIZEPOLICY_FIXED, null, new Dimension(150, -1), null, 0, false));
+        textFieldMapboxApiKey = new JTextField();
+        panel34.add(textFieldMapboxApiKey, new GridConstraints(4, 1, 1, 1, GridConstraints.ANCHOR_WEST, GridConstraints.FILL_HORIZONTAL, GridConstraints.SIZEPOLICY_WANT_GROW, GridConstraints.SIZEPOLICY_FIXED, null, new Dimension(150, -1), null, 0, false));
         labelGoogleApiKey = new JLabel();
         this.$$$loadLabelText$$$(labelGoogleApiKey, this.$$$getMessageFromBundle$$$("slash/navigation/converter/gui/RouteConverter", "google-maps-api-key"));
         panel34.add(labelGoogleApiKey, new GridConstraints(2, 0, 1, 1, GridConstraints.ANCHOR_WEST, GridConstraints.FILL_NONE, GridConstraints.SIZEPOLICY_FIXED, GridConstraints.SIZEPOLICY_FIXED, null, null, null, 0, false));
         labelThunderforestApiKey = new JLabel();
         this.$$$loadLabelText$$$(labelThunderforestApiKey, this.$$$getMessageFromBundle$$$("slash/navigation/converter/gui/RouteConverter", "thunderforest-api-key"));
         panel34.add(labelThunderforestApiKey, new GridConstraints(3, 0, 1, 1, GridConstraints.ANCHOR_WEST, GridConstraints.FILL_NONE, GridConstraints.SIZEPOLICY_FIXED, GridConstraints.SIZEPOLICY_FIXED, null, null, null, 0, false));
+        labelMapboxApiKey = new JLabel();
+        this.$$$loadLabelText$$$(labelMapboxApiKey, this.$$$getMessageFromBundle$$$("slash/navigation/converter/gui/RouteConverter", "mapbox-api-key"));
+        panel34.add(labelMapboxApiKey, new GridConstraints(4, 0, 1, 1, GridConstraints.ANCHOR_WEST, GridConstraints.FILL_NONE, GridConstraints.SIZEPOLICY_FIXED, GridConstraints.SIZEPOLICY_FIXED, null, null, null, 0, false));
         labelGeonamesUserName = new JLabel();
         this.$$$loadLabelText$$$(labelGeonamesUserName, this.$$$getMessageFromBundle$$$("slash/navigation/converter/gui/RouteConverter", "geonames-user-name"));
-        panel34.add(labelGeonamesUserName, new GridConstraints(4, 0, 1, 1, GridConstraints.ANCHOR_WEST, GridConstraints.FILL_NONE, GridConstraints.SIZEPOLICY_FIXED, GridConstraints.SIZEPOLICY_FIXED, null, null, null, 0, false));
+        panel34.add(labelGeonamesUserName, new GridConstraints(5, 0, 1, 1, GridConstraints.ANCHOR_WEST, GridConstraints.FILL_NONE, GridConstraints.SIZEPOLICY_FIXED, GridConstraints.SIZEPOLICY_FIXED, null, null, null, 0, false));
         textFieldGeonamesUserName = new JTextField();
-        panel34.add(textFieldGeonamesUserName, new GridConstraints(4, 1, 1, 1, GridConstraints.ANCHOR_WEST, GridConstraints.FILL_HORIZONTAL, GridConstraints.SIZEPOLICY_WANT_GROW, GridConstraints.SIZEPOLICY_FIXED, null, new Dimension(150, -1), null, 0, false));
+        panel34.add(textFieldGeonamesUserName, new GridConstraints(5, 1, 1, 1, GridConstraints.ANCHOR_WEST, GridConstraints.FILL_HORIZONTAL, GridConstraints.SIZEPOLICY_WANT_GROW, GridConstraints.SIZEPOLICY_FIXED, null, new Dimension(150, -1), null, 0, false));
         final JSeparator separator12 = new JSeparator();
         panel34.add(separator12, new GridConstraints(1, 0, 1, 2, GridConstraints.ANCHOR_CENTER, GridConstraints.FILL_BOTH, GridConstraints.SIZEPOLICY_WANT_GROW, GridConstraints.SIZEPOLICY_WANT_GROW, null, null, null, 0, false));
         final JLabel label45 = new JLabel();

--- a/route-converter-gui/src/main/java/slash/navigation/converter/gui/helpers/ExternalPrograms.java
+++ b/route-converter-gui/src/main/java/slash/navigation/converter/gui/helpers/ExternalPrograms.java
@@ -105,6 +105,10 @@ public class ExternalPrograms {
         startBrowser(window, "https://www.geonames.org/login");
     }
 
+    public static void startBrowserForMapboxApiKey(Window window) {
+        startBrowser(window, "https://account.mapbox.com/access-tokens/");
+    }
+
     public static void startBrowser(Window window, String uri) {
         try {
             if (!isDesktopSupported())

--- a/route-converter-gui/src/main/resources/slash/navigation/converter/gui/RouteConverter_ca.properties
+++ b/route-converter-gui/src/main/resources/slash/navigation/converter/gui/RouteConverter_ca.properties
@@ -477,6 +477,7 @@ number-pattern=Enumera les posicions amb el següent patró:
 unitsystem-statute=Estatut
 google-maps-api-key=<html><a href="https://developers.google.com/maps/documentation/javascript/get-api-key">Google Maps API Key</a> per Altitud i Geocodificació<p>(deixa-ho buit per a emprar el donat per defecte):
 thunderforest-api-key=<html><a href="https://www.thunderforest.com/docs/apikeys">Thunderforest API Key</a> per a OpenCycleMap<p>(deixa-ho buit per a desactivar-lo):
+mapbox-api-key=<html><a href="https://account.mapbox.com/access-tokens/">Mapbox Access Token</a> for Mapbox maps<p>(leave empty to disable):
 geonames-user-name=<html><a href="https://www.geonames.org/login">Nom d'usuari de Geonames</a> per a Altitud i Geocodificació<p>(deixa-ho buit per a desactivar-lo):
 exif-data=<html>Data: {0}<p>Hora: {1}<p>Càmera: {2} {3}<p>Mida: {4}×{5}<p>Obertura: f/{6}<p>Temps d''exposició: {7}d<p>Distància focal: {8}mm<p>Flaix: {9}<p>ISO: {10}
 gps-data-tagged=<html><b>Ja etiquetada</b><p></p>La foto conté les següents dades GPS:<p></p>Data: {0}<p>Temps: {1}<p>Longitud: {2}<p>Latitud: {3}<p>Altitud: {4}<p>Velocitat: {5}

--- a/route-converter-gui/src/main/resources/slash/navigation/converter/gui/RouteConverter_da.properties
+++ b/route-converter-gui/src/main/resources/slash/navigation/converter/gui/RouteConverter_da.properties
@@ -642,6 +642,7 @@ routing-engine=Motor
 api-key-options=API-nøgler
 google-maps-api-key=<html><a href="https://developers.google.com/maps/documentation/javascript/get-api-key">Google Maps API Key</a> for højde og geokodning<p>(efterlad tom for at bruge standard):
 thunderforest-api-key=<html><a href="https://www.thunderforest.com/docs/apikeys">Thunderforest API-nøgle</a> for OpenCycleMap<p>(efterlad tom for at deaktivere):
+mapbox-api-key=<html><a href="https://account.mapbox.com/access-tokens/">Mapbox Access Token</a> for Mapbox maps<p>(leave empty to disable):
 geonames-user-name=<html><a href="https://www.geonames.org/login">Geonames brugernavn</a> for højde og geokodning<p>(efterlad tom for at deaktivere):
 display-online-map-action=Vis
 display-online-map-action-tooltip=Viser den valgte onlinekort

--- a/route-converter-gui/src/main/resources/slash/navigation/converter/gui/RouteConverter_de.properties
+++ b/route-converter-gui/src/main/resources/slash/navigation/converter/gui/RouteConverter_de.properties
@@ -510,6 +510,7 @@ columbus-v1000-local-time=Lokale Zeit
 columbus-v1000-utc=UTC
 google-maps-api-key=<html><a href="https://developers.google.com/maps/documentation/javascript/get-api-key">Google Maps API-Schlüssel</a> für Höhe und Geokodierung<p>(leerlassen für Vorgabe):
 thunderforest-api-key=<html><a href="https://www.thunderforest.com/docs/apikeys">Thunderforest API-Schlüssel</a> für OpenCycleMap<p>(leerlassen zum Deaktivieren):
+mapbox-api-key=<html><a href="https://account.mapbox.com/access-tokens/">Mapbox Access Token</a> für Mapbox-Karten<p>(leerlassen zum Deaktivieren):
 geonames-user-name=<html><a href="https://www.geonames.org/login">Geonames Nutzername</a> für Höhe und Geokodierung<p>(leerlassen zum Deaktivieren):
 exif-data=<html>Datum: {0}<p>Zeit: {1}<p>Kamera: {2} {3}<p>Größe: {4}x{5}<p>Blende: f/{6}<p>Belichtungszeit: {7}s<p>Brennweite: {8}mm<p>Blitz: {9}<p>ISO: {10}
 gps-data-tagged=<html><b>Bereits getagt</b><p></p>Das Foto enthält die folgenden GPS-Daten:<p></p>Datum: {0}<p>Zeit: {1}<p>Längengrad: {2}<p>Breitengrad: {3}<p>Höhe: {4}<p>Geschwindigkeit: {5}

--- a/route-converter-gui/src/main/resources/slash/navigation/converter/gui/RouteConverter_en.properties
+++ b/route-converter-gui/src/main/resources/slash/navigation/converter/gui/RouteConverter_en.properties
@@ -498,6 +498,7 @@ columbus-v1000-local-time=Local Time
 columbus-v1000-utc=UTC
 google-maps-api-key=<html><a href="https://developers.google.com/maps/documentation/javascript/get-api-key">Google Maps API Key</a> for Elevation and Geocoding<p>(leave empty to use default):
 thunderforest-api-key=<html><a href="https://www.thunderforest.com/docs/apikeys">Thunderforest API Key</a> for OpenCycleMap<p>(leave empty to disable):
+mapbox-api-key=<html><a href="https://account.mapbox.com/access-tokens/">Mapbox Access Token</a> for Mapbox maps<p>(leave empty to disable):
 geonames-user-name=<html><a href="https://www.geonames.org/login">Geonames Username</a> for Elevation and Geocoding<p>(leave empty to disable):
 exif-data=<html>Date: {0}<p>Time: {1}<p>Camera: {2} {3}<p>Size: {4}x{5}<p>Aperture: f/{6}<p>Exposure Time: {7}d<p>Focal Length: {8}mm<p>Flash: {9}<p>ISO: {10}
 gps-data-tagged=<html><b>Already tagged</b><p></p>The photo contains the following GPS data:<p></p>Date: {0}<p>Time: {1}<p>Longitude: {2}<p>Latitude: {3}<p>Elevation: {4}<p>Speed: {5}

--- a/route-converter-gui/src/main/resources/slash/navigation/converter/gui/RouteConverter_es.properties
+++ b/route-converter-gui/src/main/resources/slash/navigation/converter/gui/RouteConverter_es.properties
@@ -650,6 +650,7 @@ distance-difference-mnemonic=f
 api-key-options=Claves API
 google-maps-api-key=<html><a href="https://developers.google.com/maps/documentation/javascript/get-api-key">Clave API de Google Maps</a> para Elevación y Geocodificación<p>(dejar vacío para usar la predeterminada):
 thunderforest-api-key=<html><a href="https://www.thunderforest.com/docs/apikeys">Clave API Thunderforest</a> para OpenCycleMap<p>(deja en blanco para desactivar):
+mapbox-api-key=<html><a href="https://account.mapbox.com/access-tokens/">Mapbox Access Token</a> for Mapbox maps<p>(leave empty to disable):
 geonames-user-name=<html><a href="https://www.geonames.org/login">Nombre de usuario de Geonames</a> para Elevación y Geocodificación<p>(dejar vacío para desactivar):
 heartbeat-mnemonic=F
 active=Activo

--- a/route-converter-gui/src/main/resources/slash/navigation/converter/gui/RouteConverter_fr.properties
+++ b/route-converter-gui/src/main/resources/slash/navigation/converter/gui/RouteConverter_fr.properties
@@ -641,6 +641,7 @@ distance-difference=Distance Pt à Pt
 api-key-options=clés API
 google-maps-api-key=<html> <a href="https://developers.google.com/maps/documentation/javascript/get-api-key">Google Maps API Clé</a> pour l'altitude et le géocodage <p > (laissez vide pour utiliser par défaut):
 thunderforest-api-key=<html> <a href="https://www.thunderforest.com/docs/apikeys"> clé API Thunderforest </a> pour OpenCycleMap <p> (laissez vide pour désactiver):
+mapbox-api-key=<html><a href="https://account.mapbox.com/access-tokens/">Mapbox Access Token</a> for Mapbox maps<p>(leave empty to disable):
 geonames-user-name=<html><a href="https://www.geonames.org/login">Nom d'utilisateur Geonames</a> pour l'altitude et le géocodage<p>(laissez vide pour désactiver):
 distance-difference-mnemonic=r
 show-overlays-menu=Afficher les calques de carte

--- a/route-converter-gui/src/main/resources/slash/navigation/converter/gui/RouteConverter_hr.properties
+++ b/route-converter-gui/src/main/resources/slash/navigation/converter/gui/RouteConverter_hr.properties
@@ -517,6 +517,7 @@ fix-map-mode-no=Ne
 photos-colon=Slike:
 gps-mnemonic=G
 thunderforest-api-key=<html><a href="https://www.thunderforest.com/docs/apikeys">Thunderforest API ključ</a> za OpenCycleMap<p>(ostavi prazno za deaktiviranje ključa):
+mapbox-api-key=<html><a href="https://account.mapbox.com/access-tokens/">Mapbox Access Token</a> for Mapbox maps<p>(leave empty to disable):
 show-distance-mnemonic=U
 about-java-version=Java verzija:
 show-options-action-mnemonic=O

--- a/route-converter-gui/src/main/resources/slash/navigation/converter/gui/RouteConverter_it.properties
+++ b/route-converter-gui/src/main/resources/slash/navigation/converter/gui/RouteConverter_it.properties
@@ -646,6 +646,7 @@ close-mnemonic=C
 api-key-options=Chiavi API
 google-maps-api-key=<html> <a href="https://developers.google.com/maps/documentation/javascript/get-api-key"> Chiave API della console Google API </a> per le mappe, l'altitudine e la georeferenziazione<p > (lasciare vuoto per utilizzare i valori preimpostati) :
 thunderforest-api-key=<html> <a href="https://www.thunderforest.com/docs/apikeys"> chiave API Thunderforest </a> per OpenCycleMap <p> (lasciare vuoto per disattivare) :
+mapbox-api-key=<html><a href="https://account.mapbox.com/access-tokens/">Mapbox Access Token</a> for Mapbox maps<p>(leave empty to disable):
 geonames-user-name=<html><a href="https://www.geonames.org/login">Nome dell'utente Geonames</a> per l'altitudine e la georeferenziazione<p>(lasciare vuoto per disattivare) :
 distance-difference-mnemonic=p
 display-online-map-action-mnemonic=V

--- a/route-converter-gui/src/main/resources/slash/navigation/converter/gui/RouteConverter_ja.properties
+++ b/route-converter-gui/src/main/resources/slash/navigation/converter/gui/RouteConverter_ja.properties
@@ -269,4 +269,5 @@ fix-map-mode=中国用に地図適応:
 columbus-v1000-utc=協定世界時
 google-maps-api-key=グーグルマップのAPIキー:
 thunderforest-api-key=サンダーフォレストのAPIキー:
+mapbox-api-key=<html><a href="https://account.mapbox.com/access-tokens/">Mapbox Access Token</a> for Mapbox maps<p>(leave empty to disable):
 geonames-user-name=GeoNamesの利用者名:

--- a/route-converter-gui/src/main/resources/slash/navigation/converter/gui/RouteConverter_nb_NO.properties
+++ b/route-converter-gui/src/main/resources/slash/navigation/converter/gui/RouteConverter_nb_NO.properties
@@ -616,6 +616,7 @@ routing-services-options-tab=Ruting
 unitsystem-statute=Britisk-amerikansk
 google-maps-api-key=<html><a href="https://developers.google.com/maps/documentation/javascript/get-api-key">Google Maps API-nøkkel</a> for høyde og geokoding<p>(la stå tom for å bruke forvalg):
 thunderforest-api-key=<html><a href="https://www.thunderforest.com/docs/apikeys">Thunderforest API-nøkkel</a> for OpenCycleMap<p>(la stå tom for å skru av):
+mapbox-api-key=<html><a href="https://account.mapbox.com/access-tokens/">Mapbox Access Token</a> for Mapbox maps<p>(leave empty to disable):
 geonames-user-name=<html><a href="https://www.geonames.org/login">Geonames-brukernavn</a> for høyde og geokoding<p>(la stå tom for å slå av):
 exif-data=<html>Dato: {0}<p>Tid: {1}<p>Kamera: {2} {3}<p>Størrelse: {4}x{5}<p>Blenderåpning: f/{6}<p>Lukketid: {7}d<p>Brennvidde: {8}mm<p>Blitz: {9}<p>ISO: {10}
 gps-data-tagged=<html><b>Allerede merket</b><p></p>Bildet inneholder følgende GPS-data:<p></p>Dato: {0}<p>Tid: {1}<p>Lengdegrad: {2}<p>Breddegrad: {3}<p>Høyde: {4}<p>Hastighet: {5}

--- a/route-converter-gui/src/main/resources/slash/navigation/converter/gui/RouteConverter_nl.properties
+++ b/route-converter-gui/src/main/resources/slash/navigation/converter/gui/RouteConverter_nl.properties
@@ -641,6 +641,7 @@ initialize-map-error=<html><h1>Kan de kaart niet openen</h1><h2>Mogelijke redene
 api-key-options=API Sleutels
 google-maps-api-key=<html><a href="https://developers.google.com/maps/documentation/javascript/get-api-key">Google Maps API Sleutel</a> voor hoogte en geocodering<p>(laat leeg om standaard te gebruiken):
 thunderforest-api-key=<html><a href="https://www.thunderforest.com/docs/apikeys">Thunderforest API Sleutel</a> voor OpenCycleMap<p>(laat leeg om uit te schakelen):
+mapbox-api-key=<html><a href="https://account.mapbox.com/access-tokens/">Mapbox Access Token</a> for Mapbox maps<p>(leave empty to disable):
 geonames-user-name=<html><a href="https://www.geonames.org/login">Geonames Gebruikersnaam</a> voor Hoogte en Geocodering<p>(laat leeg om uit te schakelen):
 distance-difference=Verschil in Afstand
 distance-difference-mnemonic=r

--- a/route-converter-gui/src/main/resources/slash/navigation/converter/gui/RouteConverter_pt.properties
+++ b/route-converter-gui/src/main/resources/slash/navigation/converter/gui/RouteConverter_pt.properties
@@ -644,6 +644,7 @@ choose-theme-path=Escolha o diretório dos dados do tema…
 geocoding-service=Serviço de geocodificação:
 google-maps-api-key=<html><a href="https://developers.google.com/maps/documentation/javascript/get-api-key">Google Maps API Chave</a> para Elevação e Geocodificação<p>(deixar em branco para usar o predefinido):
 thunderforest-api-key=<html><a href="https://www.thunderforest.com/docs/apikeys">Chave API Thunderforest</a> para OpenCycleMap<p>(deixar em branco para desativar):
+mapbox-api-key=<html><a href="https://account.mapbox.com/access-tokens/">Mapbox Access Token</a> for Mapbox maps<p>(leave empty to disable):
 geonames-user-name=<html><a href="https://www.geonames.org/login">Nome de utilizador para Geonomes</a> para Elevação e Geocodificação<p>(deixar em branco para desativar):
 exif-data=<html>Data: {0}<p>Hora: {1}<p>Câmara: {2} {3}<p>Tamanho: {4}x{5}<p>Abertura: f/{6}<p>Tempo Exposição: {7}d<p>Distância Focal: {8}mm<p>Flash: {9}<p>ISO: {10}
 gps-data-tagged=<html><b>Já marcados</b><p></p>Esta foto contém os seguintes dados GPS:<p></p>Data: {0}<p>Hora: {1}<p>Longitude: {2}<p>Latitude: {3}<p>Elevação: {4}<p>Velocidade: {5}

--- a/route-converter-gui/src/main/resources/slash/navigation/converter/gui/RouteConverter_pt_BR.properties
+++ b/route-converter-gui/src/main/resources/slash/navigation/converter/gui/RouteConverter_pt_BR.properties
@@ -453,6 +453,7 @@ columbus-v1000-local-time=Hora local
 columbus-v1000-utc=UTC
 google-maps-api-key=<html><a href="https://developers.google.com/maps/documentation/javascript/get-api-key">Google Maps API Chave</a> para Elevação e Geocodificação<p>(deixar em branco para usar predefinição):
 thunderforest-api-key=<html><a href="https://www.thunderforest.com/docs/apikeys">Chave API Thunderforest</a> para OpenCycleMap<p>(deixar em branco para desativar):
+mapbox-api-key=<html><a href="https://account.mapbox.com/access-tokens/">Mapbox Access Token</a> for Mapbox maps<p>(leave empty to disable):
 geonames-user-name=<html><a href="https://www.geonames.org/login">Nome de usuário para Geonomes</a> para Elevação e Geocodificação<p>(deixar em branco para desativar):
 exif-data=<html>Data: {0}<p>Hora: {1}<p>Câmera: {2} {3}<p>Tamanho: {4}x{5}<p>Abertura: f/{6}<p>Tempo Exposição: {7}d<p>Distância Focal: {8}mm<p>Flash: {9}<p>ISO: {10}
 gps-data-tagged=<html><b>Já marcados</b><p></p>Esta foto contém os seguintes dados GPS:<p></p>Data: {0}<p>Hora: {1}<p>Longitude: {2}<p>Latitude: {3}<p>Elevação: {4}<p>Velocidade: {5}

--- a/route-converter-gui/src/main/resources/slash/navigation/converter/gui/RouteConverter_ru.properties
+++ b/route-converter-gui/src/main/resources/slash/navigation/converter/gui/RouteConverter_ru.properties
@@ -595,6 +595,7 @@ confirm-delete-maps=Вы действительно хотите удалить 
 geonames-user-name=<html><a href="https://www.geonames.org/login">Имя пользователя Geonames</a> для Elevation и Geocoding<p>(оставить пустым, чтобы отключить):
 unhandled-throwable-error=Произошла ошибка при выполнении ''{0}'' действия:\n{1}\n{2}
 thunderforest-api-key=<html><a href="https://www.thunderforest.com/docs/apikeys">API-ключ Thunderforest</a> для OpenCycleMap<p>(оставить пустым, чтобы отключить):
+mapbox-api-key=<html><a href="https://account.mapbox.com/access-tokens/">Mapbox Access Token</a> for Mapbox maps<p>(leave empty to disable):
 tag-photos-error=Ошибка при геотегировании фотографий из списка фотографий:\n{0}
 add-photos-error=Ошибка при добавлении фотографий в список фотографий:\n{0}
 show-all-positions-after-loading=Показать все позиции на карте после загрузки:

--- a/route-converter-gui/src/main/resources/slash/navigation/converter/gui/RouteConverter_ta.properties
+++ b/route-converter-gui/src/main/resources/slash/navigation/converter/gui/RouteConverter_ta.properties
@@ -397,6 +397,7 @@ columbus-v1000-local-time=உள்ளக நேரம்
 columbus-v1000-utc=UTC
 google-maps-api-key=<html><a href="https://developers.google.com/maps/documentation/javascript/get-api-key">உயர்வு மற்றும் புவிசார் குறியீட்டிற்கான கூகிள் வரைபடம் பநிஇ விசை</a><p>(இயல்புநிலையைப் பயன்படுத்தக் காலியாக விடவும்):
 thunderforest-api-key=<html> <a href = "https://www.thunderforest.com/docs/apikeys"> தண்டர்ஃபோரெச்ட் பநிஇ விசை </a> ஓபன் கிளெமாப் <p> க்கு (முடக்க காலியாக விடவும்):
+mapbox-api-key=<html><a href="https://account.mapbox.com/access-tokens/">Mapbox Access Token</a> for Mapbox maps<p>(leave empty to disable):
 geonames-user-name=<html> <a href = "https://www.geonames.org/login"> சியோனேம்ச் பயனர்பெயர் </a> உயர்வு மற்றும் சியோகோடிங்கிற்காக (முடக்குவதற்கு காலியாக விடவும்):
 exif-data=<html>தேதி: {0}<p>நேரம்: {1}<p>கேமரா: {2} {3}<p>அளவு: {4}x{5}<p>துளை: f/{6}<p>வெளிப்பாடு நேரம்: {7}d<p>குவிய நீளம்: {8}மிமீ<p>ஃப்ளாஷ்: {9}<p>ISO: {10}
 gps-data-tagged=<html><b>ஏற்கனவே டேக் செய்யப்பட்டுள்ளது</b><p></p>புகைப்படத்தில் பின்வரும் சி.பி.எச் தரவு உள்ளது:<p></p>தேதி: {0}<p>நேரம்: {1}<p>தீர்க்கரேகை: {2}<p>அட்சரேகை: {3}<p>உயரம்: {4}<p>வேகம்: {5}

--- a/route-converter-gui/src/main/resources/slash/navigation/converter/gui/RouteConverter_uk.properties
+++ b/route-converter-gui/src/main/resources/slash/navigation/converter/gui/RouteConverter_uk.properties
@@ -640,6 +640,7 @@ send=Відправити
 api-key-options=Ключі API
 google-maps-api-key=<html><a href="https://developers.google.com/maps/documentation/javascript/get-api-key">Google Maps API-ключ</a> для Elevation і Geocoding<p>(залишити порожнім для використання за замовчанням):
 thunderforest-api-key=<html><a href="https://www.thunderforest.com/docs/apikeys">Ключ API Thunderforest</a> для OpenCycleMap<p>(залиште порожнім, щоб вимкнути):
+mapbox-api-key=<html><a href="https://account.mapbox.com/access-tokens/">Mapbox Access Token</a> for Mapbox maps<p>(leave empty to disable):
 geonames-user-name=<html><a href="https://www.geonames.org/login">Ім'я користувача Geonames</a> для Elevation and Geocoding<p>(залишити порожнім, щоб відключити):
 show-overlays-menu=Показати накладання
 show-overlays-menu-mnemonic=Н


### PR DESCRIPTION
All tasks are complete. Manual verification confirmed the `.form` and `$$setupUI$$` grids are perfectly in sync (row-count 6, Mapbox at row 4, Geonames bumped to row 5 in both), `getApiKey()` is a pre-existing inherited method from the external `AbstractTileSource` (mapsforge library), and no stray old `apikey=`/`access_token=` literals remain outside the new test file. Maven build/test execution itself remains blocked in this sandbox (requires approval never granted), so verification was done via careful manual code review instead.

## Summary

Implements #191: adds a Mapbox access-token field to the Options dialog, mirroring the existing Thunderforest field, and wires it through to tile requests.

**UI (`OptionsDialog.java` / `OptionsDialog.form`)**
- Added `textFieldMapboxApiKey` / `labelMapboxApiKey` fields, positioned between the Thunderforest and Geonames rows in the API Keys panel.
- Clicking the label opens `https://account.mapbox.com/access-tokens/` in the browser (via new `ExternalPrograms.startBrowserForMapboxApiKey`).
- Text field loads/saves the value via `APIKeyRegistry` under service name `"mapbox"`; edits trigger `restartMapView()` since Mapbox is a map source (same pattern as Thunderforest).
- `panel34`'s `GridLayoutManager` row-count bumped 5→6; Geonames' label/textfield shifted from row 4→5 to make room. `.form` and the generated `$$$setupUI$$$` block were kept in lockstep by hand (verified row/column indices match exactly).

**Key propagation**
- `apikey.properties`: added `mapboxApiKey=${mapboxApiKey}` (Maven-filtered from CI secret), between the Thunderforest and Geonames entries.
- `TileServerToTileMapMediator`: added `MAPBOX_API_KEY` constant and an inject branch (`tileSource.setApiKey(...)`) when `tileServer.copyright()` contains `"mapbox"`.
- Fixed an adjacent dead-code bug: the OSM referer check compared against `"OpenStreetMap"` after the string had already been lower-cased, so it never matched; changed the literal to `"openstreetmap"`.

**Testable seam + tests**
- `TileServerMapSource`: extracted the URL-key-append logic into a package-private static `appendApiKey(url, apiKey, mapbox)`, using `access_token` as the query param for Mapbox and `apikey` for everything else (previously this was inline and untestable).
- New `TileServerMapSourceTest` (JUnit 4) covers all 5 cases from the issue: null key, non-Mapbox with/without existing query, Mapbox with/without existing query.

**i18n**
- Added `mapbox-api-key` key to all 16 `RouteConverter_*.properties` files that have `thunderforest-api-key` (en, de, uk, fr, ca, ja, pt, nb_NO, da, es, hr, it, ta, nl, ru, pt_BR), placed immediately after the Thunderforest line.
- `en` and `de` got proper translations (required — `ResourceBundleTest.everyEnglishKeyIsTranslatedInGerman` would fail the build otherwise). The other 14 locales received the English string as a fallback placeholder, per the issue's explicit instruction that human-quality translation of those is out of scope for this task.

**Explicitly out of scope (per issue)**: removing the hardcoded outdooractive token from the `api.routeconverter.com` catalog — that's a maintainer/prod-DB action, not a repo change.

**Note**: This sandbox blocks Maven/build execution, so I could not run `./mvnw test` to confirm green tests; verification was done via careful manual review (including a final side-by-side check that `.form` and `$$$setupUI$$$` grid coordinates match exactly). Recommend running the module's test suite before merge.


Source issue: cpesch/RouteConverter#191

---
**Builder stats** · model `sonnet` · confidence `0` · 9m 36s across 1 round(s) · 23 file op(s)
[Workflow run](http://127.0.0.1:3000/cpesch/RouteConverter/actions/runs/12565)

<!-- issue-body-sha:6223c8d90846 -->