### PR TITLE
fix(javadoc): rsync from target/reports/apidocs (maven-javadoc 3.x path)

### DIFF
--- a/.github/workflows/javadoc.yml
+++ b/.github/workflows/javadoc.yml
@@ -58,6 +58,9 @@ jobs:
         env:
           DEPLOY_HOST: ${{ secrets.RC_RELEASE_DEPLOY_HOST }}
         run: |
+          # maven-javadoc-plugin 3.x writes the aggregate report under
+          # target/reports/apidocs (was target/site/apidocs pre-3.x); the old
+          # path no longer exists, which failed this rsync ("No such file").
           rsync -av --delete --omit-dir-times --no-perms \
-            target/site/apidocs/ \
+            target/reports/apidocs/ \
             "rc-release-deploy@${DEPLOY_HOST}:/var/www/routeconverter.com/static/javadoc/"


### PR DESCRIPTION
The **Publish Javadoc** workflow has been red on every master push: `rsync: change_dir ".../target/site/apidocs" failed: No such file or directory`.

**Cause:** maven-javadoc-plugin 3.x writes the aggregate report to `target/reports/apidocs`; the workflow still rsynced the pre-3.x `target/site/apidocs`. The `Aggregate javadoc` step succeeds (docs ARE generated), but at the new path, so the rsync of the old path fails.

**Fix:** rsync `target/reports/apidocs/`.

**Verified locally:** `mvn -DskipTests install javadoc:aggregate` produces **3859** HTML files under `target/reports/apidocs` (`index.html` present); the old `target/site/apidocs` does not exist.

Note (not fixed here, cosmetic): the root pom still uses the removed `<additionalparam>-Xdoclint:none</additionalparam>` on maven-javadoc-plugin 3.12.0 (logged as "unknown parameter"); modern equivalent is `<doclint>none</doclint>`. Docs build fine regardless, so left for a separate cleanup.