### PR TITLE
Fix two Maps dialog crashes (double-open + null bounding box)

### DIFF
--- a/common-gui/src/main/java/slash/navigation/gui/actions/SingletonDialogAction.java
+++ b/common-gui/src/main/java/slash/navigation/gui/actions/SingletonDialogAction.java
@@ -29,11 +29,16 @@ import slash.navigation.gui.SimpleDialog;
  */
 
 public abstract class SingletonDialogAction extends FrameAction {
+    private SimpleDialog dialog;
 
     protected abstract SimpleDialog createDialog();
 
     public void run() {
-        SimpleDialog dialog = createDialog();
+        if (dialog != null && dialog.isShowing()) {
+            dialog.toFront();
+            return;
+        }
+        dialog = createDialog();
         dialog.showWithPreferences();
         dialog.toFront();
         dialog.setVisible(true);

--- a/common-gui/src/test/java/slash/navigation/gui/actions/SingletonDialogActionTest.java
+++ b/common-gui/src/test/java/slash/navigation/gui/actions/SingletonDialogActionTest.java
@@ -1,0 +1,70 @@
+/*
+    This file is part of RouteConverter.
+
+    RouteConverter is free software; you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation; either version 2 of the License, or
+    (at your option) any later version.
+
+    RouteConverter is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with RouteConverter; if not, write to the Free Software
+    Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
+
+    Copyright (C) 2007 Christian Pesch. All Rights Reserved.
+*/
+
+package slash.navigation.gui.actions;
+
+import org.junit.Test;
+import slash.navigation.gui.SimpleDialog;
+
+import static org.junit.Assert.assertEquals;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+public class SingletonDialogActionTest {
+
+    private static class CountingDialogAction extends SingletonDialogAction {
+        private final SimpleDialog dialog;
+        int createDialogCount;
+
+        private CountingDialogAction(SimpleDialog dialog) {
+            this.dialog = dialog;
+        }
+
+        protected SimpleDialog createDialog() {
+            createDialogCount++;
+            return dialog;
+        }
+    }
+
+    @Test
+    public void testReusesShowingDialogAndRebuildsAfterItWasClosed() {
+        SimpleDialog dialog = mock(SimpleDialog.class);
+        // dialog reports it is showing after the first open, then closed before the third
+        when(dialog.isShowing()).thenReturn(true, false);
+        CountingDialogAction action = new CountingDialogAction(dialog);
+
+        // first open: no cached dialog yet, so it is built and shown
+        action.run();
+        assertEquals(1, action.createDialogCount);
+        verify(dialog, times(1)).showWithPreferences();
+
+        // second open while still showing: bring the existing dialog to front, do not build a second one
+        action.run();
+        assertEquals(1, action.createDialogCount);
+        verify(dialog, times(1)).showWithPreferences();
+
+        // third open after it was closed (isShowing() == false): build a fresh dialog again
+        action.run();
+        assertEquals(2, action.createDialogCount);
+        verify(dialog, times(2)).showWithPreferences();
+    }
+}

--- a/graphhopper/src/main/java/slash/navigation/graphhopper/GraphDescriptor.java
+++ b/graphhopper/src/main/java/slash/navigation/graphhopper/GraphDescriptor.java
@@ -43,7 +43,8 @@ class GraphDescriptor {
 
     private boolean matchesBoundingBox(MapDescriptor mapDescriptor) {
         BoundingBox fileBoundingBox = getBoundingBox();
-        return fileBoundingBox != null && fileBoundingBox.contains(mapDescriptor.getBoundingBox());
+        BoundingBox mapBoundingBox = mapDescriptor.getBoundingBox();
+        return fileBoundingBox != null && mapBoundingBox != null && fileBoundingBox.contains(mapBoundingBox);
     }
 
     public boolean matches(MapDescriptor mapDescriptor) {

--- a/graphhopper/src/test/java/slash/navigation/graphhopper/GraphManagerTest.java
+++ b/graphhopper/src/test/java/slash/navigation/graphhopper/GraphManagerTest.java
@@ -4,6 +4,7 @@ import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
 import slash.navigation.common.BoundingBox;
+import slash.navigation.common.MapDescriptor;
 import slash.navigation.datasources.DataSource;
 
 import java.io.File;
@@ -216,6 +217,21 @@ public class GraphManagerTest {
         File directory = graphManager.getDirectory(createDataSource("unused"));
 
         assertEquals(existingDirectory.getAbsolutePath(), directory.getAbsolutePath());
+    }
+
+    @Test
+    public void testMatchesReturnsFalseForMapWithoutBoundingBoxInsteadOfThrowing() {
+        slash.navigation.datasources.File germany = mock(slash.navigation.datasources.File.class);
+        when(germany.getUri()).thenReturn("germany.pbf");
+        when(germany.getBoundingBox()).thenReturn(new BoundingBox(20.0, 20.0, 5.0, 5.0));
+
+        GraphDescriptor descriptor = new GraphDescriptor(GraphManager.GraphType.PBF, null, germany);
+
+        MapDescriptor mapDescriptorWithoutBoundingBox = mock(MapDescriptor.class);
+        when(mapDescriptorWithoutBoundingBox.getIdentifier()).thenReturn("unrelated-map");
+        when(mapDescriptorWithoutBoundingBox.getBoundingBox()).thenReturn(null);
+
+        assertFalse(descriptor.matches(mapDescriptorWithoutBoundingBox));
     }
 
     private static DataSource createDataSource(String directoryName) {


### PR DESCRIPTION
Fixes two independent crashes in the Maps dialog, both reported by a user (Edgar Kraus) on macOS with RouteConverter 3.5-SNAPSHOT-298.

## 1. `IllegalArgumentException: Action '…' for 'display-online-map' already registered`

`SingletonDialogAction` — despite its name and Javadoc ("Show a dialog at most once") — built a new dialog on every invocation. `MapsDialog` (and the themes/downloads dialogs) register their actions in the constructor and unregister them in `close()`. Opening a second dialog while the first was still showing therefore re-registered the same action key and threw, crashing `ShowMapsAction`.

Fix: cache the dialog instance; if it is still showing, bring it to front instead of constructing a duplicate. Applies to all `SingletonDialogAction` subclasses (Maps, Themes, Downloads, Options, About, …).

### Lineage — why this isn't a plain revert

`SingletonDialogAction` originally cached the dialog (commit `e9d542def`, "introduce SingletonDialogAction … to prevent them being opened more than once"). That cache was removed in `776a07648` (2024-07-03), bundled into an unrelated logout commit: after the change `run()` built a fresh dialog on every open.

The original cache had the opposite defect — it never reset the field, so it reused the **same** dialog instance forever and showed **stale** content on reopen (models are bound once at construction). Removing it fixed staleness but reintroduced the double-open crash the class exists to prevent.

This fix keeps both properties: it rebuilds the dialog when it is **not** currently showing (fresh content, no staleness), and reuses / fronts it only while it **is** showing (no duplicate registration).

## 2. `NullPointerException` when selecting a downloadable map

`GraphDescriptor.matchesBoundingBox` null-checked the graph's own bounding box but passed the map's bounding box straight into `BoundingBox.contains(BoundingBox)`, which dereferences `other.northEast()`. Selecting a downloadable map whose descriptor has no bounding box crashed via `MapsDialog.updateLabel` → `GraphHopper.calculateRemainingDownloadSize` → `DownloadableFinder`.

Fix: skip the bounding-box match when the map descriptor has no bounding box.

Both modules compile (`common-gui`, `graphhopper`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)