### PR TITLE
Fix map view permanently stopping to update after appending files

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -11,6 +11,10 @@
 - Elevation, heading, HDOP and acceleration are shown with two decimal places
 - NMEA: GGA fix quality and HDOP are now read and written; GPX fix element and Columbus Type 1 VALID column map to the quality attribute
 
+### Fixes
+
+- Map view (and profile view) could permanently stop updating after appending several files in quick succession; a race between the background map-update queue and newly loaded files could misclassify a pure append as a mid-list edit, desyncing the map from the position list and crashing the update worker (TimeAlbum Pro)
+
 ## 3.5 — 2026-07-03
 
 **GitHub Release:** https://github.com/cpesch/RouteConverter/releases/tag/3.5

--- a/mapsforge-mapview/src/main/java/slash/navigation/mapview/mapsforge/updater/TrackUpdater.java
+++ b/mapsforge-mapview/src/main/java/slash/navigation/mapview/mapsforge/updater/TrackUpdater.java
@@ -38,6 +38,10 @@ public class TrackUpdater implements EventMapUpdater {
     private final PositionsModel positionsModel;
     private final TrackOperation trackOperation;
     private final List<PairWithLayer> pairWithLayers = new ArrayList<>();
+    // own-state row count, tracked independently of positionsModel.getRowCount(): a queued
+    // event can execute after a later file has already advanced the live model, so reading
+    // the live row count at execution time can misclassify a pure append as a middle-insert
+    private int rowCount = 0;
 
     public TrackUpdater(PositionsModel positionsModel, TrackOperation trackOperation) {
         this.positionsModel = positionsModel;
@@ -45,17 +49,21 @@ public class TrackUpdater implements EventMapUpdater {
     }
 
     public synchronized void handleAdd(int firstRow, int lastRow) {
-        int beforeFirstRow = firstRow > 0 ? firstRow - 1 : firstRow;
-        int validLastRow = min(lastRow, positionsModel.getRowCount() - 1);
-        int afterLastRow = lastRow < positionsModel.getRowCount() - 1 ? lastRow + 1 : validLastRow;
+        int oldRowCount = rowCount;
+        int newRowCount = oldRowCount + (lastRow - firstRow + 1);
+        rowCount = newRowCount;
+
+        // do not remove anything if a new position is prepended or appended to the track
+        boolean middleInsert = firstRow > 0 && lastRow < newRowCount - 1;
 
         List<PairWithLayer> removed = new ArrayList<>();
-        // do not remove anything if a new position is prepended or appended to the track
-        if (firstRow > 0 && lastRow < positionsModel.getRowCount() - 1)
-            removed.add(pairWithLayers.remove(beforeFirstRow));
+        if (middleInsert)
+            removed.add(pairWithLayers.remove(firstRow - 1));
 
         List<PairWithLayer> added = new ArrayList<>();
-        for (int i = beforeFirstRow; i < afterLastRow; i++) {
+        int from = firstRow > 0 ? firstRow - 1 : firstRow;
+        int to = min(lastRow, newRowCount - 2);
+        for (int i = from; i <= to; i++) {
             PairWithLayer pairWithLayer = new PairWithLayer(positionsModel.getPosition(i), positionsModel.getPosition(i + 1), i);
             pairWithLayers.add(i, pairWithLayer);
             added.add(pairWithLayer);
@@ -68,16 +76,20 @@ public class TrackUpdater implements EventMapUpdater {
     }
 
     public synchronized void handleUpdate(int firstRow, int lastRow) {
-        int beforeFirstRow = firstRow > 0 ? firstRow - 1 : firstRow;
-        int validLastRow = min(lastRow, positionsModel.getRowCount() - 1);
-        int afterLastRow = lastRow < positionsModel.getRowCount() - 1 ? lastRow + 1 : validLastRow;
+        if (pairWithLayers.isEmpty())
+            return;
+
+        int beforeFirstRow = firstRow > 0 ? firstRow - 1 : 0;
+        int afterLastRow = min(lastRow, pairWithLayers.size() - 1);
+        if (afterLastRow < beforeFirstRow)
+            return;
 
         List<PairWithLayer> updated = new ArrayList<>();
-        for (int i = beforeFirstRow; i < afterLastRow; i++) {
+        for (int i = beforeFirstRow; i <= afterLastRow; i++) {
             PairWithLayer pairWithLayer = new PairWithLayer(positionsModel.getPosition(i), positionsModel.getPosition(i + 1), i);
             pairWithLayer.setLayer(pairWithLayers.get(i).getLayer());
             pairWithLayers.set(i, pairWithLayer);
-            updated.add(pairWithLayers.get(i));
+            updated.add(pairWithLayer);
         }
 
         if (!updated.isEmpty())
@@ -85,8 +97,17 @@ public class TrackUpdater implements EventMapUpdater {
     }
 
     public synchronized void handleRemove(int firstRow, int lastRow) {
+        if (pairWithLayers.isEmpty()) {
+            rowCount = 0;
+            return;
+        }
+
         int beforeFirstRow = firstRow > 0 ? firstRow - 1 : firstRow;
         int validLastRow = min(lastRow, pairWithLayers.size() - 1);
+        if (validLastRow < beforeFirstRow) {
+            rowCount = pairWithLayers.size() + 1;
+            return;
+        }
 
         List<PairWithLayer> added = new ArrayList<>();
         if (beforeFirstRow < firstRow && validLastRow == lastRow) {
@@ -103,6 +124,8 @@ public class TrackUpdater implements EventMapUpdater {
 
         for (PairWithLayer pairWithLayer : added)
             pairWithLayers.add(beforeFirstRow, pairWithLayer);
+
+        rowCount = pairWithLayers.isEmpty() ? 0 : pairWithLayers.size() + 1;
 
         if (!removed.isEmpty())
             trackOperation.remove(removed);

--- a/mapsforge-mapview/src/main/java/slash/navigation/mapview/mapsforge/updater/UpdateDecoupler.java
+++ b/mapsforge-mapview/src/main/java/slash/navigation/mapview/mapsforge/updater/UpdateDecoupler.java
@@ -24,8 +24,10 @@ import slash.navigation.converter.gui.models.PositionsModel;
 
 import java.util.concurrent.ExecutorService;
 import java.util.function.Function;
+import java.util.logging.Logger;
 
 import static java.lang.Integer.MAX_VALUE;
+import static java.lang.String.format;
 import static javax.swing.event.TableModelEvent.*;
 import static slash.common.helpers.ThreadHelper.createSingleThreadExecutor;
 import static slash.navigation.base.RouteCharacteristics.Waypoints;
@@ -39,6 +41,8 @@ import static slash.navigation.base.RouteCharacteristics.Waypoints;
  */
 
 public class UpdateDecoupler {
+    private static final Logger log = Logger.getLogger(UpdateDecoupler.class.getName());
+
     private final ExecutorService executor;
     private final PositionsModel positionsModel;
     private final Function<RouteCharacteristics, EventMapUpdater> updaterFactory;
@@ -58,23 +62,48 @@ public class UpdateDecoupler {
 
     public void replaceRoute() {
         executor.execute(() -> {
-            // remove all from previous event map updater
-            eventMapUpdater.handleRemove(0, MAX_VALUE);
+            try {
+                // remove all from previous event map updater
+                eventMapUpdater.handleRemove(0, MAX_VALUE);
 
-            // select current event map updater and let him add all
-            eventMapUpdater = updaterFactory.apply(positionsModel.getRoute().getCharacteristics());
-            eventMapUpdater.handleAdd(0, positionsModel.getRowCount() - 1);
+                // select current event map updater and let him add all
+                eventMapUpdater = updaterFactory.apply(positionsModel.getRoute().getCharacteristics());
+                eventMapUpdater.handleAdd(0, positionsModel.getRowCount() - 1);
+            } catch (RuntimeException e) {
+                log.severe("Cannot replace route: " + e);
+                rebuild(e);
+            }
         });
     }
 
     public void handleUpdate(final int eventType, final int firstRow, final int lastRow) {
         executor.execute(() -> {
-            switch (eventType) {
-                case INSERT -> eventMapUpdater.handleAdd(firstRow, lastRow);
-                case UPDATE -> eventMapUpdater.handleUpdate(firstRow, lastRow);
-                case DELETE -> eventMapUpdater.handleRemove(firstRow, lastRow);
+            try {
+                switch (eventType) {
+                    case INSERT -> eventMapUpdater.handleAdd(firstRow, lastRow);
+                    case UPDATE -> eventMapUpdater.handleUpdate(firstRow, lastRow);
+                    case DELETE -> eventMapUpdater.handleRemove(firstRow, lastRow);
+                }
+            } catch (RuntimeException e) {
+                log.severe(format("Cannot handle event type %d for rows %d..%d: %s", eventType, firstRow, lastRow, e));
+                rebuild(e);
             }
         });
+    }
+
+    // Self-heals a desynced updater instead of leaving it broken for the rest of the session:
+    // a queued event racing a later file's already-applied rows previously desynced the
+    // updater's own state permanently (see TrackUpdater/WaypointUpdater). The failing event is
+    // not fed to the crash reporter since this rebuild is expected to recover on its own.
+    private void rebuild(RuntimeException cause) {
+        try {
+            eventMapUpdater.handleRemove(0, MAX_VALUE);
+            int rowCount = positionsModel.getRowCount();
+            if (rowCount > 0)
+                eventMapUpdater.handleAdd(0, rowCount - 1);
+        } catch (RuntimeException e) {
+            log.severe("Cannot rebuild after " + cause + ": " + e);
+        }
     }
 
     public void dispose() {

--- a/mapsforge-mapview/src/main/java/slash/navigation/mapview/mapsforge/updater/WaypointUpdater.java
+++ b/mapsforge-mapview/src/main/java/slash/navigation/mapview/mapsforge/updater/WaypointUpdater.java
@@ -50,7 +50,10 @@ public class WaypointUpdater implements EventMapUpdater {
         List<PositionWithLayer> added = new ArrayList<>();
         for (int i = firstRow; i <= validLastRow; i++) {
             PositionWithLayer positionWithLayer = new PositionWithLayer(positionsModel.getPosition(i));
-            positionWithLayers.add(i, positionWithLayer);
+            // clamp the insertion index to this updater's own list: a stale firstRow/lastRow
+            // from an event queued before a later file already advanced the live model must
+            // never exceed positionWithLayers.size(), or List.add throws IndexOutOfBoundsException
+            positionWithLayers.add(min(i, positionWithLayers.size()), positionWithLayer);
             added.add(positionWithLayer);
         }
 

--- a/mapsforge-mapview/src/test/java/slash/navigation/mapview/mapsforge/updater/TrackUpdaterTest.java
+++ b/mapsforge-mapview/src/test/java/slash/navigation/mapview/mapsforge/updater/TrackUpdaterTest.java
@@ -138,6 +138,29 @@ public class TrackUpdaterTest {
     }
 
     @Test
+    public void testAppendNotMisclassifiedWhenModelRowCountRacesAhead() {
+        PositionsModel positionsModel = mock(PositionsModel.class);
+        when(positionsModel.getPosition(0)).thenReturn(p1);
+        when(positionsModel.getPosition(1)).thenReturn(p2);
+        when(positionsModel.getPosition(2)).thenReturn(p3);
+        when(positionsModel.getRowCount()).thenReturn(2);
+        TrackOperation trackOperation = mock(TrackOperation.class);
+
+        TrackUpdater trackUpdater = new TrackUpdater(positionsModel, trackOperation);
+        trackUpdater.handleAdd(0, 1);
+
+        // simulate a later file already appended to the live model before this updater's
+        // own append event for row 2 executes -- the desync race from the bug report
+        when(positionsModel.getRowCount()).thenReturn(10);
+
+        trackUpdater.handleAdd(2, 2);
+
+        assertEquals(asList(p1p2, p2p3), trackUpdater.getPairWithLayers());
+        verify(trackOperation, times(1)).add(singletonList(p2p3));
+        verify(trackOperation, never()).remove(new ArrayList<>());
+    }
+
+    @Test
     public void testInsert() {
         PositionsModel positionsModel = mock(PositionsModel.class);
         when(positionsModel.getPosition(0)).thenReturn(p1);

--- a/mapsforge-mapview/src/test/java/slash/navigation/mapview/mapsforge/updater/UpdateDecouplerTest.java
+++ b/mapsforge-mapview/src/test/java/slash/navigation/mapview/mapsforge/updater/UpdateDecouplerTest.java
@@ -115,4 +115,32 @@ public class UpdateDecouplerTest {
         verify(waypointUpdater).handleRemove(0, MAX_VALUE);
         verify(routeUpdater).handleAdd(0, 9);
     }
+
+    @Test
+    public void insertThatThrowsTriggersRebuildOfTheCurrentUpdater() throws Exception {
+        when(positionsModel.getRowCount()).thenReturn(5);
+        doThrow(new IndexOutOfBoundsException("boom")).when(waypointUpdater).handleAdd(2, 5);
+
+        decoupler.handleUpdate(INSERT, 2, 5);
+        awaitQueuedWork();
+
+        verify(waypointUpdater).handleAdd(2, 5);
+        verify(waypointUpdater).handleRemove(0, MAX_VALUE);
+        verify(waypointUpdater).handleAdd(0, 4);
+    }
+
+    @Test
+    public void executorKeepsProcessingEventsWhenTheRebuildItselfThrows() throws Exception {
+        when(positionsModel.getRowCount()).thenReturn(0);
+        doThrow(new IndexOutOfBoundsException("boom")).when(waypointUpdater).handleAdd(0, 3);
+        doThrow(new IllegalStateException("still broken")).when(waypointUpdater).handleRemove(0, MAX_VALUE);
+
+        decoupler.handleUpdate(INSERT, 0, 3);
+        awaitQueuedWork();
+
+        decoupler.handleUpdate(UPDATE, 1, 1);
+        awaitQueuedWork();
+
+        verify(waypointUpdater).handleUpdate(1, 1);
+    }
 }

--- a/mapsforge-mapview/src/test/java/slash/navigation/mapview/mapsforge/updater/WaypointUpdaterTest.java
+++ b/mapsforge-mapview/src/test/java/slash/navigation/mapview/mapsforge/updater/WaypointUpdaterTest.java
@@ -113,6 +113,30 @@ public class WaypointUpdaterTest {
     }
 
     @Test
+    public void testAddClampsInsertionIndexToOwnListWhenModelRowCountRacesAhead() {
+        PositionsModel positionsModel = mock(PositionsModel.class);
+        when(positionsModel.getPosition(0)).thenReturn(p1);
+        when(positionsModel.getRowCount()).thenReturn(1);
+        WaypointOperation waypointOperation = mock(WaypointOperation.class);
+
+        WaypointUpdater waypointUpdater = new WaypointUpdater(positionsModel, waypointOperation);
+        waypointUpdater.handleAdd(0, 0);
+
+        assertEquals(singletonList(w1), waypointUpdater.getPositionWithLayers());
+
+        // simulate the live model racing ahead of this updater's own state (later files
+        // already appended) before the event for row 5 executes -- an insertion index
+        // beyond the updater's own list must not throw IndexOutOfBoundsException
+        when(positionsModel.getPosition(5)).thenReturn(p2);
+        when(positionsModel.getRowCount()).thenReturn(50);
+
+        waypointUpdater.handleAdd(5, 5);
+
+        assertEquals(asList(w1, w2), waypointUpdater.getPositionWithLayers());
+        verify(waypointOperation, times(1)).add(singletonList(w2));
+    }
+
+    @Test
     public void testRemove() {
         PositionsModel positionsModel = mock(PositionsModel.class);
         when(positionsModel.getPosition(0)).thenReturn(p1);


### PR DESCRIPTION
Closes #259.

## Summary

- `TrackUpdater.handleAdd`/`handleUpdate` now classify append vs. middle-insert and compute loop bounds against the updater's own tracked row count, never against `positionsModel.getRowCount()`. That live-model read raced ahead once a later file's rows were already applied by the time an earlier file's queued event executed, misclassifying a pure append as a middle-insert and crashing on an out-of-bounds `pairWithLayers.remove(...)`.
- `TrackUpdater.handleRemove` gets a guard against underflowing to a negative/out-of-range index when the list is already empty or a stale event no longer overlaps the current state; existing in-range behaviour is unchanged.
- `WaypointUpdater.handleAdd` clamps the `pairWithLayers`/`positionWithLayers` insertion index to the list's own size (`min(i, positionWithLayers.size())`), so a stale insertion index from the same race can no longer throw `IndexOutOfBoundsException` on `List.add`.
- `UpdateDecoupler` wraps both `replaceRoute` and the `handleUpdate` dispatch in try/catch, and on any `RuntimeException` performs a full resync (`handleRemove(0, MAX_VALUE)` + `handleAdd(0, rowCount - 1)`) instead of leaving the map permanently desynced. The event itself is not fed to the crash reporter since the resync is expected to recover on its own; if the rebuild itself throws, it is logged and the worker survives to try the next event.

## Why

Maintainer-reported crash cluster (10 spooled reports, 2026-08-01 session): `TrackUpdater.handleAdd` threw `IndexOutOfBoundsException` on `UpdateDecoupler-N` threads after appending several files in quick succession, permanently desyncing the map/profile view from the position list until restart. Root cause and fix are fully specified in issue #259.

## Risk

Scoped to the three map-update-worker classes plus their unit tests; no interface/behavioural change for callers (`EventMapUpdater` signatures unchanged). All existing `TrackUpdaterTest`/`WaypointUpdaterTest`/`UpdateDecouplerTest` cases were traced by hand against the new arithmetic and are unaffected; three new regression tests pin the exact race and the resync safety net.

🤖 Builder.

---
**Builder stats** · model `sonnet` · confidence `0.85` · 9m 8s across 1 round(s) · 7 file op(s)
[Workflow run](http://127.0.0.1:3000/cpesch/RouteConverter/actions/runs/18673)

⚠ UNVERIFIED: target not verifiable by the broker (non-rc/* target or no pom.xml — v1 is maven-only)

Closes #259

<!-- issue-body-sha:7e0ece1f3aea -->