### PR TITLE
ci: guard SignPath signing invariants (config-guard)

### DIFF
--- a/.github/workflows/workflow-config-guard.yml
+++ b/.github/workflows/workflow-config-guard.yml
@@ -1,0 +1,71 @@
+name: workflow-config-guard
+# Guards the SignPath signing invariants so a future edit cannot silently
+# (a) re-enable prerelease signing — which drains the OSS SignPath
+#     artifact-data-volume quota (the 2026-07 incident; PR #197), or
+# (b) break release signing, or
+# (c) remove the "fail if unsigned" verify gates from the build workflows.
+# See rc-meta specs/00043.
+
+on:
+  pull_request:
+    paths:
+      - '.github/workflows/prerelease.yml'
+      - '.github/workflows/release.yml'
+      - '.github/workflows/_build-windows.yml'
+      - '.github/workflows/_build-linux-mac.yml'
+      - '.github/workflows/_sign-mac.yml'
+      - '.github/workflows/workflow-config-guard.yml'
+  push:
+    branches: [master]
+    paths:
+      - '.github/workflows/prerelease.yml'
+      - '.github/workflows/release.yml'
+      - '.github/workflows/_build-windows.yml'
+      - '.github/workflows/_build-linux-mac.yml'
+      - '.github/workflows/_sign-mac.yml'
+
+permissions:
+  contents: read
+
+jobs:
+  guard:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v5
+
+      - name: Assert SignPath signing invariants
+        run: |
+          set -uo pipefail
+          P=.github/workflows/prerelease.yml
+          R=.github/workflows/release.yml
+          fail=0
+          chk() { # desc expected actual file
+            if [[ "$3" != "$2" ]]; then
+              echo "::error file=$4::$1 — expected '$2', got '$3'"; fail=1
+            else
+              echo "OK  $1 = $3"
+            fi
+          }
+          # (a) prereleases MUST NOT submit to SignPath (quota)
+          chk "prerelease build-linux-mac .sign" false "$(yq '.jobs["build-linux-mac"].with.sign' "$P")" "$P"
+          chk "prerelease build-windows .sign"   false "$(yq '.jobs["build-windows"].with.sign' "$P")" "$P"
+          # (b) releases MUST sign with the production policy
+          chk "release build-linux-mac .sign" true "$(yq '.jobs["build-linux-mac"].with.sign' "$R")" "$R"
+          chk "release build-windows .sign"   true "$(yq '.jobs["build-windows"].with.sign' "$R")" "$R"
+          chk "release build-linux-mac policy" release-signing "$(yq '.jobs["build-linux-mac"].with["signing-policy-slug"]' "$R")" "$R"
+          chk "release build-windows policy"   release-signing "$(yq '.jobs["build-windows"].with["signing-policy-slug"]' "$R")" "$R"
+          [[ $fail -eq 0 ]] || { echo "::error::SignPath signing config invariants violated (rc-meta specs/00043)"; exit 1; }
+
+      - name: Assert unsigned-artifact verify gates still present
+        run: |
+          set -uo pipefail
+          fail=0
+          need() { # file needle desc
+            if grep -qF "$2" "$1"; then echo "OK  $3"; else echo "::error file=$1::verify gate removed — $3 ('$2' not found)"; fail=1; fi
+          }
+          need .github/workflows/_build-windows.yml   "Get-AuthenticodeSignature" "windows Authenticode verify"
+          need .github/workflows/_build-windows.yml   "Verify installer signatures" "windows verify step"
+          need .github/workflows/_build-linux-mac.yml "jarsigner -verify"          "jar signature verify"
+          need .github/workflows/_sign-mac.yml        "codesign --verify"          "mac codesign verify"
+          [[ $fail -eq 0 ]] || { echo "::error::a signature-verify gate was removed — releases could ship unsigned"; exit 1; }
+          echo "All signing invariants + verify gates hold."


### PR DESCRIPTION
## Why (proposal #2 + regression-proofs #3)
After PR #197 stopped prereleases from draining the SignPath artifact-data-volume quota, this guard makes sure the config can't silently drift back — or lose its verify gates.

## What
New `.github/workflows/workflow-config-guard.yml`, runs on PR + master-push that touch any signing workflow. Fails if:
- `prerelease.yml` build jobs are not `sign: false` (would re-drain the quota), or
- `release.yml` build jobs are not `sign: true` + `signing-policy-slug: release-signing`, or
- any unsigned-artifact **verify gate** is removed (`Get-AuthenticodeSignature` / `jarsigner -verify` / `codesign --verify`) — so a broken signing run can never silently ship an unsigned release.

Lightweight (checkout + yq/grep, no Maven). Self-tests on this PR. rc-meta specs/00043.