### PR TITLE
fix(navigation-formats): pin surefire forkCount=1 to stop Columbus timezone test race

### DIFF
--- a/navigation-formats/pom.xml
+++ b/navigation-formats/pom.xml
@@ -187,7 +187,9 @@
                         <artifactId>maven-surefire-plugin</artifactId>
                         <configuration combine.self="override">
                             <skipTests>${skip.unit.tests}</skipTests>
-                            <forkCount>1.5C</forkCount>
+                            <!-- forkCount=1: see the forkCount note on this module's default
+                                 maven-surefire-plugin configuration above. -->
+                            <forkCount>1</forkCount>
                             <includes>
                                 <include>**/*Test.java</include>
                                 <include>**/*IT.java</include>
@@ -201,6 +203,24 @@
 
     <build>
         <plugins>
+            <plugin>
+                <!-- Several Columbus tests (ColumbusGpsBinaryFormatTest, ColumbusFusionFormatTest, ...)
+                     toggle ColumbusV1000Device's useLocalTimeZone/timeZone flags, which are backed by
+                     java.util.prefs.Preferences: a process-external, OS-shared store (Windows Registry,
+                     ~/.java/.userPrefs, ...), not JVM-local state. The root pom's forkCount=1.5C runs
+                     several test-class forks concurrently, so two of these tests can land in different
+                     forked JVMs at the same time and race on that shared store - one test's setUp/finally
+                     flips useLocalTimeZone/timeZone while another test's parseTime() is mid-assertion,
+                     producing an exact device-timezone-offset time shift (seen as e.g. Europe/Berlin's
+                     1-hour winter offset). forkCount=1 makes this module's tests run sequentially in one
+                     JVM, removing the race. See the "Java 21 on Windows" intermittent CI failures on
+                     PR #243 for the observed symptom. -->
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-surefire-plugin</artifactId>
+                <configuration>
+                    <forkCount>1</forkCount>
+                </configuration>
+            </plugin>
             <plugin>
                 <groupId>org.codehaus.mojo</groupId>
                 <artifactId>jaxb2-maven-plugin</artifactId>


### PR DESCRIPTION
## Summary

Investigated the intermittent `ColumbusGpsBinaryFormatTest.testParseTime` / `ColumbusFusionFormatTest.testWriteInvertsDeviceLocalTimeZoneConversion` failures seen only on the "Java 21 on Windows" CI job across reruns of the same commit on #243, both off by exactly 1 hour.

**Root cause is not JVM-default-timezone/tzdata drift** (the original suspicion). Both tests already pin an explicit timezone before asserting:
- `ColumbusGpsBinaryFormatTest.setUp()` calls `ColumbusV1000Device.setUseLocalTimeZone(false)`.
- `ColumbusFusionFormatTest.testWriteInvertsDeviceLocalTimeZoneConversion` explicitly sets `useLocalTimeZone=true` + `timeZone="Europe/Berlin"`.
- `ColumbusGpsBinaryFormat.parseTime()` builds the calendar in `Calendar.getInstance(UTC)` and only shifts it when `getUseLocalTimeZone()` is true - it never reads `TimeZone.getDefault()`/`ZoneId.systemDefault()` directly.
- `CompactCalendar.equals()` compares only millis + tz-id string, with no dependence on the JVM default timezone either.

The actual bug: `ColumbusV1000Device`'s `useLocalTimeZone`/`timeZone` flags are backed by `java.util.prefs.Preferences` - a **process-external, OS-shared store** (Windows Registry / `~/.java/.userPrefs` / plist), not JVM-local state. Several Columbus tests (`ColumbusGpsBinaryFormatTest`, `ColumbusFusionFormatTest`, `ColumbusGpsType1FormatTest`, `ColumbusGpsType2FormatTest`, `ColumbusV1000DeviceTest`, plus the shared `ConvertBase.ignoreLocalTimeZone()` helper used across the format test suite) all mutate these same flags around each test.

The root `pom.xml` runs Surefire with `forkCount=1.5C`, i.e. several test-class forks running **concurrently in separate JVM processes**. Since two Columbus test classes can be dispatched to different forks at the same time, they race on that shared OS-level Preferences store: one test's `setUp`/`finally` flips `useLocalTimeZone`/`timeZone` while another test's `parseTime()` is mid-assertion in a different process. That produces an exact device-timezone-offset shift - Europe/Berlin's winter (non-DST) offset is UTC+1, which is precisely the reported 1-hour delta on Nov 29.

This explains every observed symptom: the exact 1-hour offset, the intermittency (fork-scheduling dependent), why it's Windows-specific in practice (Windows' registry-backed `Preferences` impl has more cross-process latency/contention than the other platforms' backing stores), why reruns of the identical commit differ, and why master's own CI was green nearby (still probabilistic).

## Fix

Pin `forkCount=1` for the `navigation-formats` module's Surefire execution (both the default config and the `local-with-samples` profile override), so this module's tests run sequentially in a single JVM. No other module is touched, so their parallelism/build time is unaffected.

## Test plan

- [x] `mvn -pl navigation-formats -am test -Dtest=ColumbusGpsBinaryFormatTest,ColumbusFusionFormatTest,ColumbusGpsType1FormatTest,ColumbusGpsType2FormatTest,ColumbusV1000DeviceTest` - all green (26+4+11+8+2 tests, 0 failures/errors).
- [x] Verified via `help:effective-pom` that only `navigation-formats`' Surefire config now resolves `forkCount=1`; every other module still resolves the inherited `1.5C`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)