### PR TITLE
Potential fix for code scanning alert no. 9: Implicit narrowing conversion in compound assignment

### DIFF
--- a/navigation-formats/src/main/java/slash/navigation/nmn/NmnRouteFormat.java
+++ b/navigation-formats/src/main/java/slash/navigation/nmn/NmnRouteFormat.java
@@ -561,7 +561,10 @@ public class NmnRouteFormat extends SimpleFormat<Wgs84Route> {
                 (byte) 0x90, (byte) 0xF9, (byte) 0x46, (byte) 0x27,
                 (byte) 0x0A, (byte) 0x00, (byte) 0x00, (byte) 0x00
         };
-        rawData[0] += positionNo; //erhöht sich mit jedem Punkt
+        int rawData0 = rawData[0] + positionNo; //erhöht sich mit jedem Punkt
+        if (rawData0 < Byte.MIN_VALUE || rawData0 > Byte.MAX_VALUE)
+            throw new IllegalArgumentException("positionNo out of byte range: " + positionNo);
+        rawData[0] = (byte) rawData0;
         byteBuffer.put(rawData);
 
         //Countrycode


### PR DESCRIPTION
Potential fix for [https://github.com/cpesch/RouteConverter/security/code-scanning/9](https://github.com/cpesch/RouteConverter/security/code-scanning/9)

The general fix is to avoid implicit narrowing in compound assignments by doing the arithmetic in a wider type and then explicitly converting to `byte`, ideally with range checking to prevent silent overflow.

Best fix here (without changing intended functionality) is to replace `rawData[0] += positionNo;` with an explicit checked conversion using `Math.addExact` and `Math.toIntExact`/range check. Since `positionNo` is likely an `Integer`, compute in `int`, then use `Math.toIntExact` only if needed; finally ensure value is within `Byte.MIN_VALUE..Byte.MAX_VALUE` before assigning. This preserves current behavior for valid ranges and fails fast if out-of-range instead of silently corrupting bytes.

Edit only this file/region:
- `navigation-formats/src/main/java/slash/navigation/nmn/NmnRouteFormat.java`
- Around line 564 where `rawData[0] += positionNo;` appears.

No new imports or dependencies are required (`Math` is in `java.lang`).


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
