### PR TITLE
Potential fix for code scanning alert no. 1: Cache Poisoning via low-privileged code injection

### DIFF
--- a/.github/workflows/verify-cut.yml
+++ b/.github/workflows/verify-cut.yml
@@ -16,9 +16,11 @@ jobs:
         id: ctx
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          HEAD_BRANCH: ${{ github.event.workflow_run.head_branch }}
+          RUN_CONCLUSION: ${{ github.event.workflow_run.conclusion }}
         run: |
-          TAG='${{ github.event.workflow_run.head_branch }}'
-          CONCLUSION='${{ github.event.workflow_run.conclusion }}'
+          TAG="$HEAD_BRANCH"
+          CONCLUSION="$RUN_CONCLUSION"
           echo "tag=$TAG"               >> "$GITHUB_OUTPUT"
           echo "conclusion=$CONCLUSION" >> "$GITHUB_OUTPUT"
           echo "release run tag=$TAG conclusion=$CONCLUSION"


### PR DESCRIPTION
Potential fix for [https://github.com/cpesch/RouteConverter/security/code-scanning/1](https://github.com/cpesch/RouteConverter/security/code-scanning/1)

General fix: do not inline untrusted GitHub expression values inside shell scripts. Instead, pass them through `env:` and read them as normal shell variables (`$VAR`) with proper quoting.

Best fix here (minimal, no functional change): in `.github/workflows/verify-cut.yml`, update the `Resolve tag from triggering release run` step to:
- add environment variables for `HEAD_BRANCH` and `RUN_CONCLUSION` sourced from GitHub context
- assign `TAG` and `CONCLUSION` from those env vars inside the script
- keep all existing outputs/echo behavior unchanged

This removes direct expression injection into `run:` while preserving current logic.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
