### PR TITLE
Potential fix for code scanning alert no. 3: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/build-mac-jre.yml
+++ b/.github/workflows/build-mac-jre.yml
@@ -35,6 +35,9 @@ on:
       - 'mac-launcher/JavaAppLauncher.m'
       - '.github/workflows/build-mac-jre.yml'
 
+permissions:
+  contents: read
+
 concurrency:
   group: build-mac-jre
   cancel-in-progress: true


### PR DESCRIPTION
Potential fix for [https://github.com/cpesch/RouteConverter/security/code-scanning/3](https://github.com/cpesch/RouteConverter/security/code-scanning/3)

Add an explicit workflow-level `permissions` block in `.github/workflows/build-mac-jre.yml` so all jobs inherit minimal token rights by default.

Best single fix without changing functionality:
- Insert at the top level (after `on:` block, before `concurrency:` is ideal):
  - `permissions:`
  - `contents: read`

Why this is sufficient:
- `actions/checkout` requires `contents: read`.
- `upload-artifact` / `download-artifact` work within the workflow context and do not require broad repository write permissions.
- Deployment is done over SSH key, not via GitHub write APIs.

File/region to change:
- `.github/workflows/build-mac-jre.yml`, around lines 38–41 (between trigger config and `concurrency`).

No new imports, methods, or dependencies are needed.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
