### PR TITLE
ci(prerelease): stop submitting prereleases to SignPath (only sign releases)

### DIFF
--- a/.github/workflows/prerelease.yml
+++ b/.github/workflows/prerelease.yml
@@ -24,10 +24,12 @@ jobs:
     with:
       artefact-name: prerelease-linux-mac
       retention-days: 7
-      sign: true
-      # prereleases stay on test-signing (auto, no approval gate). Production
-      # release-signing requires manual approval in the SignPath app — reserved
-      # for release.yml. (rc-meta specs/00043.)
+      sign: false
+      # Prereleases are NOT submitted to SignPath — SignPath signing is reserved
+      # for real releases (release.yml, release-signing) to conserve the OSS
+      # artifact-data-volume quota, which daily prerelease signing was draining
+      # (rc-meta specs/00043). Mac notarisation (sign-mac) is Apple Developer ID,
+      # not SignPath, so it is unaffected and still runs below.
     secrets: inherit
 
   build-windows:
@@ -39,10 +41,11 @@ jobs:
     with:
       artefact-name: prerelease-windows
       retention-days: 7
-      sign: true
-      # prereleases stay on test-signing (auto, no approval gate). Production
-      # release-signing requires manual approval in the SignPath app — reserved
-      # for release.yml. (rc-meta specs/00043.)
+      sign: false
+      # Prereleases are NOT submitted to SignPath — SignPath signing is reserved
+      # for real releases (release.yml, release-signing) to conserve the OSS
+      # artifact-data-volume quota, which daily prerelease signing was draining
+      # (rc-meta specs/00043).
     secrets: inherit
 
   sign-mac:


### PR DESCRIPTION
## Why
Daily prerelease signing (master push + nightly cron) drains the OSS SignPath **artifact-data-volume** quota — each prerelease run uploads the Windows installers *and* standalone jars to SignPath. Even after the recent quota bump to 98 GB, usage was at 51% only 9.5% into the period.

## Change
`sign: false` on both prerelease build jobs (`build-linux-mac`, `build-windows`). SignPath signing is now reserved for **real releases** — `release.yml` (triggered on version tags) keeps `release-signing`.

## Safety
- Prerelease deliverables still build and publish — the artefact uploads in `_build-windows.yml`/`_build-linux-mac.yml` are ungated; only the SignPath *submit* is skipped. Prerelease installers/jars just ship **unsigned**.
- **Mac notarisation** (`sign-mac` → `_sign-mac.yml`) is Apple Developer ID, not SignPath — unaffected, still runs.
- `release.yml` untouched.

rc-meta specs/00043.