### PR TITLE
Rename BRouter segments datasource id brouter-segments-4 to brouter-segments

### DIFF
--- a/route-converter/src/main/java/slash/navigation/converter/gui/RouteConverter.java
+++ b/route-converter/src/main/java/slash/navigation/converter/gui/RouteConverter.java
@@ -189,7 +189,7 @@ public class RouteConverter extends BaseRouteConverter {
 
     private void configureRoutingServices() {
         DataSource brouterProfiles = getDataSourceManager().getDataSourceService().getDataSourceById("brouter-profiles");
-        DataSource brouterSegments = getDataSourceManager().getDataSourceService().getDataSourceById("brouter-segments-4");
+        DataSource brouterSegments = getDataSourceManager().getDataSourceService().getDataSourceById("brouter-segments");
         if (brouterProfiles != null || brouterSegments != null) {
             BRouter router = getRoutingServiceFacade().getRoutingService(BRouter.class);
             router.setProfilesAndSegments(brouterProfiles, brouterSegments);


### PR DESCRIPTION
Closes #237.

## Summary
Changes `configureRoutingServices()` in `RouteConverter.java` to resolve the BRouter segments datasource via the id `brouter-segments` instead of `brouter-segments-4`.

## Why
Consolidates two legacy BRouter segment-tile datasources into one un-versioned id; the `-4` suffix was an internal rd5-format-version detail that leaked into the catalog id. The server now serves `brouter-segments` in the offline edition with the same `baseUrl`/`directory` as `brouter-segments-4`, so existing local segment downloads keep validating without re-downloading.

## Risk
Low — a single string-constant swap with no logic change. No fallback to the old id is added, per the maintainer's explicit hard-cutover decision; the server-side catalog change and cutover timing are out of scope for this PR.

🤖 Builder.

---
**Builder stats** · model `sonnet` · confidence `0.97` · 3m 4s across 1 round(s) · 1 file op(s)
[Workflow run](http://127.0.0.1:3000/cpesch/RouteConverter/actions/runs/15836)

Closes #237

<!-- issue-body-sha:a32d537c03ab -->