### PR TITLE
chore(build): mac .app smoke-gate + runner-safety doc + drop stale javadoc param

### DIFF
--- a/.github/workflows/_build-linux-mac.yml
+++ b/.github/workflows/_build-linux-mac.yml
@@ -114,6 +114,36 @@ jobs:
           scripts/verify-runtime.sh \
             RouteConverterLinux/target/RouteConverterLinux.jar \
             RouteConverterCmdLine/target/RouteConverterCmdLine.jar
+      - name: Smoke-check assembled .app bundles
+        # Fail loudly here (not at a downstream cp / at runtime) if a bundle is
+        # missing its universal launcher stub, JRE, or jar -- the failure modes
+        # behind the 2026-07 Open-with regression + the mislocated assembly.
+        # Runs on ubuntu, so use `file` (not the macOS-only `lipo`) to confirm
+        # the stub is a fat Mach-O with both arches.
+        run: |
+          set -euo pipefail
+          check() {  # $1 = app-zip, $2 = executable/app name
+            local zip="$1" exe="$2" app="$2.app" t
+            echo "== $zip =="
+            unzip -l "$zip" | grep -qE "${app}/Contents/MacOS/${exe}\$"  || { echo "::error::$zip: missing MacOS/${exe}"; exit 1; }
+            unzip -l "$zip" | grep -qE "${app}/Contents/bin/java\$"       || { echo "::error::$zip: missing bin/java"; exit 1; }
+            unzip -l "$zip" | grep -qE "${app}/Contents/Java/.+\.jar\$"   || { echo "::error::$zip: missing Java/*.jar"; exit 1; }
+            t="$(mktemp -d)"
+            unzip -q "$zip" "${app}/Contents/MacOS/${exe}" -d "$t"
+            local info; info="$(file -b "$t/${app}/Contents/MacOS/${exe}")"
+            echo "  stub: $info"
+            case "$info" in
+              *"universal binary"*|*"Mach-O universal"*) : ;;
+              *) echo "::error::$zip: MacOS/${exe} is not a universal Mach-O"; exit 1 ;;
+            esac
+            printf '%s' "$info" | grep -q x86_64 && printf '%s' "$info" | grep -q arm64 \
+              || { echo "::error::$zip: MacOS/${exe} missing an arch (need x86_64 + arm64)"; exit 1; }
+            echo "  OK"
+          }
+          check RouteConverterMac/target/RouteConverterMac-x64-app.zip     RouteConverter
+          check RouteConverterMac/target/RouteConverterMac-aarch64-app.zip RouteConverter
+          check TimeAlbumProMac/target/TimeAlbumProMac-x64-app.zip         TimeAlbumPro
+          check TimeAlbumProMac/target/TimeAlbumProMac-aarch64-app.zip     TimeAlbumPro
       - name: Stage artefacts
         run: |
           mkdir -p artefacts

--- a/mac-launcher/README.md
+++ b/mac-launcher/README.md
@@ -1,0 +1,62 @@
+# mac-launcher
+
+`JavaAppLauncher.m` — the native macOS launcher stub used as
+`Contents/MacOS/<App>` in the RouteConverter and TimeAlbumPro `.app` bundles.
+
+On a cold "Open with" macOS delivers the file via a `kAEOpenDocuments` (odoc)
+Apple Event, **not** as `argv`. This stub is an `NSApplication` delegate that
+catches the launch odoc in `application:openFiles:` (delivered before
+`applicationDidFinishLaunching:`), then `execv`s the bundled JRE with the
+file(s) appended as `argv` — the path RouteConverter already handles
+(`BaseRouteConverter.parseInitialArgs`). After exec, `java` is the app process,
+so a subsequent *warm* "Open with" is handled by its own `Desktop`
+open-file handler. Fixes forum #4139 (issue #206 / PR #208).
+
+It is a universal (`x86_64` + `arm64`) binary and is byte-identical for both
+products — it resolves its jar, icon, and dock name from its own bundle at
+runtime, so one build serves both.
+
+## How it is built and installed
+
+- **CI (release/prerelease):** compiled on the **macOS** runner in
+  `build-mac-jre.yml` and hosted at
+  `https://static.routeconverter.com/build/mac/macos-launcher-stub` (+ `.sha256`).
+  The **Linux** assembly runner (`_build-linux-mac.yml`) fetches it into
+  `RouteConverterMac/target/RouteConverter` and
+  `TimeAlbumProMac/target/TimeAlbumPro`, then the `mac-app` Maven profile
+  (`-DmacApp`) assembles the `.app` zips.
+- **Local macOS build:** the `mac-native-launcher` profile (auto-active on
+  `os.family=mac`) compiles the stub with `clang`; pass `-DmacApp` to also
+  assemble the `.app`.
+
+## Checklist: is a hand-rolled Maven/CI build change runner-safe?
+
+The Mac `.app` is **assembled on a Linux runner**, and different workflows run
+different profiles. Before merging a change to a Mac `*/pom.xml` or a build
+workflow, confirm all three axes — each has burned us:
+
+1. **Profile activation × runner OS.** `os.family=mac` profiles do **not**
+   activate on the Linux assembly runner; a step gated that way silently never
+   runs there. Anything that must run during the release assembly belongs in the
+   main `<build>` or a property-gated profile (`-DmacApp`), **not** an `os=mac`
+   gate. `clang` is the only thing that must stay `os=mac` (it can't run on Linux).
+2. **Which workflow runs it.** The generic `mvn verify` PR matrix (Java
+   21/25/Windows) does **not** fetch the hosted stub and does **not** pass
+   `-DmacApp` — so a release-only step failing there would be a false alarm, and
+   a release-only step *missing* passes PR CI while breaking the release build.
+   Keep `.app` assembly behind `-DmacApp` so PR CI only builds the shaded jar.
+3. **Phase.** `RouteConverterMac`/`TimeAlbumProMac` have no compilable sources,
+   so `target/` does not exist until `package`; a step writing under `target/`
+   must create the dir itself (`mkdir -p`) rather than assume an earlier phase made it.
+
+**Verify against the runner, not a local partial run.** `mvn prepare-package` on
+a Mac does not exercise the Linux `package`/assembly path. Simulate it:
+
+```sh
+# CI mvn-verify path (must succeed, must NOT produce a .app zip):
+mvn -pl RouteConverterMac -am -Dmaven.test.skip=true -P '!mac-native-launcher' package
+
+# release path (must produce both -x64-app.zip and -aarch64-app.zip):
+#   seed target/RouteConverter (the stub) + target/Runtime-{x64,aarch64} first, then:
+mvn -pl RouteConverterMac -am -Dmaven.test.skip=true -P '!mac-native-launcher' -DmacApp package
+```

--- a/pom.xml
+++ b/pom.xml
@@ -251,7 +251,6 @@
                         -->
                         <doclint>none</doclint>
                         <failOnError>false</failOnError>
-                        <additionalparam>-Xdoclint:none</additionalparam>
                     </configuration>
                 </plugin>
                 <plugin>
@@ -506,7 +505,6 @@
                     </excludePackageNames>
                     <doclint>none</doclint>
                     <failOnError>false</failOnError>
-                    <additionalparam>-Xdoclint:none</additionalparam>
                 </configuration>
                 <reportSets>
                     <reportSet>


### PR DESCRIPTION
Three post-mortem hardening items from the macOS Open-with / prerelease repair (issues #206, PRs #208/#215/#216/#217/#220):

1. **Smoke-gate the assembled `.app` bundles** (`_build-linux-mac.yml`): after assembly, assert each of the four app-zips contains `Contents/MacOS/<App>` + `bin/java` + `Java/*.jar`, and that the launcher stub is a universal `x86_64`+`arm64` Mach-O (checked with `file` — `lipo` is macOS-only, this runs on ubuntu). Turns a silent missing/mislocated stub into a loud build failure instead of a downstream `cp` error or a broken shipped app.
2. **Runner-safety doc** (`mac-launcher/README.md`): what the stub is + how it is built/hosted/fetched, plus a checklist for hand-rolled Maven/CI changes (profile activation × runner OS, which workflow runs it, `target/` phase) and the simulate-the-runner verification commands. The assembly-in-`os=mac`-profile trap was invisible three ways.
3. **Drop the stale `<additionalparam>-Xdoclint:none</additionalparam>`** (`pom.xml`, both javadoc configs): the parameter was removed in maven-javadoc-plugin 3.x (logged "unknown parameter") and the modern `<doclint>none</doclint>` was already present alongside it — so this just removes the redundant line. No behaviour change.

Verified locally: both workflow YAML + pom parse; the `file`-based universal check matches a real fat Mach-O; `<doclint>none</doclint>` retained (x2), `additionalparam` gone.