### PR TITLE
Fix crash sending error report when attachment file has vanished

### DIFF
--- a/feedback/src/main/java/slash/navigation/feedback/domain/RouteFeedback.java
+++ b/feedback/src/main/java/slash/navigation/feedback/domain/RouteFeedback.java
@@ -129,7 +129,7 @@ public class RouteFeedback {
         request.addString("log", logOutput);
         request.addString("description", description);
         request.addString("locale", getDefault().toString());
-        if (file != null)
+        if (file != null && file.isFile())
             request.addFile("file", file);
 
         String result = request.executeAsString();


### PR DESCRIPTION
## Summary
- `Files.findExistingPath()` walks up to the nearest existing ancestor when a chosen attachment no longer exists, which can resolve to a directory (e.g. `Documents`).
- `RouteFeedback.sendErrorReport()` only checked `file != null`, so it handed that directory to `addFile()` → `FileInputStream` on a directory → Windows throws `FileNotFoundException ... Zugriff verweigert`, crashing the whole error-report send.
- Guard with `file.isFile()` so a vanished attachment is silently skipped instead of crashing the report.

Reported by a user whose diagnostics forwarded this stack trace:
```
java.io.FileNotFoundException: C:\Users\Thomas\Documents (Zugriff verweigert)
    at slash.navigation.rest.MultipartRequest.execute(MultipartRequest.java:112)
    at slash.navigation.feedback.domain.RouteFeedback.sendErrorReport(RouteFeedback.java:135)
```

## Test plan
- [x] `feedback` module compiles
- [ ] Manual: reproduce by pointing the error report attachment field at a path that no longer exists inside a valid directory, confirm send succeeds without the attachment