### PR TITLE
Pin transitive tools.jackson.core to 3.2.1 (fixes 2 CVEs)

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -85,6 +85,7 @@
         <httpclient.version>5.6.3</httpclient.version>
         <jackson.version>2.22.1</jackson.version>
         <jackson-annotations.version>2.22</jackson-annotations.version>
+        <jackson3.version>3.2.1</jackson3.version>
         <!-- jaxb-api.version / jaxb-impl.version must stay on the same JAXB
              major as the jaxb2-maven-plugin's bundled xjc (see the plugin
              entry in pluginManagement below). -->
@@ -677,6 +678,16 @@
                         <artifactId>jackson-databind</artifactId>
                     </exclusion>
                 </exclusions>
+            </dependency>
+            <dependency>
+                <groupId>tools.jackson.core</groupId>
+                <artifactId>jackson-core</artifactId>
+                <version>${jackson3.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>tools.jackson.core</groupId>
+                <artifactId>jackson-databind</artifactId>
+                <version>${jackson3.version}</version>
             </dependency>
             <dependency>
                 <groupId>org.bidib.com.github.markusbernhardt</groupId>


### PR DESCRIPTION
Closes #284.

## Summary
- Add `jackson3.version` (3.2.1) property to root `pom.xml`.
- Add `dependencyManagement` overrides for `tools.jackson.core:jackson-core` and `tools.jackson.core:jackson-databind` pinned to that version.

## Why
`de.grundid.opendatalab:geojson-jackson:3.0` (used by `photon`) transitively pulls in `tools.jackson.core:jackson-core:3.0.0` and `jackson-databind:3.0.0`, vulnerable to GHSA-72hv-8253-57qq (Number Length Constraint Bypass / DoS) and GHSA-5gvw-p9qm-jgwh (`@JsonView` bypass on `@JsonUnwrapped` deserialization) respectively. These never appear as direct dependencies, so Dependabot can't auto-fix them, and `geojson-jackson:3.0` is upstream's latest release, so bumping it isn't an option. A `dependencyManagement` override is the only fix; Maven's mediation then applies it to every module in the reactor, which is why the 127 open Dependabot alerts collapse to these 2 unique CVEs.

The existing `<exclusions>` on the `geojson-jackson` dependency entry (for the old `com.fasterxml.jackson.core` coordinates) are left untouched — they're inert now but unrelated cleanup, not part of this fix.

## Risk
Low — only affects `photon`'s transitive Jackson 3.x dependency, a different Maven group (`tools.jackson.core`) from this project's own direct Jackson usage (`com.fasterxml.jackson.core`, pinned separately via `jackson.version`/`jackson-annotations.version`), which is untouched. No source changes.

🤖 Builder.

---
**Builder stats** · model `sonnet` · confidence `0.93` · 2m 20s across 1 round(s) · 1 file op(s)
[Workflow run](http://127.0.0.1:3000/cpesch/RouteConverter/actions/runs/19375)

⚠ UNVERIFIED: target not verifiable by the broker (non-rc/* target or no pom.xml — v1 is maven-only)

Closes #284

<!-- issue-body-sha:9a95c2be9b93 -->