### PR TITLE
Fix Norwegian language override key in crowdin.yml

### DIFF
--- a/crowdin.yml
+++ b/crowdin.yml
@@ -11,4 +11,4 @@ files:
     languages_mapping:
       two_letters_code:
         pt-BR: pt_BR
-        "no": nb_NO
+        nb: nb_NO


### PR DESCRIPTION
## Summary
- Override key was `no` (generic Norwegian), but the project's actual target language is "Norwegian Bokmal" with id `nb`
- Sync was creating an empty `RouteConverter_nb.properties` instead of matching the existing `RouteConverter_nb_NO.properties`

## Still open (not this PR)
- Portuguese, Brazilian (`pt-BR`) is missing from a manual zip export — check **Settings → Languages** in Crowdin to confirm it's actually added as a target language; the override key (`pt-BR`) itself is correct.

## Test plan
- [ ] Re-run sync, confirm `RouteConverter_nb_NO.properties` gets populated (not a new `_nb.properties`)