### PR TITLE
fix(map): show world-map background under any displayed map, not only…

### DIFF
--- a/mapsforge-mapview/src/main/java/slash/navigation/mapview/mapsforge/BackgroundMapAttachment.java
+++ b/mapsforge-mapview/src/main/java/slash/navigation/mapview/mapsforge/BackgroundMapAttachment.java
@@ -24,6 +24,14 @@ package slash.navigation.mapview.mapsforge;
  * base layer, independent of the order in which the async background map
  * download (Path B) and the EDT map/theme layer-stack build (Path A) run.
  *
+ * The world map is a global, low-detail base layer: it belongs underneath every
+ * displayed map regardless of type, not just Mapsforge maps. It fills the area a
+ * partial offline map (Mapsforge/MBTiles) does not cover, and it keeps the
+ * offline edition usable when its only selectable map is the online OpenStreetMap
+ * default and those tiles cannot be reached - without it the map stays gray.
+ * The background sits at layer index 0, so an opaque map on top hides it and
+ * there is no visible cost when the displayed map does render.
+ *
  * @author Christian Pesch
  */
 
@@ -34,14 +42,9 @@ public class BackgroundMapAttachment {
     /**
      * @param layerReady            whether the background layer has been built successfully
      * @param hasDisplayedMap       whether a map is currently displayed
-     * @param displayedMapIsMapsforge whether the displayed map is of type Mapsforge
      * @return true iff the world-map background layer should be attached as the base layer now
      */
-    public static boolean shouldAttachBackground(boolean layerReady, boolean hasDisplayedMap, boolean displayedMapIsMapsforge) {
-        if (!layerReady)
-            return false;
-        if (!hasDisplayedMap)
-            return false;
-        return displayedMapIsMapsforge;
+    public static boolean shouldAttachBackground(boolean layerReady, boolean hasDisplayedMap) {
+        return layerReady && hasDisplayedMap;
     }
 }

--- a/mapsforge-mapview/src/main/java/slash/navigation/mapview/mapsforge/MapsforgeMapView.java
+++ b/mapsforge-mapview/src/main/java/slash/navigation/mapview/mapsforge/MapsforgeMapView.java
@@ -679,9 +679,7 @@ public class MapsforgeMapView extends BaseMapView {
             layers.remove(backgroundLayer);
 
         LocalMap map = getMapManager().getDisplayedMapModel().getItem();
-        boolean shouldAttach = BackgroundMapAttachment.shouldAttachBackground(backgroundLayer != null,
-                map != null, map != null && map.getType().equals(Mapsforge));
-        if (shouldAttach)
+        if (BackgroundMapAttachment.shouldAttachBackground(backgroundLayer != null, map != null))
             layers.add(0, backgroundLayer);
     }
 

--- a/mapsforge-mapview/src/test/java/slash/navigation/mapview/mapsforge/BackgroundMapAttachmentTest.java
+++ b/mapsforge-mapview/src/test/java/slash/navigation/mapview/mapsforge/BackgroundMapAttachmentTest.java
@@ -33,21 +33,20 @@ import static slash.navigation.mapview.mapsforge.BackgroundMapAttachment.shouldA
 public class BackgroundMapAttachmentTest {
     @Test
     public void doesNotAttachWhenLayerNotReady() {
-        assertFalse(shouldAttachBackground(false, true, true));
+        assertFalse(shouldAttachBackground(false, true));
     }
 
     @Test
     public void doesNotAttachWhenLayerReadyButNoDisplayedMap() {
-        assertFalse(shouldAttachBackground(true, false, false));
+        assertFalse(shouldAttachBackground(true, false));
     }
 
     @Test
-    public void doesNotAttachWhenLayerReadyAndDisplayedMapIsNotMapsforge() {
-        assertFalse(shouldAttachBackground(true, true, false));
-    }
-
-    @Test
-    public void attachesWhenLayerReadyAndDisplayedMapIsMapsforge() {
-        assertTrue(shouldAttachBackground(true, true, true));
+    public void attachesWhenLayerReadyAndAnyMapDisplayed() {
+        // the world map is a global base layer: it belongs under every displayed
+        // map type (Download/Mapsforge/MBTiles), so an offline edition whose only
+        // selectable map is the online OpenStreetMap default still shows a map
+        // instead of staying gray when those tiles cannot be reached
+        assertTrue(shouldAttachBackground(true, true));
     }
 }


### PR DESCRIPTION
… Mapsforge

The offline edition skips the routeconverter/ directory when scanning maps (MapsforgeMapManager.scanMaps), so world.map is never a selectable map - it is only ever the background layer. When no offline map is installed, the sole available map is the online OpenStreetMap default (a Download map). But handleBackground attached the world.map background only when the displayed map was of type Mapsforge, so with OpenStreetMap selected and its tiles unreachable the map stayed gray with no base layer at all.

Treat world.map as what it is: a global, low-detail base layer that belongs underneath every displayed map type. shouldAttachBackground now attaches whenever the layer is built and a map is displayed. The background sits at layer index 0, so an opaque map on top hides it - no visible cost when the displayed map renders, and a usable world map instead of gray when it does not.