### PR TITLE
Potential fix for code scanning alert no. 8: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/javadoc.yml
+++ b/.github/workflows/javadoc.yml
@@ -29,6 +29,9 @@ concurrency:
   group: javadoc
   cancel-in-progress: true
 
+permissions:
+  contents: read
+
 jobs:
   publish-javadoc:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Potential fix for [https://github.com/cpesch/RouteConverter/security/code-scanning/8](https://github.com/cpesch/RouteConverter/security/code-scanning/8)

Add an explicit `permissions` block to `.github/workflows/javadoc.yml` at the workflow root (top-level), just below `concurrency` (or before `jobs`).  
For this workflow, the minimal and appropriate permission is:

- `contents: read`

This supports `actions/checkout` and does not grant unnecessary write scopes. No imports, methods, or additional definitions are needed since this is YAML configuration only.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
