### PR TITLE
Potential fix for code scanning alert no. 10: Arbitrary file access during archive extraction ("Zip Slip")

### DIFF
--- a/download/src/main/java/slash/navigation/download/actions/Extractor.java
+++ b/download/src/main/java/slash/navigation/download/actions/Extractor.java
@@ -50,16 +50,6 @@ public class Extractor {
         this.listener = listener;
     }
 
-    private File validatedDestinationFile(File destination, String entryName) throws IOException {
-        File canonicalDestination = destination.getCanonicalFile();
-        File candidate = new File(canonicalDestination, entryName).getCanonicalFile();
-        String destinationPath = canonicalDestination.getPath();
-        String candidatePath = candidate.getPath();
-        if (!candidatePath.equals(destinationPath) && !candidatePath.startsWith(destinationPath + File.separator))
-            throw new IOException(format("Bad zip entry outside destination directory: %s", entryName));
-        return candidate;
-    }
-
     private void doExtract(File tempFile, File destination, boolean flatten) throws IOException {
         File canonicalDestination = destination.getCanonicalFile();
         try (ZipInputStream zipInputStream = new ZipInputStream(new FileInputStream(tempFile))) {
@@ -67,17 +57,21 @@ public class Extractor {
             while (entry != null) {
                 if (entry.isDirectory()) {
                     if (!flatten) {
-                        File directory = validatedDestinationFile(canonicalDestination, entry.getName());
+                        File directory = new File(canonicalDestination, entry.getName());
+                        if (!directory.toPath().normalize().startsWith(canonicalDestination.toPath()))
+                            throw new IOException(format("Bad zip entry outside destination directory: %s", entry.getName()));
                         handleDirectory(directory, entry);
                     }
 
                 } else {
                     File extracted;
                     if(flatten)
-                        extracted = validatedDestinationFile(canonicalDestination, lastPathFragment(entry.getName(), MAX_VALUE));
+                        extracted = new File(canonicalDestination, lastPathFragment(entry.getName(), MAX_VALUE));
                     else {
-                        extracted = validatedDestinationFile(canonicalDestination, entry.getName());
+                        extracted = new File(canonicalDestination, entry.getName());
                     }
+                    if (!extracted.toPath().normalize().startsWith(canonicalDestination.toPath()))
+                        throw new IOException(format("Bad zip entry outside destination directory: %s", entry.getName()));
                     File directory = extracted.getParentFile();
                     handleDirectory(directory, entry);
 

--- a/download/src/main/java/slash/navigation/download/actions/Extractor.java
+++ b/download/src/main/java/slash/navigation/download/actions/Extractor.java
@@ -50,22 +50,33 @@ public class Extractor {
         this.listener = listener;
     }
 
+    private File validatedDestinationFile(File destination, String entryName) throws IOException {
+        File canonicalDestination = destination.getCanonicalFile();
+        File candidate = new File(canonicalDestination, entryName).getCanonicalFile();
+        String destinationPath = canonicalDestination.getPath();
+        String candidatePath = candidate.getPath();
+        if (!candidatePath.equals(destinationPath) && !candidatePath.startsWith(destinationPath + File.separator))
+            throw new IOException(format("Bad zip entry outside destination directory: %s", entryName));
+        return candidate;
+    }
+
     private void doExtract(File tempFile, File destination, boolean flatten) throws IOException {
+        File canonicalDestination = destination.getCanonicalFile();
         try (ZipInputStream zipInputStream = new ZipInputStream(new FileInputStream(tempFile))) {
             ZipEntry entry = zipInputStream.getNextEntry();
             while (entry != null) {
                 if (entry.isDirectory()) {
                     if (!flatten) {
-                        File directory = new File(destination, entry.getName());
+                        File directory = validatedDestinationFile(canonicalDestination, entry.getName());
                         handleDirectory(directory, entry);
                     }
 
                 } else {
                     File extracted;
                     if(flatten)
-                        extracted = new File(destination, lastPathFragment(entry.getName(), MAX_VALUE));
+                        extracted = validatedDestinationFile(canonicalDestination, lastPathFragment(entry.getName(), MAX_VALUE));
                     else {
-                        extracted = new File(destination, entry.getName());
+                        extracted = validatedDestinationFile(canonicalDestination, entry.getName());
                     }
                     File directory = extracted.getParentFile();
                     handleDirectory(directory, entry);


### PR DESCRIPTION
Potential fix for [https://github.com/cpesch/RouteConverter/security/code-scanning/10](https://github.com/cpesch/RouteConverter/security/code-scanning/10)

The correct fix is to validate every extracted target path (for both directories and files) against the intended extraction root after canonicalization/normalization, and reject entries that escape the destination directory.

Best single fix in `download/src/main/java/slash/navigation/download/actions/Extractor.java`:
1. Add a helper method that resolves a `ZipEntry` name against `destination`, canonicalizes both destination and candidate path, and checks that candidate starts with destination path boundary.
2. Use this helper for:
   - directory entries (`entry.isDirectory()` branch)
   - non-flatten file entries
3. Keep existing behavior for flatten mode (still uses `lastPathFragment`), but you can also safely run it through the same validator for consistency.
4. Throw `IOException` for invalid entries.
5. Use canonical files for downstream operations (`handleDirectory`, `FileOutputStream`, `setLastModified`) so all sinks are protected.

No changes are required in `Directories.java` or `Files.java`; sanitization belongs at archive extraction boundaries.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
