### PR TITLE
Potential fix for code scanning alert no. 6: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/build-windows-jre.yml
+++ b/.github/workflows/build-windows-jre.yml
@@ -31,6 +31,9 @@ concurrency:
   group: build-windows-jre
   cancel-in-progress: true
 
+permissions:
+  contents: read
+
 jobs:
   build:
     runs-on: windows-latest


### PR DESCRIPTION
Potential fix for [https://github.com/cpesch/RouteConverter/security/code-scanning/6](https://github.com/cpesch/RouteConverter/security/code-scanning/6)

Add an explicit top-level `permissions` block to `.github/workflows/build-windows-jre.yml` so all jobs inherit least-privilege defaults.

Best single fix (without changing functionality):
- Insert at workflow root (after `concurrency` and before `jobs`):
  - `permissions:`
  - `contents: read`

Why this is best:
- `actions/checkout` requires `contents: read`.
- Other actions used here (`setup-java`, artifact upload/download) do not require repository write permissions.
- Deployment uses SSH, not GitHub API writes.
- A root-level block is concise and applies to both `build` and `publish` consistently.

No new imports, methods, or dependencies are needed.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
