### PR TITLE
Fix crowdin.yml locale placeholder to match repo file suffixes

### DIFF
--- a/crowdin.yml
+++ b/crowdin.yml
@@ -7,8 +7,8 @@ preserve_hierarchy: true
 
 files:
   - source: /route-converter-gui/src/main/resources/slash/navigation/converter/gui/RouteConverter_en.properties
-    translation: /route-converter-gui/src/main/resources/slash/navigation/converter/gui/RouteConverter_%locale_with_underscore%.properties
+    translation: /route-converter-gui/src/main/resources/slash/navigation/converter/gui/RouteConverter_%two_letters_code%.properties
     languages_mapping:
-      locale_with_underscore:
+      two_letters_code:
         pt-BR: pt_BR
         "no": nb_NO


### PR DESCRIPTION
## Summary
- `%locale_with_underscore%` resolves Crowdin's full locale tag (`cs-CZ` → `cs_CZ`), not matching existing `RouteConverter_cs.properties` / `_da.properties`
- Switch to `%two_letters_code%`, which matches every existing bundle except pt-BR / Norwegian (both already had an explicit override, kept)

## Test plan
- [ ] Trigger a Crowdin sync, confirm proposed filenames match existing `RouteConverter_<code>.properties` for all configured languages