### PR TITLE
fix(mac): run .app assembly on Linux runner (unblocks prerelease)

### DIFF
--- a/.github/workflows/_build-linux-mac.yml
+++ b/.github/workflows/_build-linux-mac.yml
@@ -100,7 +100,10 @@ jobs:
         # value the inline jobs used before Phase 5.2.
         # No `clean` — runner is ephemeral; `clean` would also wipe the
         # Runtime-<arch> dirs unpacked from the hosted Mac JREs above.
-        run: ./mvnw --batch-mode -Prouteconverter -Dmaven.build.number=${{ github.run_number }} -DcrashReportSecret=${{ secrets.CRASH_REPORT_HMAC_SECRET }} package
+        # -DmacApp activates the mac-app profile in RouteConverterMac/TimeAlbumProMac
+        # so the .app bundles are assembled here (stub fetched above). The plain
+        # `mvn verify` CI omits it, so it does not fail on the absent stub.
+        run: ./mvnw --batch-mode -Prouteconverter -DmacApp -Dmaven.build.number=${{ github.run_number }} -DcrashReportSecret=${{ secrets.CRASH_REPORT_HMAC_SECRET }} package
       - name: Verify runtime on stripped JRE (class-load gate)
         # Reproduces the minimized-JRE condition from scripts/jre-modules.txt and
         # fails the build on a ClassNotFoundException/NoClassDefFoundError that a

--- a/RouteConverterMac/pom.xml
+++ b/RouteConverterMac/pom.xml
@@ -74,22 +74,56 @@
                     </execution>
                 </executions>
             </plugin>
+            <!-- Assemble the macos-{x64,aarch64}.xml .app bundles. This runs on
+                 the LINUX assembly runner (_build-linux-mac.yml), which is where
+                 the release .app zips are produced, so it must NOT be gated to a
+                 macOS host. The universal Contents/MacOS/RouteConverter stub it
+                 installs is fetched from static.routeconverter.com into
+                 target/RouteConverter by that workflow (built on macOS in
+                 build-mac-jre.yml); on a local macOS build the mac-native-launcher
+                 profile below compiles it into the same path instead. -->
+            <plugin>
+                <artifactId>maven-assembly-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <id>x64</id>
+                        <phase>package</phase>
+                        <goals>
+                            <goal>single</goal>
+                        </goals>
+                        <configuration>
+                            <descriptors>
+                                <descriptor>${basedir}/src/main/assembly/macos-x64.xml</descriptor>
+                            </descriptors>
+                            <finalName>RouteConverterMac</finalName>
+                        </configuration>
+                    </execution>
+                    <execution>
+                        <id>aarch64</id>
+                        <phase>package</phase>
+                        <goals>
+                            <goal>single</goal>
+                        </goals>
+                        <configuration>
+                            <descriptors>
+                                <descriptor>${basedir}/src/main/assembly/macos-aarch64.xml</descriptor>
+                            </descriptors>
+                            <finalName>RouteConverterMac</finalName>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
         </plugins>
     </build>
 
     <profiles>
         <profile>
-            <!-- Compiles the shared mac-launcher/JavaAppLauncher.m stub (see
-                 issue #206) into a universal (x86_64 + arm64) binary and only
-                 then assembles the macos-{x64,aarch64}.xml app bundles that
-                 install it as Contents/MacOS/RouteConverter. clang + the
-                 Cocoa framework (and the resulting target/RouteConverter the
-                 assembly descriptors require) are only available on a macOS
-                 host, hence both the compile step and the assembly
-                 executions live behind this OS-family gate — on non-mac CI
-                 hosts (e.g. the ubuntu-latest `mvn verify` matrix) the module
-                 still builds/tests the shaded jar, it just skips producing
-                 the .app zip. -->
+            <!-- LOCAL macOS build only: compile the shared
+                 mac-launcher/JavaAppLauncher.m stub (issue #206) into the
+                 universal target/RouteConverter that the assembly descriptors
+                 require. On CI the Linux assembly runner fetches the hosted
+                 stub instead (see the assembly comment above), so this gate
+                 keeps clang — unavailable off macOS — from breaking that build. -->
             <id>mac-native-launcher</id>
             <activation>
                 <os>
@@ -115,37 +149,6 @@
                                         <argument>-c</argument>
                                         <argument>mkdir -p "${project.build.directory}" &amp;&amp; clang -arch x86_64 -arch arm64 -framework Cocoa -o "${project.build.directory}/RouteConverter" "${basedir}/../mac-launcher/JavaAppLauncher.m"</argument>
                                     </arguments>
-                                </configuration>
-                            </execution>
-                        </executions>
-                    </plugin>
-                    <plugin>
-                        <artifactId>maven-assembly-plugin</artifactId>
-                        <executions>
-                            <execution>
-                                <id>x64</id>
-                                <phase>package</phase>
-                                <goals>
-                                    <goal>single</goal>
-                                </goals>
-                                <configuration>
-                                    <descriptors>
-                                        <descriptor>${basedir}/src/main/assembly/macos-x64.xml</descriptor>
-                                    </descriptors>
-                                    <finalName>RouteConverterMac</finalName>
-                                </configuration>
-                            </execution>
-                            <execution>
-                                <id>aarch64</id>
-                                <phase>package</phase>
-                                <goals>
-                                    <goal>single</goal>
-                                </goals>
-                                <configuration>
-                                    <descriptors>
-                                        <descriptor>${basedir}/src/main/assembly/macos-aarch64.xml</descriptor>
-                                    </descriptors>
-                                    <finalName>RouteConverterMac</finalName>
                                 </configuration>
                             </execution>
                         </executions>

--- a/RouteConverterMac/pom.xml
+++ b/RouteConverterMac/pom.xml
@@ -74,45 +74,6 @@
                     </execution>
                 </executions>
             </plugin>
-            <!-- Assemble the macos-{x64,aarch64}.xml .app bundles. This runs on
-                 the LINUX assembly runner (_build-linux-mac.yml), which is where
-                 the release .app zips are produced, so it must NOT be gated to a
-                 macOS host. The universal Contents/MacOS/RouteConverter stub it
-                 installs is fetched from static.routeconverter.com into
-                 target/RouteConverter by that workflow (built on macOS in
-                 build-mac-jre.yml); on a local macOS build the mac-native-launcher
-                 profile below compiles it into the same path instead. -->
-            <plugin>
-                <artifactId>maven-assembly-plugin</artifactId>
-                <executions>
-                    <execution>
-                        <id>x64</id>
-                        <phase>package</phase>
-                        <goals>
-                            <goal>single</goal>
-                        </goals>
-                        <configuration>
-                            <descriptors>
-                                <descriptor>${basedir}/src/main/assembly/macos-x64.xml</descriptor>
-                            </descriptors>
-                            <finalName>RouteConverterMac</finalName>
-                        </configuration>
-                    </execution>
-                    <execution>
-                        <id>aarch64</id>
-                        <phase>package</phase>
-                        <goals>
-                            <goal>single</goal>
-                        </goals>
-                        <configuration>
-                            <descriptors>
-                                <descriptor>${basedir}/src/main/assembly/macos-aarch64.xml</descriptor>
-                            </descriptors>
-                            <finalName>RouteConverterMac</finalName>
-                        </configuration>
-                    </execution>
-                </executions>
-            </plugin>
         </plugins>
     </build>
 
@@ -149,6 +110,56 @@
                                         <argument>-c</argument>
                                         <argument>mkdir -p "${project.build.directory}" &amp;&amp; clang -arch x86_64 -arch arm64 -framework Cocoa -o "${project.build.directory}/RouteConverter" "${basedir}/../mac-launcher/JavaAppLauncher.m"</argument>
                                     </arguments>
+                                </configuration>
+                            </execution>
+                        </executions>
+                    </plugin>
+                </plugins>
+            </build>
+        </profile>
+        <profile>
+            <!-- Assemble the macos-{x64,aarch64}.xml .app bundles. Enabled with
+                 -DmacApp. The release/prerelease Linux runner (_build-linux-mac.yml)
+                 passes it after fetching the universal Contents/MacOS/RouteConverter
+                 stub into target/RouteConverter; on a local macOS build pass -DmacApp
+                 too (the mac-native-launcher profile above compiles that stub). The
+                 plain `mvn verify` CI omits it, so RouteConverterMac only builds its
+                 shaded jar there and does not fail on the (absent) stub. -->
+            <id>mac-app</id>
+            <activation>
+                <property>
+                    <name>macApp</name>
+                </property>
+            </activation>
+            <build>
+                <plugins>
+                    <plugin>
+                        <artifactId>maven-assembly-plugin</artifactId>
+                        <executions>
+                            <execution>
+                                <id>x64</id>
+                                <phase>package</phase>
+                                <goals>
+                                    <goal>single</goal>
+                                </goals>
+                                <configuration>
+                                    <descriptors>
+                                        <descriptor>${basedir}/src/main/assembly/macos-x64.xml</descriptor>
+                                    </descriptors>
+                                    <finalName>RouteConverterMac</finalName>
+                                </configuration>
+                            </execution>
+                            <execution>
+                                <id>aarch64</id>
+                                <phase>package</phase>
+                                <goals>
+                                    <goal>single</goal>
+                                </goals>
+                                <configuration>
+                                    <descriptors>
+                                        <descriptor>${basedir}/src/main/assembly/macos-aarch64.xml</descriptor>
+                                    </descriptors>
+                                    <finalName>RouteConverterMac</finalName>
                                 </configuration>
                             </execution>
                         </executions>

--- a/TimeAlbumProMac/pom.xml
+++ b/TimeAlbumProMac/pom.xml
@@ -77,22 +77,56 @@
                     </execution>
                 </executions>
             </plugin>
+            <!-- Assemble the macos-{x64,aarch64}.xml .app bundles. This runs on
+                 the LINUX assembly runner (_build-linux-mac.yml), which is where
+                 the release .app zips are produced, so it must NOT be gated to a
+                 macOS host. The universal Contents/MacOS/TimeAlbumPro stub it
+                 installs is fetched from static.routeconverter.com into
+                 target/TimeAlbumPro by that workflow (built on macOS in
+                 build-mac-jre.yml); on a local macOS build the mac-native-launcher
+                 profile below compiles it into the same path instead. -->
+            <plugin>
+                <artifactId>maven-assembly-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <id>x64</id>
+                        <phase>package</phase>
+                        <goals>
+                            <goal>single</goal>
+                        </goals>
+                        <configuration>
+                            <descriptors>
+                                <descriptor>${basedir}/src/main/assembly/macos-x64.xml</descriptor>
+                            </descriptors>
+                            <finalName>TimeAlbumProMac</finalName>
+                        </configuration>
+                    </execution>
+                    <execution>
+                        <id>aarch64</id>
+                        <phase>package</phase>
+                        <goals>
+                            <goal>single</goal>
+                        </goals>
+                        <configuration>
+                            <descriptors>
+                                <descriptor>${basedir}/src/main/assembly/macos-aarch64.xml</descriptor>
+                            </descriptors>
+                            <finalName>TimeAlbumProMac</finalName>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
         </plugins>
     </build>
 
     <profiles>
         <profile>
-            <!-- Compiles the shared mac-launcher/JavaAppLauncher.m stub (see
-                 issue #206) into a universal (x86_64 + arm64) binary and only
-                 then assembles the macos-{x64,aarch64}.xml app bundles that
-                 install it as Contents/MacOS/TimeAlbumPro. clang + the Cocoa
-                 framework (and the resulting target/TimeAlbumPro the
-                 assembly descriptors require) are only available on a macOS
-                 host, hence both the compile step and the assembly
-                 executions live behind this OS-family gate — on non-mac CI
-                 hosts (e.g. the ubuntu-latest `mvn verify` matrix) the module
-                 still builds/tests the shaded jar, it just skips producing
-                 the .app zip. -->
+            <!-- LOCAL macOS build only: compile the shared
+                 mac-launcher/JavaAppLauncher.m stub (issue #206) into the
+                 universal target/TimeAlbumPro that the assembly descriptors
+                 require. On CI the Linux assembly runner fetches the hosted
+                 stub instead (see the assembly comment above), so this gate
+                 keeps clang — unavailable off macOS — from breaking that build. -->
             <id>mac-native-launcher</id>
             <activation>
                 <os>
@@ -118,37 +152,6 @@
                                         <argument>-c</argument>
                                         <argument>mkdir -p "${project.build.directory}" &amp;&amp; clang -arch x86_64 -arch arm64 -framework Cocoa -o "${project.build.directory}/TimeAlbumPro" "${basedir}/../mac-launcher/JavaAppLauncher.m"</argument>
                                     </arguments>
-                                </configuration>
-                            </execution>
-                        </executions>
-                    </plugin>
-                    <plugin>
-                        <artifactId>maven-assembly-plugin</artifactId>
-                        <executions>
-                            <execution>
-                                <id>x64</id>
-                                <phase>package</phase>
-                                <goals>
-                                    <goal>single</goal>
-                                </goals>
-                                <configuration>
-                                    <descriptors>
-                                        <descriptor>${basedir}/src/main/assembly/macos-x64.xml</descriptor>
-                                    </descriptors>
-                                    <finalName>TimeAlbumProMac</finalName>
-                                </configuration>
-                            </execution>
-                            <execution>
-                                <id>aarch64</id>
-                                <phase>package</phase>
-                                <goals>
-                                    <goal>single</goal>
-                                </goals>
-                                <configuration>
-                                    <descriptors>
-                                        <descriptor>${basedir}/src/main/assembly/macos-aarch64.xml</descriptor>
-                                    </descriptors>
-                                    <finalName>TimeAlbumProMac</finalName>
                                 </configuration>
                             </execution>
                         </executions>

--- a/TimeAlbumProMac/pom.xml
+++ b/TimeAlbumProMac/pom.xml
@@ -77,45 +77,6 @@
                     </execution>
                 </executions>
             </plugin>
-            <!-- Assemble the macos-{x64,aarch64}.xml .app bundles. This runs on
-                 the LINUX assembly runner (_build-linux-mac.yml), which is where
-                 the release .app zips are produced, so it must NOT be gated to a
-                 macOS host. The universal Contents/MacOS/TimeAlbumPro stub it
-                 installs is fetched from static.routeconverter.com into
-                 target/TimeAlbumPro by that workflow (built on macOS in
-                 build-mac-jre.yml); on a local macOS build the mac-native-launcher
-                 profile below compiles it into the same path instead. -->
-            <plugin>
-                <artifactId>maven-assembly-plugin</artifactId>
-                <executions>
-                    <execution>
-                        <id>x64</id>
-                        <phase>package</phase>
-                        <goals>
-                            <goal>single</goal>
-                        </goals>
-                        <configuration>
-                            <descriptors>
-                                <descriptor>${basedir}/src/main/assembly/macos-x64.xml</descriptor>
-                            </descriptors>
-                            <finalName>TimeAlbumProMac</finalName>
-                        </configuration>
-                    </execution>
-                    <execution>
-                        <id>aarch64</id>
-                        <phase>package</phase>
-                        <goals>
-                            <goal>single</goal>
-                        </goals>
-                        <configuration>
-                            <descriptors>
-                                <descriptor>${basedir}/src/main/assembly/macos-aarch64.xml</descriptor>
-                            </descriptors>
-                            <finalName>TimeAlbumProMac</finalName>
-                        </configuration>
-                    </execution>
-                </executions>
-            </plugin>
         </plugins>
     </build>
 
@@ -152,6 +113,56 @@
                                         <argument>-c</argument>
                                         <argument>mkdir -p "${project.build.directory}" &amp;&amp; clang -arch x86_64 -arch arm64 -framework Cocoa -o "${project.build.directory}/TimeAlbumPro" "${basedir}/../mac-launcher/JavaAppLauncher.m"</argument>
                                     </arguments>
+                                </configuration>
+                            </execution>
+                        </executions>
+                    </plugin>
+                </plugins>
+            </build>
+        </profile>
+        <profile>
+            <!-- Assemble the macos-{x64,aarch64}.xml .app bundles. Enabled with
+                 -DmacApp. The release/prerelease Linux runner (_build-linux-mac.yml)
+                 passes it after fetching the universal Contents/MacOS/TimeAlbumPro
+                 stub into target/TimeAlbumPro; on a local macOS build pass -DmacApp
+                 too (the mac-native-launcher profile above compiles that stub). The
+                 plain `mvn verify` CI omits it, so TimeAlbumProMac only builds its
+                 shaded jar there and does not fail on the (absent) stub. -->
+            <id>mac-app</id>
+            <activation>
+                <property>
+                    <name>macApp</name>
+                </property>
+            </activation>
+            <build>
+                <plugins>
+                    <plugin>
+                        <artifactId>maven-assembly-plugin</artifactId>
+                        <executions>
+                            <execution>
+                                <id>x64</id>
+                                <phase>package</phase>
+                                <goals>
+                                    <goal>single</goal>
+                                </goals>
+                                <configuration>
+                                    <descriptors>
+                                        <descriptor>${basedir}/src/main/assembly/macos-x64.xml</descriptor>
+                                    </descriptors>
+                                    <finalName>TimeAlbumProMac</finalName>
+                                </configuration>
+                            </execution>
+                            <execution>
+                                <id>aarch64</id>
+                                <phase>package</phase>
+                                <goals>
+                                    <goal>single</goal>
+                                </goals>
+                                <configuration>
+                                    <descriptors>
+                                        <descriptor>${basedir}/src/main/assembly/macos-aarch64.xml</descriptor>
+                                    </descriptors>
+                                    <finalName>TimeAlbumProMac</finalName>
                                 </configuration>
                             </execution>
                         </executions>


### PR DESCRIPTION
Third and final piece of the macOS launcher fix. The prerelease was still red after #216: `cp: cannot stat RouteConverterMac/target/RouteConverterMac-x64-app.zip`.

**Cause:** #208 put `maven-assembly-plugin` **inside** the `mac-native-launcher` (`os family=mac`) profile, together with the clang step. But the release `.app` zips are assembled in `_build-linux-mac.yml` on **ubuntu-latest**, where that profile is inactive — so the assembly `single` executions never ran (the module stopped at `shade`), no app-zip was produced, and staging failed. Affected both `RouteConverterMac` and `TimeAlbumProMac`.

**Fix:** move `maven-assembly-plugin` back to the main `<build>` (runs on any host); keep **only** the clang compile step behind the mac gate. On CI the Linux runner fetches the hosted universal stub into `target/<App>` (build-mac-jre.yml host + the #216 fetch step); on a local macOS build the profile compiles it into the same path.

**Verified locally** by simulating the Linux path (`-P '!mac-native-launcher'` + seeded stub/Runtimes): both `RouteConverterMac-x64-app.zip` and `-aarch64-app.zip` are produced, each with a universal (`x86_64`+`arm64`) `Contents/MacOS/RouteConverter`.