### PR TITLE
Potential fix for code scanning alert no. 4: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/build-windows-jre.yml
+++ b/.github/workflows/build-windows-jre.yml
@@ -13,6 +13,9 @@ name: Build Windows JRE
 #
 # Plan: rc-meta specs/00018-release-automation-3.4.md Phase 5.4 prerequisite.
 
+permissions:
+  contents: read
+
 on:
   workflow_dispatch:
     inputs:


### PR DESCRIPTION
Potential fix for [https://github.com/cpesch/RouteConverter/security/code-scanning/4](https://github.com/cpesch/RouteConverter/security/code-scanning/4)

Add an explicit top-level `permissions` block to `.github/workflows/build-windows-jre.yml` so all jobs inherit minimal `GITHUB_TOKEN` access.

Best fix (without changing behavior):
- Insert, near the top of the workflow (after `name:` and before `on:`),:
  - `permissions:`
  - `contents: read`

Why this is best:
- `actions/checkout` needs `contents: read`.
- The workflow does not create releases, comment on PRs, or otherwise require write scopes.
- Applying at workflow root covers both `build` and `publish` jobs consistently and minimally.

No imports/dependencies/methods are needed (YAML-only change).


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
