### PR TITLE
Potential fix for code scanning alert no. 5: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -2,6 +2,9 @@ name: RouteConverter CI
 
 on: [push]
 
+permissions:
+  contents: read
+
 jobs:
   build:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Potential fix for [https://github.com/cpesch/RouteConverter/security/code-scanning/5](https://github.com/cpesch/RouteConverter/security/code-scanning/5)

Add an explicit top-level `permissions` block in `.github/workflows/build.yml` so all jobs inherit least-privilege defaults.  
Best fix without changing functionality: insert

```yml
permissions:
  contents: read
```

directly under the `on:` trigger section (before `jobs:`). This satisfies CodeQL’s minimal recommendation and is compatible with the current steps (`checkout`, `setup-java`, cache, build, artifact upload, codecov with separate token). No imports, methods, or dependencies are needed.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
