### PR TITLE
Sort the map dropdown alphabetically (offline block, then online block)

### DIFF
--- a/mapsforge-maps/src/main/java/slash/navigation/maps/mapsforge/MapsforgeMapManager.java
+++ b/mapsforge-maps/src/main/java/slash/navigation/maps/mapsforge/MapsforgeMapManager.java
@@ -25,6 +25,7 @@ import slash.navigation.datasources.DataSourceManager;
 import slash.navigation.datasources.Downloadable;
 import slash.navigation.download.Download;
 import slash.navigation.gui.models.FilteringTableModel;
+import slash.navigation.maps.item.Item;
 import slash.navigation.maps.item.ItemModel;
 import slash.navigation.maps.item.ItemTableModel;
 import slash.navigation.maps.mapsforge.helpers.ActiveTileMapPredicate;
@@ -80,7 +81,8 @@ public class MapsforgeMapManager {
 
     private final DataSourceManager dataSourceManager;
     private final ItemTableModel<TileDownloadMap> availableOnlineMapsModel = new TileMapTableModel();
-    private final ItemTableModel<LocalMap> availableOfflineMapsModel = new ItemTableModel<>(1);
+    private final ItemTableModel<LocalMap> availableOfflineMapsModel = new ItemTableModel<>(1,
+            Comparator.comparing(Item::description, String.CASE_INSENSITIVE_ORDER));
     private final JoinedItemTableModel<LocalMap> availableMapsModel = new JoinedItemTableModel<>(availableOfflineMapsModel,
             new FilteringTableModel<>(availableOnlineMapsModel, new ActiveTileMapPredicate()));
     private final ItemTableModel<LocalTheme> availableThemesModel = new ItemTableModel<>(1);

--- a/mapsforge-maps/src/main/java/slash/navigation/maps/mapsforge/models/TileMapTableModel.java
+++ b/mapsforge-maps/src/main/java/slash/navigation/maps/mapsforge/models/TileMapTableModel.java
@@ -19,10 +19,12 @@
 */
 package slash.navigation.maps.mapsforge.models;
 
+import slash.navigation.maps.item.Item;
 import slash.navigation.maps.item.ItemTableModel;
 import slash.navigation.maps.mapsforge.impl.TileDownloadMap;
 
 import javax.swing.table.TableModel;
+import java.util.Comparator;
 
 /**
  * Acts as a {@link TableModel} for {@link TileDownloadMap}s
@@ -35,7 +37,7 @@ public class TileMapTableModel extends ItemTableModel<TileDownloadMap> {
     public static final int ACTIVE_COLUMN = 1;
 
     public TileMapTableModel() {
-        super(2);
+        super(2, Comparator.comparing(Item::description, String.CASE_INSENSITIVE_ORDER));
     }
 
     public Class<?> getColumnClass(int columnIndex) {

--- a/tileserver-maps/src/main/java/slash/navigation/maps/item/ItemTableModel.java
+++ b/tileserver-maps/src/main/java/slash/navigation/maps/item/ItemTableModel.java
@@ -90,10 +90,15 @@ public class ItemTableModel<T extends Item> extends AbstractTableModel {
     }
 
     static <T> int sortedIndex(List<T> items, T item, Comparator<? super T> comparator) {
-        int i = 0;
-        while (i < items.size() && comparator.compare(items.get(i), item) <= 0)
-            i++;
-        return i;
+        int low = 0, high = items.size();
+        while (low < high) {
+            int mid = (low + high) >>> 1;
+            if (comparator.compare(items.get(mid), item) <= 0)
+                low = mid + 1;
+            else
+                high = mid;
+        }
+        return low;
     }
 
     private void addItem(T item) {

--- a/tileserver-maps/src/main/java/slash/navigation/maps/item/ItemTableModel.java
+++ b/tileserver-maps/src/main/java/slash/navigation/maps/item/ItemTableModel.java
@@ -22,6 +22,7 @@ package slash.navigation.maps.item;
 import javax.swing.table.AbstractTableModel;
 import javax.swing.table.TableModel;
 import java.util.ArrayList;
+import java.util.Comparator;
 import java.util.List;
 
 /**
@@ -32,10 +33,16 @@ import java.util.List;
 
 public class ItemTableModel<T extends Item> extends AbstractTableModel {
     private final int columnCount;
+    private final Comparator<? super T> comparator;
     private final List<T> items = new ArrayList<>();
 
     public ItemTableModel(int columnCount) {
+        this(columnCount, null);
+    }
+
+    public ItemTableModel(int columnCount, Comparator<? super T> comparator) {
         this.columnCount = columnCount;
+        this.comparator = comparator;
     }
 
     public List<T> getItems() {
@@ -82,7 +89,21 @@ public class ItemTableModel<T extends Item> extends AbstractTableModel {
         return items.contains(item);
     }
 
+    static <T> int sortedIndex(List<T> items, T item, Comparator<? super T> comparator) {
+        int i = 0;
+        while (i < items.size() && comparator.compare(items.get(i), item) <= 0)
+            i++;
+        return i;
+    }
+
     private void addItem(T item) {
+        if (comparator != null) {
+            int index = sortedIndex(items, item, comparator);
+            items.add(index, item);
+            fireTableRowsInserted(index, index);
+            return;
+        }
+
         if (!items.add(item))
             throw new IllegalArgumentException("Item " + item + " not added to " + items);
 

--- a/tileserver-maps/src/test/java/slash/navigation/maps/item/ItemTableModelSortTest.java
+++ b/tileserver-maps/src/test/java/slash/navigation/maps/item/ItemTableModelSortTest.java
@@ -1,0 +1,113 @@
+/*
+    This file is part of RouteConverter.
+
+    RouteConverter is free software; you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation; either version 2 of the License, or
+    (at your option) any later version.
+
+    RouteConverter is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with RouteConverter; if not, write to the Free Software
+    Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
+
+    Copyright (C) 2007 Christian Pesch. All Rights Reserved.
+*/
+package slash.navigation.maps.item;
+
+import org.junit.Test;
+
+import java.util.Comparator;
+import java.util.List;
+
+import static org.junit.Assert.assertEquals;
+
+public class ItemTableModelSortTest {
+    private static final Comparator<Item> DESCRIPTION_COMPARATOR =
+            Comparator.comparing(Item::description, String.CASE_INSENSITIVE_ORDER);
+
+    private static class TestItem implements Item {
+        private final String description;
+
+        private TestItem(String description) {
+            this.description = description;
+        }
+
+        public String description() {
+            return description;
+        }
+
+        public String getUrl() {
+            return description;
+        }
+    }
+
+    @Test
+    public void testAddOutOfOrderEndsUpSorted() {
+        ItemTableModel<TestItem> model = new ItemTableModel<>(1, DESCRIPTION_COMPARATOR);
+
+        model.addOrUpdateItem(new TestItem("Viamichelin"));
+        model.addOrUpdateItem(new TestItem("ArcGIS Topo"));
+        model.addOrUpdateItem(new TestItem("bergfex"));
+        model.addOrUpdateItem(new TestItem("CyclOSM"));
+
+        List<String> descriptions = model.getItems().stream().map(TestItem::description).toList();
+        assertEquals(List.of("ArcGIS Topo", "bergfex", "CyclOSM", "Viamichelin"), descriptions);
+    }
+
+    @Test
+    public void testInsertIntoEmptyModel() {
+        ItemTableModel<TestItem> model = new ItemTableModel<>(1, DESCRIPTION_COMPARATOR);
+
+        model.addOrUpdateItem(new TestItem("Solo"));
+
+        assertEquals(1, model.getItems().size());
+        assertEquals("Solo", model.getItems().get(0).description());
+    }
+
+    @Test
+    public void testInsertAtStartMiddleEnd() {
+        ItemTableModel<TestItem> model = new ItemTableModel<>(1, DESCRIPTION_COMPARATOR);
+
+        model.addOrUpdateItem(new TestItem("Mango"));
+
+        model.addOrUpdateItem(new TestItem("Apple"));
+        assertEquals(0, model.getIndex(model.getItemByDescription("Apple")));
+
+        model.addOrUpdateItem(new TestItem("Kiwi"));
+        assertEquals(1, model.getIndex(model.getItemByDescription("Kiwi")));
+
+        model.addOrUpdateItem(new TestItem("Zebra"));
+        assertEquals(3, model.getIndex(model.getItemByDescription("Zebra")));
+    }
+
+    @Test
+    public void testDuplicateDescriptionLandsAfterExistingEqualItem() {
+        ItemTableModel<TestItem> model = new ItemTableModel<>(1, DESCRIPTION_COMPARATOR);
+
+        TestItem first = new TestItem("Duplicate");
+        model.addOrUpdateItem(first);
+        TestItem second = new TestItem("Duplicate");
+        model.addOrUpdateItem(second);
+
+        assertEquals(2, model.getItems().size());
+        assertEquals(0, model.getIndex(first));
+        assertEquals(1, model.getIndex(second));
+    }
+
+    @Test
+    public void testNoComparatorKeepsInsertionOrder() {
+        ItemTableModel<TestItem> model = new ItemTableModel<>(1);
+
+        model.addOrUpdateItem(new TestItem("Zebra"));
+        model.addOrUpdateItem(new TestItem("Apple"));
+        model.addOrUpdateItem(new TestItem("Mango"));
+
+        List<String> descriptions = model.getItems().stream().map(TestItem::description).toList();
+        assertEquals(List.of("Zebra", "Apple", "Mango"), descriptions);
+    }
+}


### PR DESCRIPTION
All four files from the spec are present. Implementation complete.

## Summary

Implemented alphabetical sorting for the "Karte:" map dropdown (offline block, then online block) per issue #222.

**Changes:**

1. **`tileserver-maps/src/main/java/slash/navigation/maps/item/ItemTableModel.java`** — Added an optional `Comparator<? super T>` field with a new constructor `ItemTableModel(int columnCount, Comparator<? super T> comparator)`. The existing `ItemTableModel(int columnCount)` delegates with `comparator = null`, preserving append-only behavior for themes/styles/downloads. Extracted the insertion-index calculation to a pure static seam `sortedIndex(items, item, comparator)`; `addItem` uses it for a sorted insert (`items.add(index, item)` + `fireTableRowsInserted(index, index)`) when a comparator is set, otherwise falls back to the original append logic unchanged.

2. **`mapsforge-maps/src/main/java/slash/navigation/maps/mapsforge/models/TileMapTableModel.java`** — Passes `Comparator.comparing(Item::description, String.CASE_INSENSITIVE_ORDER)` to `super(...)`, so the online-maps model (`availableOnlineMapsModel`) self-sorts as maps are added by the catalog mediator.

3. **`mapsforge-maps/src/main/java/slash/navigation/maps/mapsforge/MapsforgeMapManager.java`** — Constructs `availableOfflineMapsModel` with the same case-insensitive `description()` comparator, so offline maps discovered from directories self-sort.

4. **`tileserver-maps/src/test/java/slash/navigation/maps/item/ItemTableModelSortTest.java`** (new) — JUnit tests covering the `sortedIndex` seam: out-of-order inserts end up sorted, insert into empty model, insert at start/middle/end, duplicate descriptions land stably after the existing equal item, and the no-comparator constructor preserves plain insertion order.

Both `availableOfflineMapsModel` and `availableOnlineMapsModel` are sorted independently (not merged), matching the existing `JoinedItemTableModel` structure that already renders offline rows first, then online rows. `OpenStreetMap` is not pinned — it sorts purely under "O". Themes/styles/downloadable-maps models are untouched (out of scope per the issue).

Couldn't run `mvn`/`javac` in this sandbox (blocked), so changes were verified by careful manual review against the existing code conventions rather than an actual build/test run.


Source issue: cpesch/RouteConverter#222

---
**Builder stats** · model `sonnet` · confidence `0` · 2m 10s across 1 round(s) · 4 file op(s)
[Workflow run](http://127.0.0.1:3000/cpesch/RouteConverter/actions/runs/13597)

<!-- issue-body-sha:369128bed9bd -->