### PR TITLE
fix(test): import java.util.UUID in AutomaticGeocodingServiceTest

### DIFF
--- a/route-converter-gui/src/test/java/slash/navigation/converter/gui/helpers/AutomaticGeocodingServiceTest.java
+++ b/route-converter-gui/src/test/java/slash/navigation/converter/gui/helpers/AutomaticGeocodingServiceTest.java
@@ -31,6 +31,7 @@ import slash.navigation.gui.models.InMemoryPreferences;
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.UUID;
 import java.util.prefs.Preferences;
 
 import static java.util.Collections.emptyList;


### PR DESCRIPTION
Restores a green build. `AutomaticGeocodingServiceTest` calls `UUID.randomUUID()` (lines 73, 93) but never imported `java.util.UUID`, so `route-converter-gui` `test-compile` failed and **every prerelease build has been red** (Prerelease + RouteConverter CI on master).

Fix: add `import java.util.UUID;`. Verified locally: `mvn -pl route-converter-gui -am test-compile` now passes (previously `cannot find symbol: variable UUID`).

One line, test-only.