### PR TITLE
Potential fix for code scanning alert no. 7: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -2,6 +2,9 @@ name: RouteConverter CI
 
 on: [push]
 
+permissions:
+  contents: read
+
 jobs:
   build:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Potential fix for [https://github.com/cpesch/RouteConverter/security/code-scanning/7](https://github.com/cpesch/RouteConverter/security/code-scanning/7)

Add an explicit `permissions` block at the workflow root in `.github/workflows/build.yml`, just below the trigger (`on:`) and above `jobs:`.  
For this workflow, the minimal safe baseline is:

- `contents: read`

This applies to all jobs unless overridden, preserves existing functionality, and addresses the CodeQL finding by enforcing least privilege for `GITHUB_TOKEN`.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
