### PR TITLE
charset follow-ups: pin UTF-8 for internal reads + Garble KML regression test

### DIFF
--- a/common/src/main/java/slash/common/io/Externalization.java
+++ b/common/src/main/java/slash/common/io/Externalization.java
@@ -26,6 +26,7 @@ import java.net.URLConnection;
 import java.util.logging.Logger;
 
 import static java.lang.Long.MAX_VALUE;
+import static java.nio.charset.StandardCharsets.UTF_8;
 import static slash.common.io.Directories.getTemporaryDirectory;
 import static slash.common.io.Files.extractFileName;
 import static slash.common.io.InputOutput.copyAndClose;
@@ -79,8 +80,8 @@ public class Externalization {
 
         File target = getTempFile(fileName.replace(".", "_" + targetInfix + "."));
         log.info("Extracting " + fileName + " to " + target);
-        Reader reader = new TokenReplacingReader(new InputStreamReader(inputStream), tokenResolver);
-        FileWriter writer = new FileWriter(target);
+        Reader reader = new TokenReplacingReader(new InputStreamReader(inputStream, UTF_8), tokenResolver);
+        FileWriter writer = new FileWriter(target, UTF_8);
         copyAndClose(reader, writer);
         return target;
     }

--- a/common/src/main/java/slash/common/log/LoggingHelper.java
+++ b/common/src/main/java/slash/common/log/LoggingHelper.java
@@ -23,6 +23,7 @@ package slash.common.log;
 import java.io.*;
 import java.util.logging.*;
 
+import static java.nio.charset.StandardCharsets.UTF_8;
 import static java.util.logging.Level.*;
 import static slash.common.io.Directories.getTemporaryDirectory;
 
@@ -157,7 +158,7 @@ public class LoggingHelper {
     private String readFile(File file) throws IOException {
         StringBuilder buffer = new StringBuilder();
 
-        try (BufferedReader reader = new BufferedReader(new FileReader(file))) {
+        try (BufferedReader reader = new BufferedReader(new FileReader(file, UTF_8))) {
             while (buffer.length() < LOG_SIZE) {
                 String line = reader.readLine();
                 if (line == null)

--- a/navigation-formats/src/test/java/slash/navigation/kml/GarbleKml22FormatTest.java
+++ b/navigation-formats/src/test/java/slash/navigation/kml/GarbleKml22FormatTest.java
@@ -1,0 +1,63 @@
+/*
+    This file is part of RouteConverter.
+
+    RouteConverter is free software; you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation; either version 2 of the License, or
+    (at your option) any later version.
+
+    RouteConverter is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with RouteConverter; if not, write to the Free Software
+    Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
+
+    Copyright (C) 2007 Christian Pesch. All Rights Reserved.
+*/
+
+package slash.navigation.kml;
+
+import org.junit.Test;
+import slash.navigation.base.ParserContext;
+import slash.navigation.base.ParserContextImpl;
+
+import java.io.ByteArrayInputStream;
+import java.nio.charset.Charset;
+import java.util.List;
+
+import static java.nio.charset.StandardCharsets.UTF_8;
+import static org.junit.Assert.assertEquals;
+
+/**
+ * Guards that a Placemark name with umlauts survives reading a garbled KML that has no encoding
+ * declaration and no BOM, regardless of the platform default charset (JEP 400 changed that default
+ * to UTF-8 in JDK 18+, which regressed legacy Windows-ANSI files).
+ */
+public class GarbleKml22FormatTest {
+    private static final String NAME = "Grün Ö Ä ß Straße";
+    private static final String KML = "<kml xmlns=\"http://www.opengis.net/kml/2.2\"><Document><Placemark>" +
+            "<name>" + NAME + "</name>" +
+            "<Point><coordinates>12.1,49.0,0</coordinates></Point>" +
+            "</Placemark></Document></kml>";
+
+    private String readName(byte[] bytes) throws Exception {
+        ParserContext<KmlRoute> context = new ParserContextImpl<>();
+        new GarbleKml22Format().read(new ByteArrayInputStream(bytes), context);
+        List<KmlRoute> routes = context.getRoutes();
+        assertEquals(1, routes.size());
+        return routes.get(0).getPositions().get(0).getDescription();
+    }
+
+    @Test
+    public void testReadWindows1252WithoutEncodingDeclaration() throws Exception {
+        assertEquals(NAME, readName(KML.getBytes(Charset.forName("windows-1252"))));
+    }
+
+    @Test
+    public void testReadUtf8WithoutEncodingDeclaration() throws Exception {
+        assertEquals(NAME, readName(KML.getBytes(UTF_8)));
+    }
+}


### PR DESCRIPTION
Follow-up to #199 (JEP 400 / charset robustness). Two independent, small changes:

## 1. Pin UTF-8 for internal resource + log reads (`common`)
`Externalization.extractFile` and `LoggingHelper.readFile` used the platform default charset (`InputStreamReader`/`FileWriter`/`FileReader` with no explicit charset). JEP 400 made that default UTF-8 in JDK 18+, and it previously varied by host locale — non-deterministic. Now pinned to UTF-8:
- `Externalization`: bundled token-replacing template resource (read + the paired write).
- `LoggingHelper`: the `RouteConverter.log` read for crash reports.

These read app-internal files (not user nav files), so they don't use the `readAsReaderPreferringUtf8` fallback helper — a fixed UTF-8 is correct.

## 2. Regression test for the Garble KML fix (`navigation-formats`)
`GarbleKml22FormatTest` reads a KML whose Placemark name has umlauts and which has **no** `<?xml encoding?>` and **no** BOM, as both Windows-1252 and UTF-8 bytes, asserting the name round-trips. Guards the #199 fix against a future bundled-JRE / default-charset change.

## Verification
`common` 11/11 (`InputOutputTest`), `navigation-formats` `GarbleKml22FormatTest` 2/2; both modules build clean (JDK 21).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
