### PR TITLE
Clean up JAXB codegen tooling: drop dead istack property, raise Maven floor

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -77,15 +77,17 @@
         <jre.version>21.0.11</jre.version>
 
         <java.version>21</java.version>
-        <maven.version>[3.5.4,)</maven.version>
+        <maven.version>[3.6.3,)</maven.version>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
 
         <alephformatter.version>0.1.1</alephformatter.version>
         <httpclient.version>5.6.3</httpclient.version>
-        <istack.version>3.0.11</istack.version>
         <jackson.version>2.22.1</jackson.version>
         <jackson-annotations.version>2.22</jackson-annotations.version>
+        <!-- jaxb-api.version / jaxb-impl.version must stay on the same JAXB
+             major as the jaxb2-maven-plugin's bundled xjc (see the plugin
+             entry in pluginManagement below). -->
         <jaxb-api.version>4.0.5</jaxb-api.version>
         <jaxb-impl.version>4.0.9</jaxb-impl.version>
         <mapsforge.version>0.29.0</mapsforge.version>
@@ -297,6 +299,9 @@
                     <artifactId>findbugs-maven-plugin</artifactId>
                     <version>3.0.5</version>
                 </plugin>
+                <!-- The bundled JAXB tooling version here is the xjc version used
+                     for codegen (4.1.0 -> xjc 4.0.6); keep jaxb-api.version /
+                     jaxb-impl.version on the same JAXB major as this plugin. -->
                 <plugin>
                     <groupId>org.codehaus.mojo</groupId>
                     <artifactId>jaxb2-maven-plugin</artifactId>


### PR DESCRIPTION
## Summary
- `jaxb2-maven-plugin` is already at `4.1.0` in this pom (bumped by dependabot PR #258) -- decision 1 from the issue is a no-op here and is skipped, as the issue's resequencing note instructs.
- Delete the unused `istack.version` property (`3.0.11`); the issue's repo-wide grep evidence shows zero consumers besides the declaration itself.
- Raise `maven.version` from `[3.5.4,)` to `[3.6.3,)` to match `jaxb2-maven-plugin` 4.1.0's own Maven prerequisite, so `maven-enforcer-plugin`'s `requireMavenVersion` rule fails fast with a clear message instead of a later, more confusing Maven error.
- Add short drift comments next to `jaxb-api.version`/`jaxb-impl.version` and next to the `jaxb2-maven-plugin` entry, noting they must move together (the plugin's bundled xjc version tracks the plugin's own version).

## Why
Issue #235 also asked to bump the plugin itself, but that exact version change (3.3.0 -> 4.1.0) already landed via dependabot PR #258, verified against the same compatibility evidence cited in the issue. This PR carries the remaining, still-open scope: the dead property, the Maven floor, and the drift comments.

## Risk
Low -- pom-only property/comment changes. The only behavioral effect is the enforcer's Maven floor, which tightens an already-satisfied constraint (the wrapper is pinned to 3.9.9, CI uses Maven 3.9.x).

Closes #235.

🤖 Builder.

---
**Builder stats** · model `sonnet` · confidence `0.88` · 3m 47s across 1 round(s) · 1 file op(s)
[Workflow run](http://127.0.0.1:3000/cpesch/RouteConverter/actions/runs/18703)

⚠ UNVERIFIED: target not verifiable by the broker (non-rc/* target or no pom.xml — v1 is maven-only)

Closes #235

<!-- issue-body-sha:ee06b872d53d -->