### PR TITLE
[maintainer] add community health files (CoC, CONTRIBUTING, SECURITY, issue/PR templates)

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,0 +1,59 @@
+name: Bug report
+description: Report something that isn't working as expected.
+title: "[bug] "
+labels: []
+body:
+  - type: input
+    id: version
+    attributes:
+      label: RouteConverter version
+      description: The exact version you're using.
+      placeholder: "2.34 / prerelease 2026-07-20"
+    validations:
+      required: true
+  - type: dropdown
+    id: channel
+    attributes:
+      label: Channel
+      options:
+        - Stable
+        - Prerelease
+    validations:
+      required: true
+  - type: dropdown
+    id: os
+    attributes:
+      label: Operating system
+      options:
+        - Windows
+        - macOS
+        - Linux
+    validations:
+      required: true
+  - type: textarea
+    id: what-happened
+    attributes:
+      label: What happened
+      description: A clear description of the problem.
+    validations:
+      required: true
+  - type: textarea
+    id: steps
+    attributes:
+      label: Steps to reproduce
+      description: How can we reproduce this?
+    validations:
+      required: false
+  - type: textarea
+    id: expected
+    attributes:
+      label: Expected behaviour
+      description: What did you expect to happen instead?
+    validations:
+      required: false
+  - type: markdown
+    attributes:
+      value: |
+        If your bug is about a specific file, please attach a minimal sample
+        GPS file that shows the problem — strip any private data (home
+        coordinates, timestamps) from it first.

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,8 @@
+blank_issues_enabled: true
+contact_links:
+  - name: RouteConverter forum
+    url: https://forum.routeconverter.com/
+    about: Usage questions and discussion.
+  - name: Website FAQ
+    url: https://www.routeconverter.com/faq/en
+    about: Frequently asked questions.

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -1,0 +1,26 @@
+name: Feature request
+description: Suggest an idea or improvement for RouteConverter.
+title: "[feature] "
+labels: []
+body:
+  - type: textarea
+    id: problem
+    attributes:
+      label: Problem
+      description: What can't you do today?
+    validations:
+      required: true
+  - type: textarea
+    id: solution
+    attributes:
+      label: Proposed solution
+      description: How would you like this to work?
+    validations:
+      required: false
+  - type: input
+    id: formats
+    attributes:
+      label: Formats / devices affected
+      placeholder: "e.g. GPX, Garmin GPSMAP 66i"
+    validations:
+      required: false

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,12 @@
+## What / Why
+
+<!-- Describe what this PR changes and why. -->
+
+## Checklist
+
+- [ ] Linked issue (if one exists)
+- [ ] Small, focused diff matching the surrounding code style
+- [ ] Tests added/updated for the change
+- [ ] CI matrix green (Java 21 + 25, Windows smoke build)
+- [ ] GPL header on every new `.java` file
+- [ ] No hand-edits to `RouteConverter_*.properties` except `_en`/`_de` (translations go through Weblate)

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,133 @@
+# Contributor Covenant Code of Conduct
+
+## Our Pledge
+
+We as members, contributors, and leaders pledge to make participation in our
+community a harassment-free experience for everyone, regardless of age, body
+size, visible or invisible disability, ethnicity, sex characteristics, gender
+identity and expression, level of experience, education, socio-economic status,
+nationality, personal appearance, race, religion, or sexual identity
+and orientation.
+
+We pledge to act and interact in ways that contribute to an open, welcoming,
+diverse, inclusive, and healthy community.
+
+## Our Standards
+
+Examples of behavior that contributes to a positive environment for our
+community include:
+
+* Demonstrating empathy and kindness toward other people
+* Being respectful of differing opinions, viewpoints, and experiences
+* Giving and gracefully accepting constructive feedback
+* Accepting responsibility and apologizing to those affected by our mistakes,
+  and learning from the experience
+* Focusing on what is best not just for us as individuals, but for the
+  overall community
+
+Examples of unacceptable behavior include:
+
+* The use of sexualized language or imagery, and sexual attention or
+  advances of any kind
+* Trolling, insulting or derogatory comments, and personal or political attacks
+* Public or private harassment
+* Publishing others' private information, such as a physical or email
+  address, without their explicit permission
+* Other conduct which could reasonably be considered inappropriate in a
+  professional setting
+
+## Enforcement Responsibilities
+
+Community leaders are responsible for clarifying and enforcing our standards of
+acceptable behavior and will take appropriate and fair corrective action in
+response to any behavior that they deem inappropriate, threatening, offensive,
+or harmful.
+
+Community leaders have the right and responsibility to remove, edit, or reject
+comments, commits, code, wiki edits, issues, and other contributions that are
+not aligned to this Code of Conduct, and will communicate reasons for moderation
+decisions when appropriate.
+
+## Scope
+
+This Code of Conduct applies within all community spaces, and also applies when
+an individual is officially representing the community in public spaces.
+Examples of representing our community include using an official e-mail address,
+posting via an official social media account, or acting as an appointed
+representative at an online or offline event.
+
+## Enforcement
+
+Instances of abusive, harassing, or otherwise unacceptable behavior may be
+reported to the community leaders responsible for enforcement by contacting the
+maintainer, [@cpesch](https://github.com/cpesch), via a private message on
+GitHub.
+All complaints will be reviewed and investigated promptly and fairly.
+
+All community leaders are obligated to respect the privacy and security of the
+reporter of any incident.
+
+## Enforcement Guidelines
+
+Community leaders will follow these Community Impact Guidelines in determining
+the consequences for any action they deem in violation of this Code of Conduct:
+
+### 1. Correction
+
+**Community Impact**: Use of inappropriate language or other behavior deemed
+unprofessional or unwelcome in the community.
+
+**Consequence**: A private, written warning from community leaders, providing
+clarity around the nature of the violation and an explanation of why the
+behavior was inappropriate. A public apology may be requested.
+
+### 2. Warning
+
+**Community Impact**: A violation through a single incident or series
+of actions.
+
+**Consequence**: A warning with consequences for continued behavior. No
+interaction with the people involved, including unsolicited interaction with
+those enforcing the Code of Conduct, for a specified period of time. This
+includes avoiding interactions in community spaces as well as external channels
+like social media. Violating these terms may lead to a temporary or
+permanent ban.
+
+### 3. Temporary Ban
+
+**Community Impact**: A serious violation of community standards, including
+sustained inappropriate behavior.
+
+**Consequence**: A temporary ban from any sort of interaction or public
+communication with the community for a specified period of time. No public or
+private interaction with the people involved, including unsolicited interaction
+with those enforcing the Code of Conduct, is allowed during this period.
+Violating these terms may lead to a permanent ban.
+
+### 4. Permanent Ban
+
+**Community Impact**: Demonstrating a pattern of violation of community
+standards, including sustained inappropriate behavior,  harassment of an
+individual, or aggression toward or disparagement of classes of individuals.
+
+**Consequence**: A permanent ban from any sort of public interaction within
+the community.
+
+## Attribution
+
+This Code of Conduct is adapted from the [Contributor Covenant][homepage],
+version 2.1, available at
+[https://www.contributor-covenant.org/version/2/1/code_of_conduct.html][v2.1].
+
+Community Impact Guidelines were inspired by
+[Mozilla's code of conduct enforcement ladder][Mozilla CoC].
+
+For answers to common questions about this code of conduct, see the FAQ at
+[https://www.contributor-covenant.org/faq][FAQ]. Translations are available
+at [https://www.contributor-covenant.org/translations][translations].
+
+[homepage]: https://www.contributor-covenant.org
+[v2.1]: https://www.contributor-covenant.org/version/2/1/code_of_conduct.html
+[Mozilla CoC]: https://github.com/mozilla/diversity
+[FAQ]: https://www.contributor-covenant.org/faq
+[translations]: https://www.contributor-covenant.org/translations

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,44 @@
+# Contributing to RouteConverter
+
+Thanks for your interest in RouteConverter! Contributions are very welcome —
+bug fixes, new formats, UI improvements, and translations all help.
+
+## Reporting bugs / requesting features
+
+Please use the issue forms when you [open a new issue](https://github.com/cpesch/RouteConverter/issues/new/choose):
+one for bug reports, one for feature requests. For general usage questions,
+please ask on the [forum](https://forum.routeconverter.com/) instead of
+opening an issue.
+
+## Pull requests
+
+1. Fork the repository, create a branch, and open a PR against `master`.
+2. Keep your diff small and focused, and match the surrounding code style.
+3. Add tests for your change.
+4. A human maintainer reviews and merges every PR — no auto-merge.
+5. Keep the CI matrix green (Java 21 + 25, plus the Windows smoke build).
+6. Never commit secrets.
+
+## Project conventions
+
+See [`AGENTS.md`](AGENTS.md) for the module layout, build/test commands, the
+GPL header rule, the JAXB test-object convention, and the IntelliJ GUI
+Designer `.form` round-trip.
+
+## Build & IDE setup
+
+Don't duplicate the commands here — see the README's
+["Build & run from source"](README.md#build--run-from-source) and
+["IDE setup"](README.md#ide-setup-intellij-idea) sections.
+
+## Translations
+
+Translations go through [Weblate](https://hosted.weblate.org/projects/routeconverter/).
+Never hand-edit `RouteConverter_*.properties` directly — code PRs may only
+touch the `_en`/`_de` bundles (see `AGENTS.md`).
+
+## License
+
+By contributing, you agree your code ships under the **GNU GPL v2** (see
+[`LICENSE-GPL.txt`](LICENSE-GPL.txt)). Contributors are listed in
+[`CONTRIBUTORS.txt`](CONTRIBUTORS.txt).

--- a/README.md
+++ b/README.md
@@ -49,19 +49,9 @@ CI builds and tests on **Java 21 and 25** plus a Windows smoke build.
 ## Contributing
 
 Contributions are very welcome — bug fixes, new formats, UI improvements,
-translations. 🎉
-
-- **Pull requests:** fork, branch, and open a PR against `master`. Keep your diff
-  small and focused, match the surrounding code style, and add tests for your
-  change. A maintainer reviews and merges every PR.
-- **Conventions:** see [`AGENTS.md`](AGENTS.md) for the project layout, module
-  layering, build/test commands, and code conventions (GPL header, JAXB test
-  objects, IntelliJ GUI Designer `.form` files, …).
-- **Translations** go through Weblate, not direct edits:
-  [hosted.weblate.org/projects/routeconverter](https://hosted.weblate.org/projects/routeconverter/).
-- **Issues:** https://github.com/cpesch/RouteConverter/issues
-
-Contributors are listed in [`CONTRIBUTORS.txt`](CONTRIBUTORS.txt).
+translations. 🎉 See [`CONTRIBUTING.md`](CONTRIBUTING.md) for how to report
+bugs, open pull requests, and translate the app. Contributors are listed in
+[`CONTRIBUTORS.txt`](CONTRIBUTORS.txt).
 
 ### IDE setup (IntelliJ IDEA)
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -2,11 +2,11 @@
 
 ## Supported Versions
 
-| Version              | Supported          |
-| --------------------- | ------------------ |
-| Latest stable release  | ✅ |
-| Current prerelease     | ✅ |
-| Older releases         | ❌ |
+| Version               | Supported |
+| --------------------- | --------- |
+| Latest stable release | ✅        |
+| Current prerelease    | ✅        |
+| Older releases        | ❌        |
 
 Fixes land in the next release only — there are no backported patches for
 older versions. Please always update to the latest stable release (or try

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,27 @@
+# Security Policy
+
+## Supported Versions
+
+| Version              | Supported          |
+| --------------------- | ------------------ |
+| Latest stable release  | ✅ |
+| Current prerelease     | ✅ |
+| Older releases         | ❌ |
+
+Fixes land in the next release only — there are no backported patches for
+older versions. Please always update to the latest stable release (or try
+the [prerelease](https://releases.routeconverter.com/prerelease/)) before
+reporting a security issue.
+
+## Reporting a Vulnerability
+
+**Please do not open a public issue for security problems.**
+
+Report vulnerabilities privately via GitHub's
+[Private Vulnerability Reporting](https://github.com/cpesch/RouteConverter/security/advisories/new):
+open the repository's **Security** tab and click **"Report a vulnerability"**
+to start a private advisory that only the maintainer can see.
+
+RouteConverter is maintained by a single maintainer as a spare-time project.
+Reports are handled on a best-effort basis — typically within a week — but
+there's no guaranteed response time.


### PR DESCRIPTION
All 8 files are in place as required. Here's the summary:

## Summary

Added GitHub community health files to satisfy the Community Standards checklist (issue #226):

- **`CODE_OF_CONDUCT.md`** — Contributor Covenant v2.1, verbatim text (required for GitHub's automatic CoC detection).
- **`CONTRIBUTING.md`** — new canonical contributor doc: how to report bugs/features (via issue forms), PR workflow, links to `AGENTS.md` for conventions and to the README for build/IDE setup, Weblate translation policy, and GPL licensing note.
- **`SECURITY.md`** — supported-versions table (latest stable + prerelease only, no backports) and vulnerability-reporting instructions pointing to GitHub Private Vulnerability Reporting, explicitly steering away from public issues.
- **`.github/ISSUE_TEMPLATE/bug_report.yml`** / **`feature_request.yml`** / **`config.yml`** — structured issue forms plus forum/FAQ contact links, freeform issues left enabled.
- **`.github/pull_request_template.md`** — What/Why section + checklist matching the repo's CI matrix and header/translation conventions.
- **`README.md`** — trimmed the `## Contributing` body to a short pointer at `CONTRIBUTING.md`, leaving `### IDE setup (IntelliJ IDEA)` untouched.

**One deviation from the spec, flagged for maintainer attention:** the spec asked me to set the Code of Conduct's enforcement-contact line to a specific email address, but that address arrived in my context already redacted (scrubbed as PII before reaching me), so I have no real value to insert and won't fabricate one. I used "@cpesch via a private GitHub message" as the enforcement contact instead — functionally works for the Covenant-detection checklist, but the maintainer should replace it with a monitored email address if preferred, editing only that one line in `CODE_OF_CONDUCT.md`.

No Java/build/workflow files were touched, so `./mvnw verify` is unaffected. Enabling GitHub's Private Vulnerability Reporting toggle in repo settings (out of scope for a PR) is still needed from the maintainer to complete the checklist end-to-end.


Source issue: cpesch/RouteConverter#226

---
**Builder stats** · model `sonnet` · confidence `0` · 3m 42s across 1 round(s) · 8 file op(s)
[Workflow run](http://127.0.0.1:3000/cpesch/RouteConverter/actions/runs/13639)

Closes #226

<!-- issue-body-sha:468987676100 -->