### PR TITLE
Migrate translation platform references from Weblate to Crowdin

### DIFF
--- a/.github/workflows/crowdin.yml
+++ b/.github/workflows/crowdin.yml
@@ -1,0 +1,36 @@
+name: Crowdin sync
+
+on:
+  push:
+    branches: [master]
+    paths:
+      - "route-converter-gui/src/main/resources/slash/navigation/converter/gui/RouteConverter_en.properties"
+  workflow_dispatch:
+  schedule:
+    - cron: "0 6 * * 1"
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  synchronize:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: crowdin action
+        uses: crowdin/github-action@v2
+        with:
+          upload_sources: true
+          upload_translations: false
+          download_translations: true
+          localization_branch_name: l10n
+          create_pull_request: true
+          pull_request_title: "New Crowdin translations"
+          pull_request_body: "New translations from Crowdin. Review before merging into master; the `l10n` branch is deleted on merge and recreated by Crowdin on next sync."
+          pull_request_base_branch_name: master
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          CROWDIN_PROJECT_ID: ${{ secrets.CROWDIN_PROJECT_ID }}
+          CROWDIN_PERSONAL_TOKEN: ${{ secrets.CROWDIN_PERSONAL_TOKEN }}

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -77,7 +77,7 @@ Reactor modules are in the root `pom.xml`. Roughly:
 - **Libraries** — `navigation-formats` (the format engine), `gpx`, `kml`,
   `common`, `common-gui`, `download`, `routing-service`, `elevation-service`,
   `mapsforge-*`/`mapview` (map rendering), `geocoding-service`, … 
-- **App bases** — `route-converter-gui` (shared GUI base, the Weblate target
+- **App bases** — `route-converter-gui` (shared GUI base, the Crowdin target
   holding `RouteConverter_*.properties`) and `route-converter` (the app).
 - **Platform builds** — `RouteConverter{Windows,Mac,Linux,Portable,CmdLine}`
   (produce the installers/jars).
@@ -112,9 +112,9 @@ coordination with that codebase.
   Failsafe convention; change Maven includes deliberately, don't add a second
   naming scheme.
 - **Small, focused diffs**; match the surrounding style.
-- **Translations go through Weblate** ([hosted.weblate.org/projects/routeconverter](https://hosted.weblate.org/projects/routeconverter/))
-  — don't hand-edit `RouteConverter_*.properties`; `weblate*` / `translations*`
-  branches are bot-managed.
+- **Translations go through Crowdin** ([crowdin.com/project/routeconverter](https://crowdin.com/project/routeconverter))
+  — don't hand-edit `RouteConverter_*.properties`; the `l10n`
+  branch is bot-managed (deleted on merge, recreated on next sync).
 - **Release tags are plain `MAJOR.MINOR[.PATCH]`**, no `v` prefix.
 
 ## Contributing

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -33,7 +33,7 @@ Don't duplicate the commands here — see the README's
 
 ## Translations
 
-Translations go through [Weblate](https://hosted.weblate.org/projects/routeconverter/).
+Translations go through [Crowdin](https://crowdin.com/project/routeconverter).
 Never hand-edit `RouteConverter_*.properties` directly — code PRs may only
 touch the `_en`/`_de` bundles (see `AGENTS.md`).
 

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # RouteConverter
 
 [![Test Coverage](https://codecov.io/gh/cpesch/RouteConverter/branch/master/graph/badge.svg)](https://codecov.io/gh/cpesch/RouteConverter)
-[![Translation status](https://hosted.weblate.org/widgets/routeconverter/-/svg-badge.svg)](https://hosted.weblate.org/engage/routeconverter/)
+[![Translation status](https://badges.crowdin.net/routeconverter/localized.svg)](https://crowdin.com/project/routeconverter)
 [![License: GPL v2](https://img.shields.io/badge/license-GPL--2.0-blue.svg)](LICENSE-GPL.txt)
 [![Java 21](https://img.shields.io/badge/Java-21-orange.svg)](https://adoptium.net/)
 

--- a/route-converter-gui/src/main/java/slash/navigation/converter/gui/helpers/ExternalPrograms.java
+++ b/route-converter-gui/src/main/java/slash/navigation/converter/gui/helpers/ExternalPrograms.java
@@ -63,7 +63,7 @@ public class ExternalPrograms {
     }
 
     public static void startBrowserForTranslation(Window window) {
-        startBrowser(window, "https://hosted.weblate.org/engage/routeconverter2/");
+        startBrowser(window, "https://crowdin.com/project/routeconverter");
     }
 
     public static void startBrowserForGoogleAPIKey(Window window) {


### PR DESCRIPTION
## Summary
- Swap Weblate → Crowdin across README badge, CONTRIBUTING, AGENTS.md, and the in-app Help ▸ Translate… link
- Add `.github/workflows/crowdin.yml` — syncs `RouteConverter_en.properties` on push/weekly cron/manual dispatch, opens a review PR from the `l10n` branch (deleted on merge, recreated by Crowdin)
- `crowdin.yml` config already on `master` (previous commit)

## Test plan
- [ ] Verify `crowdin.yml` maps `pt_BR`/`nb_NO` correctly on first sync
- [ ] Confirm README/website badges render once Crowdin project has translation data