### PR TITLE
ci(mirror): use dedicated GITEA_MIRROR_TOKEN with rc/RouteConverter read

### DIFF
--- a/.github/workflows/mirror-gitea.yml
+++ b/.github/workflows/mirror-gitea.yml
@@ -3,8 +3,11 @@ name: Mirror gitea master
 # Keeps github master a superset of the gitea factory master by merging gitea -> github on a
 # schedule. The two masters take commits independently (Dependabot + maintainer on github,
 # factory PRs on gitea), so this is a non-destructive merge, not a force-mirror: a clean merge
-# is pushed, a conflict opens an issue for manual reconciliation. Reuses the release tokens, so
-# no new secrets are needed.
+# is pushed, a conflict opens an issue for manual reconciliation.
+#
+# Secrets: RC_RELEASE_PUSH_TOKEN (github PAT, pushes master) and RC_SITE_GITEA_HOST (gitea host)
+# already exist; GITEA_MIRROR_TOKEN must be added - a gitea token with READ access to
+# rc/RouteConverter (RC_SITE_DISPATCH_TOKEN only reaches rc-site, so it cannot be reused here).
 
 on:
   schedule:
@@ -32,7 +35,7 @@ jobs:
 
       - name: Merge gitea master into github master
         env:
-          GITEA_TOKEN: ${{ secrets.RC_SITE_DISPATCH_TOKEN }}
+          GITEA_TOKEN: ${{ secrets.GITEA_MIRROR_TOKEN }}
           GITEA_HOST: ${{ secrets.RC_SITE_GITEA_HOST }}
           GH_TOKEN: ${{ github.token }}
         run: |


### PR DESCRIPTION
First mirror run failed to authenticate to gitea — `RC_SITE_DISPATCH_TOKEN` is scoped to rc-site, not rc/RouteConverter. Point the gitea fetch at a new `GITEA_MIRROR_TOKEN` secret (a gitea token with **read** access to rc/RouteConverter).

**Action needed after merge:** add repo secret `GITEA_MIRROR_TOKEN` (Settings → Secrets → Actions), then re-run the workflow.

🤖 Generated with [Claude Code](https://claude.com/claude-code)