### PR TITLE
fix(mac): build + host universal launcher stub on macOS runner (unblocks Mac release build)

### DIFF
--- a/.github/workflows/_build-linux-mac.yml
+++ b/.github/workflows/_build-linux-mac.yml
@@ -92,8 +92,8 @@ jobs:
           curl "${curl_opts[@]}" -o macos-launcher-stub        "${base_url}/macos-launcher-stub"
           curl "${curl_opts[@]}" -o macos-launcher-stub.sha256 "${base_url}/macos-launcher-stub.sha256"
           sha256sum -c macos-launcher-stub.sha256
-          install -m 0755 macos-launcher-stub RouteConverterMac/target/RouteConverter
-          install -m 0755 macos-launcher-stub TimeAlbumProMac/target/TimeAlbumPro
+          install -D -m 0755 macos-launcher-stub RouteConverterMac/target/RouteConverter
+          install -D -m 0755 macos-launcher-stub TimeAlbumProMac/target/TimeAlbumPro
           rm -f macos-launcher-stub macos-launcher-stub.sha256
       - name: Build
         # github.run_number is the CALLER workflow's run number — same

--- a/.github/workflows/_build-linux-mac.yml
+++ b/.github/workflows/_build-linux-mac.yml
@@ -79,6 +79,22 @@ jobs:
             done
             rm -f "$zip" "${zip}.sha256"
           done
+      - name: Fetch hosted macOS launcher stub
+        # The .app's Contents/MacOS/<App> is a universal Cocoa Mach-O that cannot
+        # be compiled on this Linux runner; build-mac-jre.yml builds + hosts it.
+        # One byte-identical stub serves both apps (it resolves its jar/icon/name
+        # from its own bundle at runtime), installed under each app's name. The
+        # macos-{x64,aarch64}.xml assemblies copy target/<App> into the bundle.
+        run: |
+          set -euo pipefail
+          base_url=https://static.routeconverter.com/build/mac
+          curl_opts=(-fsSL --retry 5 --retry-all-errors --retry-delay 5 --connect-timeout 30)
+          curl "${curl_opts[@]}" -o macos-launcher-stub        "${base_url}/macos-launcher-stub"
+          curl "${curl_opts[@]}" -o macos-launcher-stub.sha256 "${base_url}/macos-launcher-stub.sha256"
+          sha256sum -c macos-launcher-stub.sha256
+          install -m 0755 macos-launcher-stub RouteConverterMac/target/RouteConverter
+          install -m 0755 macos-launcher-stub TimeAlbumProMac/target/TimeAlbumPro
+          rm -f macos-launcher-stub macos-launcher-stub.sha256
       - name: Build
         # github.run_number is the CALLER workflow's run number — same
         # value the inline jobs used before Phase 5.2.

--- a/.github/workflows/build-mac-jre.yml
+++ b/.github/workflows/build-mac-jre.yml
@@ -32,6 +32,7 @@ on:
     paths:
       - 'pom.xml'
       - 'scripts/jre-modules.txt'
+      - 'mac-launcher/JavaAppLauncher.m'
       - '.github/workflows/build-mac-jre.yml'
 
 concurrency:
@@ -133,6 +134,24 @@ jobs:
             rm -f  "$OUT/lib/server/Xusage.txt"
           done
 
+      - name: Compile universal launcher stub
+        # The .app is assembled on a Linux runner (_build-linux-mac.yml), which
+        # cannot compile a macOS Cocoa Mach-O. Build the universal (x86_64 +
+        # arm64) stub here on macOS and host it alongside the JREs; the Linux
+        # assembly fetches it. Source: mac-launcher/JavaAppLauncher.m (also the
+        # local-mac build path via the RouteConverterMac/TimeAlbumProMac pom
+        # profile). One byte-identical stub serves both apps (it introspects its
+        # own bundle at runtime).
+        shell: bash
+        run: |
+          set -euo pipefail
+          clang -arch x86_64 -arch arm64 -framework Cocoa \
+            -o macos-launcher-stub mac-launcher/JavaAppLauncher.m
+          lipo -info macos-launcher-stub
+          shasum -a 256 macos-launcher-stub \
+            | awk '{print $1"  macos-launcher-stub"}' > macos-launcher-stub.sha256
+          cat macos-launcher-stub.sha256
+
       - name: Show full JRE trees
         shell: bash
         env:
@@ -170,6 +189,8 @@ jobs:
             jre-${{ steps.jdk.outputs.version }}-aarch64-stripped.zip.sha256
             jre-${{ steps.jdk.outputs.version }}-x64-stripped.zip
             jre-${{ steps.jdk.outputs.version }}-x64-stripped.zip.sha256
+            macos-launcher-stub
+            macos-launcher-stub.sha256
           retention-days: 30
 
   publish:


### PR DESCRIPTION
Follow-up to #206/#208. The launcher stub is correct, but the `.app` is assembled in `_build-linux-mac.yml` on **ubuntu-latest**, which cannot compile the Cocoa universal Mach-O — the pom clang step is gated to the `mac` profile (inactive on Linux), so the Mac release assembly would fail (`target/RouteConverter` missing; the old shell launcher was deleted).

**Fix (mirrors the hosted-JRE pattern):**
- `build-mac-jre.yml` (macos-latest): compile the universal (`x86_64`+`arm64`) stub from `mac-launcher/JavaAppLauncher.m`, host `macos-launcher-stub` (+ `.sha256`) next to the stripped JREs. Added the source to the trigger paths.
- `_build-linux-mac.yml` (ubuntu): fetch + sha256-verify the stub, `install -m 0755` it to `RouteConverterMac/target/RouteConverter` and `TimeAlbumProMac/target/TimeAlbumPro` before `mvn package`. One byte-identical stub serves both apps (it resolves jar/icon/name from its own bundle at runtime).
- The pom `mac`-profile clang step stays as the **local-mac** build path (untouched).

**Bootstrap:** on merge, `build-mac-jre.yml` is in the changed paths so it reruns and publishes the stub; the prerelease must be re-run after that completes.

Verified locally: clang produces a universal binary; both workflow YAMLs parse. Signing/notarization of the stub via `_sign-mac.yml` runs only on the macOS release job (unchanged, inner-out codesign covers `Contents/MacOS/<App>`).