### PR TITLE
Make the warning-free build enforceable (spec 00017 Scope B)

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -185,6 +185,12 @@
                              references to APIs absent from the Java 21 floor. See specs/00010. -->
                         <release>${java.version}</release>
                         <encoding>UTF-8</encoding>
+                        <!-- spec 00017 Scope B: javac warnings fail the build, so a
+                             warning-free compile cannot silently regress. The -Xlint
+                             bulk (rawtypes/serial/this-escape) stays OFF deliberately —
+                             see the tracking issue; enabling it here would fail every
+                             module on day one. -->
+                        <failOnWarning>true</failOnWarning>
                     </configuration>
                 </plugin>
                 <plugin>
@@ -402,6 +408,14 @@
                         <configuration>
                             <name>current.year</name>
                             <pattern>yyyy</pattern>
+                            <!-- Without these, timestamp-property warns "Using platform
+                                 locale (de_DE actually) to format date/time, i.e. build
+                                 is platform dependent!" once per module (46 lines). A
+                                 yyyy pattern is digits-only, so the value is unchanged —
+                                 this only pins the formatting to make the build
+                                 reproducible off the developer's locale. -->
+                            <locale>en</locale>
+                            <timeZone>UTC</timeZone>
                         </configuration>
                     </execution>
                 </executions>


### PR DESCRIPTION
Implements spec 00017 Scope B (issue #255): two root-pom config changes, no Java code.

### 1. `<failOnWarning>true</failOnWarning>` on maven-compiler-plugin

Scope A left the compile clean but nothing holding it there. This makes javac warnings fail the build.

**Worth being precise about what it catches**, because it is less than the issue implies: only warnings javac emits under **default lint**. Plain `deprecation` and `unchecked` are *notes* there, not warnings, and still pass. The first canary attempt in this PR used `new java.util.Locale("de")` exactly as the issue specified — it compiled green. In practice the gate today bites on the default-on categories (`removal`, mandatory warnings). That is still worth having, but the real line-holding for `rawtypes`/`serial`/`this-escape` comes from `-Xlint:<cat>` in #256, not from this flag alone.

### 2. `<locale>en</locale>` + `<timeZone>UTC</timeZone>` on the build-helper `current-year` execution

The 46 WARNING lines were never javac's. `build-helper-maven-plugin`'s `timestamp-property` mojo logs `Using platform locale (de_DE actually) to format date/time, i.e. build is platform dependent!` once per module whenever `locale` is unset. Spec 00017 read them as JAXB codegen noise.

The pattern is `yyyy` — digits only — so `current.year`, consumed by NSIS/launch4j resource filtering in RouteConverterWindows / TimeAlbumProWindows, is unchanged. This only pins the formatting off the developer's locale.

### Verification

Full reactor `./mvnw -B clean test-compile`, JDK 21.0.11, run against **this branch's tree** (master had moved to mapsforge 0.29.0 since the issue was written, so the older submodule pointer was not a valid baseline):

| criterion | before | after |
|---|---|---|
| `grep -c "Using platform locale"` | 46 | **0** |
| `grep -c "\[WARNING\]"` | 46 | **0** |
| build | SUCCESS | SUCCESS |

**Negative canary** (added to `common`, then reverted — not in this diff):

```java
class CanaryProbe {
    static Object probe() {
        return System.getSecurityManager();
    }
}
```

```
[WARNING] .../CanaryProbe.java:[6,22] getSecurityManager() in java.lang.System ist veraltet und wurde zum Entfernen markiert
[ERROR] .../CanaryProbe.java: Warnungen gefunden und -Werror angegeben
[ERROR] Failed to execute goal org.apache.maven.plugins:maven-compiler-plugin:3.15.0:compile (default-compile) on project common: Compilation failure
```

The gate demonstrably bites.

### Why this landed by hand

The factory aborted #255 twice with `Seed too large to build in one pass: the assembled prompt is 1012914 chars (> 600000 budget)`. That was a pre-seed defect, not an issue-scope problem: the keyword pass was seeding five `specs/review-dialogs/*.png` screenshots as mojibake plus large spec documents for a two-line pom change. Fixed separately in rc-meta PR #386; splitting this issue would never have helped.

Closes #255
