### PR TITLE
[forum #4139] macOS "Open with" drops the file on a cold launch (odoc not handled)

### DIFF
--- a/common-navigation/src/main/java/slash/navigation/common/PendingOpenUrls.java
+++ b/common-navigation/src/main/java/slash/navigation/common/PendingOpenUrls.java
@@ -1,0 +1,65 @@
+/*
+    This file is part of BaseRouteConverter.
+
+    BaseRouteConverter is free software; you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation; either version 2 of the License, or
+    (at your option) any later version.
+
+    BaseRouteConverter is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with BaseRouteConverter; if not, write to the Free Software
+    Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
+
+    Copyright (C) 2007 Christian Pesch. All Rights Reserved.
+*/
+
+package slash.navigation.common;
+
+import java.net.URL;
+import java.util.ArrayList;
+import java.util.LinkedHashSet;
+import java.util.List;
+
+/**
+ * Buffers files/URLs delivered by the operating system (e.g. a macOS {@code odoc}
+ * Apple Event on a cold launch) before the UI is ready to open them, then merges
+ * them with the URLs passed as command line arguments once the UI becomes ready.
+ *
+ * @author Christian Pesch
+ */
+
+public class PendingOpenUrls {
+    private final List<URL> buffered = new ArrayList<>();
+    private boolean released = false;
+
+    /**
+     * @return {@code true} if the urls were buffered since the UI is not yet ready;
+     * {@code false} if the caller should open them immediately since this instance
+     * has already been {@link #release released}
+     */
+    public synchronized boolean addOrDefer(List<URL> urls) {
+        if (released)
+            return false;
+        buffered.addAll(urls);
+        return true;
+    }
+
+    /**
+     * Marks this instance as ready and returns the merged list of URLs to open:
+     * the given {@code initialArgs} first, then any buffered URLs, deduped by URL
+     * with order preserved. After this call {@link #addOrDefer} always returns
+     * {@code false}.
+     */
+    public synchronized List<URL> release(List<URL> initialArgs) {
+        released = true;
+        LinkedHashSet<URL> merged = new LinkedHashSet<>(initialArgs);
+        merged.addAll(buffered);
+        buffered.clear();
+        return new ArrayList<>(merged);
+    }
+}

--- a/common-navigation/src/main/java/slash/navigation/common/PendingOpenUrls.java
+++ b/common-navigation/src/main/java/slash/navigation/common/PendingOpenUrls.java
@@ -57,6 +57,10 @@ public class PendingOpenUrls {
      */
     public synchronized List<URL> release(List<URL> initialArgs) {
         released = true;
+        // Note: URL#equals()/hashCode() perform host resolution (a blocking DNS call) for
+        // URLs with a non-empty host. Harmless here since only file:// URLs with an empty
+        // host flow through this method; if this class is ever used for remote URLs,
+        // dedupe by URI (or String) instead to avoid a network call on the EDT.
         LinkedHashSet<URL> merged = new LinkedHashSet<>(initialArgs);
         merged.addAll(buffered);
         buffered.clear();

--- a/common-navigation/src/test/java/slash/navigation/common/PendingOpenUrlsTest.java
+++ b/common-navigation/src/test/java/slash/navigation/common/PendingOpenUrlsTest.java
@@ -1,0 +1,74 @@
+package slash.navigation.common;
+
+import org.junit.Test;
+
+import java.net.MalformedURLException;
+import java.net.URL;
+import java.util.List;
+
+import static java.util.Arrays.asList;
+import static java.util.Collections.emptyList;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+public class PendingOpenUrlsTest {
+    private static URL url(String path) {
+        try {
+            return new URL("file:///" + path);
+        } catch (MalformedURLException e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    @Test
+    public void bufferedBeforeReleaseIsReturnedInArrivalOrder() {
+        PendingOpenUrls pending = new PendingOpenUrls();
+        assertTrue(pending.addOrDefer(asList(url("a.gpx"), url("b.gpx"))));
+
+        List<URL> result = pending.release(emptyList());
+
+        assertEquals(asList(url("a.gpx"), url("b.gpx")), result);
+    }
+
+    @Test
+    public void releaseMergesInitialArgsBeforeBufferedAndDedupes() {
+        PendingOpenUrls pending = new PendingOpenUrls();
+        assertTrue(pending.addOrDefer(asList(url("shared.gpx"), url("odoc.gpx"))));
+
+        List<URL> result = pending.release(asList(url("argv.gpx"), url("shared.gpx")));
+
+        assertEquals(asList(url("argv.gpx"), url("shared.gpx"), url("odoc.gpx")), result);
+    }
+
+    @Test
+    public void releaseWithNothingBufferedAndNoInitialArgsReturnsEmptyList() {
+        PendingOpenUrls pending = new PendingOpenUrls();
+
+        List<URL> result = pending.release(emptyList());
+
+        assertTrue(result.isEmpty());
+    }
+
+    @Test
+    public void addOrDeferAfterReleaseReturnsFalseAndDoesNotBuffer() {
+        PendingOpenUrls pending = new PendingOpenUrls();
+        pending.release(emptyList());
+
+        assertFalse(pending.addOrDefer(asList(url("late.gpx"))));
+
+        // a subsequent release must not resurrect the "late" url, proving it was not buffered
+        assertTrue(pending.release(emptyList()).isEmpty());
+    }
+
+    @Test
+    public void twoAddOrDeferCallsBeforeReleaseAccumulateInOrder() {
+        PendingOpenUrls pending = new PendingOpenUrls();
+        assertTrue(pending.addOrDefer(asList(url("first.gpx"))));
+        assertTrue(pending.addOrDefer(asList(url("second.gpx"))));
+
+        List<URL> result = pending.release(emptyList());
+
+        assertEquals(asList(url("first.gpx"), url("second.gpx")), result);
+    }
+}

--- a/route-converter-gui/src/main/java/slash/navigation/converter/gui/BaseRouteConverter.java
+++ b/route-converter-gui/src/main/java/slash/navigation/converter/gui/BaseRouteConverter.java
@@ -222,6 +222,7 @@ public abstract class BaseRouteConverter extends SingleFrameApplication {
             new Dimension(0, 0), new Dimension(0, 0), new Dimension(MAX_VALUE, 300), 0, true);
 
     private LazyTabInitializer tabInitializer;
+    private final PendingOpenUrls pendingOpenUrls = new PendingOpenUrls();
 
     // application lifecycle callbacks
 
@@ -229,6 +230,10 @@ public abstract class BaseRouteConverter extends SingleFrameApplication {
 
     protected void startup() {
         startupStartMillis = System.currentTimeMillis();
+        // register the open-file handler first so AppKit + its odoc Apple Event handler
+        // arm as early as possible -- a cold macOS "Open with" launch delivers the odoc
+        // event within the first seconds of JVM boot, before the rest of startup runs
+        new ApplicationMenu(pendingOpenUrls).addApplicationMenuItems();
         initializeDiagnostics();
         checkJavaPrequisites();
         checkForGoogleMapsAPIKey();
@@ -259,12 +264,12 @@ public abstract class BaseRouteConverter extends SingleFrameApplication {
 
     protected void parseInitialArgs(String[] args) {
         log.info("Processing initial arguments: " + Arrays.toString(args));
-        if (args.length > 0) {
-            List<URL> urls = toUrls(args);
-            log.info("Processing urls: " + urls);
-            getConvertPanel().openUrls(urls);
-        } else {
+        List<URL> urls = pendingOpenUrls.release(toUrls(args));
+        log.info("Processing urls: " + urls);
+        if (urls.isEmpty()) {
             getConvertPanel().newFile();
+        } else {
+            getConvertPanel().openUrls(urls);
         }
     }
 
@@ -339,7 +344,6 @@ public abstract class BaseRouteConverter extends SingleFrameApplication {
 
     private void openFrame() {
         createFrame(getTitle(), "/slash/navigation/converter/gui/" + getProduct() + ".png", contentPane, null, new FrameMenu().createMenuBar());
-        new ApplicationMenu().addApplicationMenuItems();
         new Thread(() -> invokeLater(() -> {
             openFrame(contentPane);
             log.info(format("Frame shown %d ms after startup", millisSinceStartup()));

--- a/route-converter-gui/src/main/java/slash/navigation/converter/gui/helpers/ApplicationMenu.java
+++ b/route-converter-gui/src/main/java/slash/navigation/converter/gui/helpers/ApplicationMenu.java
@@ -20,6 +20,7 @@
 
 package slash.navigation.converter.gui.helpers;
 
+import slash.navigation.common.PendingOpenUrls;
 import slash.navigation.converter.gui.BaseRouteConverter;
 
 import java.awt.*;
@@ -37,6 +38,7 @@ import java.util.logging.Logger;
 
 import static java.awt.Desktop.Action.*;
 import static java.awt.Desktop.isDesktopSupported;
+import static javax.swing.SwingUtilities.invokeLater;
 import static slash.common.helpers.ExceptionHelper.getLocalizedMessage;
 
 /**
@@ -47,6 +49,12 @@ import static slash.common.helpers.ExceptionHelper.getLocalizedMessage;
 
 public class ApplicationMenu {
     private static final Logger log = Logger.getLogger(ApplicationMenu.class.getName());
+
+    private final PendingOpenUrls pendingOpenUrls;
+
+    public ApplicationMenu(PendingOpenUrls pendingOpenUrls) {
+        this.pendingOpenUrls = pendingOpenUrls;
+    }
 
     public void addApplicationMenuItems() {
         if (!isDesktopSupported())
@@ -97,14 +105,21 @@ public class ApplicationMenu {
                 log.warning("Cannot open file " + file + ": " + getLocalizedMessage(e));
             }
         }
-        ((BaseRouteConverter)slash.navigation.gui.Application.getInstance()).getConvertPanel().openUrls(urls);
+
+        if (pendingOpenUrls.addOrDefer(urls))
+            return;
+        invokeLater(() -> ((BaseRouteConverter) slash.navigation.gui.Application.getInstance()).getConvertPanel().openUrls(urls));
     }
 
     private void openUri(OpenURIEvent openURIEvent) {
         URI uri = openURIEvent.getURI();
         try {
             URL url = uri.toURL();
-            ((BaseRouteConverter)slash.navigation.gui.Application.getInstance()).getConvertPanel().openUrls(List.of(url));
+            List<URL> urls = List.of(url);
+
+            if (pendingOpenUrls.addOrDefer(urls))
+                return;
+            invokeLater(() -> ((BaseRouteConverter) slash.navigation.gui.Application.getInstance()).getConvertPanel().openUrls(urls));
         } catch (MalformedURLException e) {
             log.warning("Cannot open URI " + uri + ": " + getLocalizedMessage(e));
         }


### PR DESCRIPTION
## Summary

Implemented the fix for issue #204 (macOS "Open with" dropping files on cold launch) exactly per the locked spec.

**Root cause:** on a cold launch, macOS delivers the "Open with" file via a `kAEOpenDocuments` (`odoc`) Apple Event almost immediately, but the app only registered its `Desktop.setOpenFileHandler` deep into `openFrame()` — well after AppKit could have already fired and dropped the event.

### Changes

1. **`common-navigation/.../PendingOpenUrls.java`** (new) — pure, testable seam. `synchronized boolean addOrDefer(List<URL>)` buffers URLs until the UI is ready (returns `true` while buffering, `false` once released). `synchronized List<URL> release(List<URL> initialArgs)` marks the instance ready and returns `argv` URLs first, then buffered URLs, deduped by URL with order preserved.

2. **`common-navigation/.../PendingOpenUrlsTest.java`** (new) — covers all 5 scenarios from the spec: buffer-then-release, argv+buffered merge/dedup, empty release, `addOrDefer` after release, and multiple buffered calls accumulating in order.

3. **`ApplicationMenu.java`** — now takes a `PendingOpenUrls` in its constructor. `openFiles`/`openUri` defer to `pendingOpenUrls.addOrDefer(urls)`; if not buffered (warm launch), they open the URLs via `invokeLater` on the EDT.

4. **`BaseRouteConverter.java`** — owns one `PendingOpenUrls` instance. `new ApplicationMenu(pendingOpenUrls).addApplicationMenuItems()` is now the **first statement** in `startup()` (before `initializeDiagnostics()`), so the AppKit `odoc` handler arms as early as possible. The old registration in `openFrame()` was removed (registered exactly once now). `parseInitialArgs` now calls `pendingOpenUrls.release(toUrls(args))` and opens the merged list, or calls `newFile()` if empty — preserving existing no-file behavior while closing the race.

Threading is safe: all buffering/release is `synchronized`, and both the warm-path open and the flushed open run via `invokeLater` on the EDT.

### Note on verification

This sandboxed environment's Bash tool blocks `java`/build-tool invocations (approval required but unavailable), so I could not run `./mvnw test` or the manual macOS cold-launch repro myself. I instead manually traced `Application.launch()` → `startup()` → `parseInitialArgs()` to confirm both run on the EDT in the expected order, and reviewed the new code line-by-line against the 5 required test scenarios. The workflow's CI build should run `PendingOpenUrlsTest` and the full `mvn verify`; the macOS cold-launch manual check from the acceptance criteria still needs a human/CI runner with a real `.app` build.


Source issue: cpesch/RouteConverter#204

---
**Builder stats** · model `sonnet` · confidence `0` · 3m 13s across 1 round(s) · 4 file op(s)
[Workflow run](http://127.0.0.1:3000/cpesch/RouteConverter/actions/runs/13096)

<!-- issue-body-sha:9100b22a461a -->