### PR TITLE
ci: add Dependabot config (maven + github-actions, weekly, grouped minor/patch)

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,35 @@
+# Dependency-update proposals. Bots propose, CI validates (build.yml runs the
+# Java matrix on every in-repo branch push), a human merges — no auto-merge.
+#
+# Deliberately NOT configured:
+# - registries: dependencies resolved only from mvn.routeconverter.com
+#   (slash.*, org.btools, repackaged legacy jars) are out of Dependabot's
+#   scope by design; "unable to find" log lines for them are expected.
+# - <jre.version> is a maintainer-controlled property (JRE bundling), not a
+#   dependency; JDK retargets are planned work, never bot bumps.
+version: 2
+updates:
+  - package-ecosystem: "maven"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+    # Minor + patch bumps arrive as one grouped PR; majors stay individual
+    # PRs so they are impossible to overlook.
+    groups:
+      maven-minor-patch:
+        patterns:
+          - "*"
+        update-types:
+          - "minor"
+          - "patch"
+
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+    groups:
+      github-actions:
+        patterns:
+          - "*"


### PR DESCRIPTION
Adds `.github/dependabot.yml`: weekly checks for Maven dependencies and GitHub Actions pins.

**Model: bots propose, CI validates, a human merges — no auto-merge.**

- Maven minor+patch bumps arrive as one grouped weekly PR; **majors stay individual PRs** so they are impossible to overlook.
- GitHub Actions pins grouped into one weekly PR.
- CI is free: `build.yml` triggers `on: [push]` and Dependabot branches live in-repo, so every bot PR gets the Java 21 + 25 matrix build.
- **No `registries:` entry by design** — dependencies resolved only from mvn.routeconverter.com (`slash.*`, `org.btools`, repackaged legacy jars) are out of Dependabot's scope; "unable to find" lines in Dependabot logs for them are expected, not breakage. mapsforge is Central-hosted and IS covered.
- `<jre.version>` is a maintainer-controlled property (JRE bundling), untouched by Dependabot; JDK retargets remain planned work.

🤖 Generated with [Claude Code](https://claude.com/claude-code)