### PR TITLE
ci: submit transitive Maven dependency graph for Dependabot

### DIFF
--- a/.github/workflows/dependency-submission.yml
+++ b/.github/workflows/dependency-submission.yml
@@ -1,0 +1,34 @@
+name: Dependency Submission
+
+# Submit the full (transitive) Maven dependency graph to GitHub so
+# Dependabot alerts cover indirect dependencies, not just those declared
+# in pom.xml. Runs on pushes to the default branch and weekly.
+
+on:
+  push:
+    branches: [ master ]
+  schedule:
+    - cron: '17 4 * * 1'
+  workflow_dispatch:
+
+permissions:
+  contents: write
+
+jobs:
+  submit:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v7
+      - name: Set up JDK 21
+        uses: actions/setup-java@v5
+        with:
+          distribution: 'zulu'
+          java-version: 21
+      - name: Cache Maven packages
+        uses: actions/cache@v6
+        with:
+          path: ~/.m2
+          key: ${{ runner.os }}-m2-${{ hashFiles('**/pom.xml') }}
+          restore-keys: ${{ runner.os }}-m2
+      - name: Submit dependency graph
+        uses: advanced-security/maven-dependency-submission-action@v5


### PR DESCRIPTION
Adds a Dependency Submission workflow so Dependabot alerts cover **transitive** deps, not just those declared in `pom.xml`.

- Runs `advanced-security/maven-dependency-submission-action@v5` on push to `master`, weekly, and on demand.
- Java 21 / zulu, Maven cache — matches `build.yml`.
- Requires `contents: write` to submit the graph.

Pairs with the "Enable automatic dependency submission for Maven" prompt on the Dependency graph page.

🤖 Generated with [Claude Code](https://claude.com/claude-code)