### PR TITLE
Potential fix for code scanning alert no. 2: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/build-mac-jre.yml
+++ b/.github/workflows/build-mac-jre.yml
@@ -35,6 +35,11 @@ on:
       - 'mac-launcher/JavaAppLauncher.m'
       - '.github/workflows/build-mac-jre.yml'
 
+permissions:
+  contents: read
+  actions: read
+  packages: read
+
 concurrency:
   group: build-mac-jre
   cancel-in-progress: true


### PR DESCRIPTION
Potential fix for [https://github.com/cpesch/RouteConverter/security/code-scanning/2](https://github.com/cpesch/RouteConverter/security/code-scanning/2)

Add an explicit top-level `permissions` block in `.github/workflows/build-mac-jre.yml` so all jobs inherit minimal token privileges.

Best fix here (without changing behavior): define workflow-wide:
- `contents: read` (needed for checkout)
- `actions: read` (safe for action metadata access)
- `packages: read` (recommended minimal read scope, harmless if unused)

This keeps functionality intact while ensuring the token is restricted. Since no step appears to need repository write actions, do not grant any write scope.

Change location:
- Insert `permissions:` after the `on:` triggers block and before `concurrency:` (around current lines 38–41 region).

No imports, methods, or dependencies are needed (YAML-only change).


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
