### PR TITLE
fix(ci): dedupe permissions key in build-windows-jre workflow

### DIFF
--- a/.github/workflows/build-windows-jre.yml
+++ b/.github/workflows/build-windows-jre.yml
@@ -34,9 +34,6 @@ concurrency:
   group: build-windows-jre
   cancel-in-progress: true
 
-permissions:
-  contents: read
-
 jobs:
   build:
     runs-on: windows-latest


### PR DESCRIPTION
## Summary
- Two independent code-scanning autofix PRs (#242, #247) each added a top-level `permissions:` block to `build-windows-jre.yml`, producing a duplicate mapping key.
- Duplicate top-level keys are invalid YAML — GitHub rejects the workflow file outright, so every run since fails immediately with zero jobs (e.g. https://github.com/cpesch/RouteConverter/actions/runs/30707599676).
- Keep a single `permissions: contents: read` block.

## Test plan
- [ ] Merge and confirm the next `build-windows-jre` run (push to `pom.xml`/`scripts/jre-modules.txt`/this file, or manual `workflow_dispatch`) actually creates jobs and completes.