### PR TITLE
fix(navigation-formats): replace ColumbusV1000Device's shared-OS-Preferences test race with in-memory fake

### DIFF
--- a/common-gui/src/test/java/slash/navigation/gui/models/IntegerModelTest.java
+++ b/common-gui/src/test/java/slash/navigation/gui/models/IntegerModelTest.java
@@ -21,6 +21,7 @@
 package slash.navigation.gui.models;
 
 import org.junit.Test;
+import slash.common.prefs.InMemoryPreferences;
 
 import java.util.UUID;
 import java.util.concurrent.atomic.AtomicInteger;

--- a/common/src/test/java/slash/common/prefs/InMemoryPreferences.java
+++ b/common/src/test/java/slash/common/prefs/InMemoryPreferences.java
@@ -18,7 +18,7 @@
     Copyright (C) 2007 Christian Pesch. All Rights Reserved.
 */
 
-package slash.navigation.gui.models;
+package slash.common.prefs;
 
 import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;

--- a/navigation-formats/pom.xml
+++ b/navigation-formats/pom.xml
@@ -187,9 +187,7 @@
                         <artifactId>maven-surefire-plugin</artifactId>
                         <configuration combine.self="override">
                             <skipTests>${skip.unit.tests}</skipTests>
-                            <!-- forkCount=1: see the forkCount note on this module's default
-                                 maven-surefire-plugin configuration above. -->
-                            <forkCount>1</forkCount>
+                            <forkCount>1.5C</forkCount>
                             <includes>
                                 <include>**/*Test.java</include>
                                 <include>**/*IT.java</include>
@@ -203,24 +201,6 @@
 
     <build>
         <plugins>
-            <plugin>
-                <!-- Several Columbus tests (ColumbusGpsBinaryFormatTest, ColumbusFusionFormatTest, ...)
-                     toggle ColumbusV1000Device's useLocalTimeZone/timeZone flags, which are backed by
-                     java.util.prefs.Preferences: a process-external, OS-shared store (Windows Registry,
-                     ~/.java/.userPrefs, ...), not JVM-local state. The root pom's forkCount=1.5C runs
-                     several test-class forks concurrently, so two of these tests can land in different
-                     forked JVMs at the same time and race on that shared store - one test's setUp/finally
-                     flips useLocalTimeZone/timeZone while another test's parseTime() is mid-assertion,
-                     producing an exact device-timezone-offset time shift (seen as e.g. Europe/Berlin's
-                     1-hour winter offset). forkCount=1 makes this module's tests run sequentially in one
-                     JVM, removing the race. See the "Java 21 on Windows" intermittent CI failures on
-                     PR #243 for the observed symptom. -->
-                <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-surefire-plugin</artifactId>
-                <configuration>
-                    <forkCount>1</forkCount>
-                </configuration>
-            </plugin>
             <plugin>
                 <groupId>org.codehaus.mojo</groupId>
                 <artifactId>jaxb2-maven-plugin</artifactId>

--- a/navigation-formats/src/main/java/slash/navigation/columbus/ColumbusV1000Device.java
+++ b/navigation-formats/src/main/java/slash/navigation/columbus/ColumbusV1000Device.java
@@ -29,9 +29,18 @@ import java.util.prefs.Preferences;
  * @author Christian Pesch
  */
 public class ColumbusV1000Device {
-    private static final Preferences preferences = Preferences.userNodeForPackage(ColumbusV1000Device.class);
+    private static Preferences preferences = Preferences.userNodeForPackage(ColumbusV1000Device.class);
     private static final String TIMEZONE_PREFERENCE = "timeZone";
     private static final String USE_LOCAL_TIMEZONE_PREFERENCE = "useLocalTimeZone";
+
+    /**
+     * Test seam — swaps the backing store so tests don't race on the shared OS-level
+     * Preferences node under concurrent multi-fork test execution. Do not call from
+     * production code.
+     */
+    public static void setPreferences(Preferences preferences) {
+        ColumbusV1000Device.preferences = preferences;
+    }
 
     public static boolean getUseLocalTimeZone() {
         return preferences.getBoolean(USE_LOCAL_TIMEZONE_PREFERENCE, true);

--- a/navigation-formats/src/test/java/slash/navigation/columbus/ColumbusFusionFormatTest.java
+++ b/navigation-formats/src/test/java/slash/navigation/columbus/ColumbusFusionFormatTest.java
@@ -19,7 +19,9 @@
 */
 package slash.navigation.columbus;
 
+import org.junit.Before;
 import org.junit.Test;
+import slash.common.prefs.InMemoryPreferences;
 import slash.navigation.base.RouteCharacteristics;
 import slash.navigation.base.WaypointType;
 import slash.navigation.base.Wgs84Position;
@@ -43,6 +45,11 @@ import static slash.navigation.columbus.ColumbusV1000Device.setUseLocalTimeZone;
 
 public class ColumbusFusionFormatTest {
     private final ColumbusFusionFormat format = new ColumbusFusionFormat();
+
+    @Before
+    public void setUp() {
+        ColumbusV1000Device.setPreferences(new InMemoryPreferences());
+    }
 
     private static BufferedReader reader(String... lines) {
         StringBuilder builder = new StringBuilder();

--- a/navigation-formats/src/test/java/slash/navigation/columbus/ColumbusGpsBinaryFormatTest.java
+++ b/navigation-formats/src/test/java/slash/navigation/columbus/ColumbusGpsBinaryFormatTest.java
@@ -1,8 +1,8 @@
 package slash.navigation.columbus;
 
-import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
+import slash.common.prefs.InMemoryPreferences;
 
 import java.nio.ByteBuffer;
 
@@ -17,17 +17,11 @@ import static slash.navigation.base.WaypointType.Waypoint;
 
 public class ColumbusGpsBinaryFormatTest {
     private final ColumbusGpsBinaryFormat format = new ColumbusGpsBinaryFormat();
-    private boolean useLocalTimeZone;
 
     @Before
     public void setUp() {
-        useLocalTimeZone = ColumbusV1000Device.getUseLocalTimeZone();
+        ColumbusV1000Device.setPreferences(new InMemoryPreferences());
         ColumbusV1000Device.setUseLocalTimeZone(false);
-    }
-
-    @After
-    public void tearDown() {
-        ColumbusV1000Device.setUseLocalTimeZone(useLocalTimeZone);
     }
 
     @Test

--- a/navigation-formats/src/test/java/slash/navigation/columbus/ColumbusGpsType2FormatTest.java
+++ b/navigation-formats/src/test/java/slash/navigation/columbus/ColumbusGpsType2FormatTest.java
@@ -20,7 +20,9 @@
 
 package slash.navigation.columbus;
 
+import org.junit.Before;
 import org.junit.Test;
+import slash.common.prefs.InMemoryPreferences;
 import slash.common.type.CompactCalendar;
 import slash.navigation.base.ParserContextImpl;
 import slash.navigation.base.Wgs84Position;
@@ -36,6 +38,11 @@ import static slash.navigation.columbus.ColumbusV1000Device.*;
 
 public class ColumbusGpsType2FormatTest {
     private final ColumbusGpsType2Format format = new ColumbusGpsType2Format();
+
+    @Before
+    public void setUp() {
+        ColumbusV1000Device.setPreferences(new InMemoryPreferences());
+    }
 
     @Test
     public void testIsValidLine() {

--- a/navigation-formats/src/test/java/slash/navigation/columbus/ColumbusV1000DeviceTest.java
+++ b/navigation-formats/src/test/java/slash/navigation/columbus/ColumbusV1000DeviceTest.java
@@ -1,27 +1,17 @@
 package slash.navigation.columbus;
 
-import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
+import slash.common.prefs.InMemoryPreferences;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 
 public class ColumbusV1000DeviceTest {
-    private boolean useLocalTimeZone;
-    private String timeZone;
-
     @Before
     public void setUp() {
-        useLocalTimeZone = ColumbusV1000Device.getUseLocalTimeZone();
-        timeZone = ColumbusV1000Device.getTimeZone();
-    }
-
-    @After
-    public void tearDown() {
-        ColumbusV1000Device.setUseLocalTimeZone(useLocalTimeZone);
-        ColumbusV1000Device.setTimeZone(timeZone);
+        ColumbusV1000Device.setPreferences(new InMemoryPreferences());
     }
 
     @Test

--- a/route-converter-gui/src/test/java/slash/navigation/converter/gui/helpers/AutomaticGeocodingServiceTest.java
+++ b/route-converter-gui/src/test/java/slash/navigation/converter/gui/helpers/AutomaticGeocodingServiceTest.java
@@ -26,7 +26,7 @@ import slash.navigation.geocoding.CategorizedNavigationPosition;
 import slash.navigation.geocoding.GeocodingResult;
 import slash.navigation.geocoding.GeocodingService;
 import slash.navigation.geocoding.SimpleCategorizedNavigationPosition;
-import slash.navigation.gui.models.InMemoryPreferences;
+import slash.common.prefs.InMemoryPreferences;
 
 import java.io.IOException;
 import java.util.ArrayList;

--- a/route-converter-gui/src/test/java/slash/navigation/converter/gui/helpers/GeocodingServiceFacadeTest.java
+++ b/route-converter-gui/src/test/java/slash/navigation/converter/gui/helpers/GeocodingServiceFacadeTest.java
@@ -28,7 +28,7 @@ import slash.navigation.geocoding.CategorizedNavigationPosition;
 import slash.navigation.geocoding.GeocodingResult;
 import slash.navigation.geocoding.GeocodingService;
 import slash.navigation.geocoding.SimpleCategorizedNavigationPosition;
-import slash.navigation.gui.models.InMemoryPreferences;
+import slash.common.prefs.InMemoryPreferences;
 
 import javax.naming.ServiceUnavailableException;
 import java.io.IOException;

--- a/route-converter-gui/src/test/java/slash/navigation/converter/gui/models/RecentFormatsModelTest.java
+++ b/route-converter-gui/src/test/java/slash/navigation/converter/gui/models/RecentFormatsModelTest.java
@@ -25,7 +25,7 @@ import org.junit.Test;
 import slash.navigation.base.NavigationFormat;
 import slash.navigation.base.NavigationFormatRegistry;
 import slash.navigation.gpx.Gpx11Format;
-import slash.navigation.gui.models.InMemoryPreferences;
+import slash.common.prefs.InMemoryPreferences;
 import slash.navigation.kml.Kml22Format;
 import slash.navigation.tcx.Tcx2Format;
 

--- a/route-converter-gui/src/test/java/slash/navigation/converter/gui/models/RecentUrlsModelTest.java
+++ b/route-converter-gui/src/test/java/slash/navigation/converter/gui/models/RecentUrlsModelTest.java
@@ -23,7 +23,7 @@ package slash.navigation.converter.gui.models;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
-import slash.navigation.gui.models.InMemoryPreferences;
+import slash.common.prefs.InMemoryPreferences;
 
 import java.io.File;
 import java.io.IOException;

--- a/route-converter-gui/src/test/java/slash/navigation/converter/gui/models/RoutesTableSortPreferencesTest.java
+++ b/route-converter-gui/src/test/java/slash/navigation/converter/gui/models/RoutesTableSortPreferencesTest.java
@@ -21,7 +21,7 @@ package slash.navigation.converter.gui.models;
 
 import org.junit.Before;
 import org.junit.Test;
-import slash.navigation.gui.models.InMemoryPreferences;
+import slash.common.prefs.InMemoryPreferences;
 
 import javax.swing.RowSorter.SortKey;
 import javax.swing.SortOrder;


### PR DESCRIPTION
## Summary
- `ColumbusV1000Device`'s `useLocalTimeZone`/`timeZone` flags were backed by a real, process-external `Preferences.userNodeForPackage()` node; two Columbus test classes in different forked JVMs could race on that shared store (PR #251 papered over this with `forkCount=1` on the whole `navigation-formats` module).
- Adds a test-only `setPreferences()` seam on `ColumbusV1000Device`, moves the existing `InMemoryPreferences` fake (from #140) into `common`'s test-jar (avoids `navigation-formats` reaching up into `common-gui`), and wires the four affected Columbus test classes onto a fresh in-memory store per test.
- Reverts #251's `forkCount=1` pin now that the root cause is fixed — `navigation-formats` regains the root pom's default `forkCount=1.5C`.

Closes #252

## Test plan
- [x] `mvn -pl common,common-gui -am install -DskipTests` (fresh test-jar with relocated fake)
- [x] `mvn -pl navigation-formats test -Dtest='ColumbusV1000DeviceTest,ColumbusGpsBinaryFormatTest,ColumbusFusionFormatTest,ColumbusGpsType2FormatTest,ColumbusGpsType1FormatTest'` — all green
- [x] Full reactor build (`common,common-gui,navigation-formats,route-converter-gui`) — only pre-existing, unrelated failures remain (`ReadIT`/`ColumbusFusionReadWriteRoundtripIT` missing rc-samples fixtures, `UrlFormatTest` network flake); none touch the changed code
- [x] `git diff <pre-#251 commit> -- navigation-formats/pom.xml` is empty — forkCount revert is exact