### PR TITLE
Retire Swing raw types in mapsforge-mapview

### DIFF
--- a/mapsforge-mapview/src/main/java/slash/navigation/mapview/mapsforge/MapSelector.java
+++ b/mapsforge-mapview/src/main/java/slash/navigation/mapview/mapsforge/MapSelector.java
@@ -198,6 +198,9 @@ public class MapSelector {
      *
      * @noinspection ALL
      */
+    // Generated code: MapSelector.form has no concept of generics, so the JComboBox
+    // initializer below is unavoidably raw; suppress rather than hand-edit generated code.
+    @SuppressWarnings("rawtypes")
     private void $$$setupUI$$$() {
         createUIComponents();
         contentPane = new JPanel();

--- a/mapsforge-mapview/src/main/java/slash/navigation/mapview/mapsforge/renderer/LocalMapListCellRenderer.java
+++ b/mapsforge-mapview/src/main/java/slash/navigation/mapview/mapsforge/renderer/LocalMapListCellRenderer.java
@@ -37,7 +37,7 @@ public class LocalMapListCellRenderer extends DefaultListCellRenderer {
     public static final LocalMap DOWNLOAD_MAP = new MapsforgeFileMap(null, null, null, null, null);
     private static final JSeparator SEPARATOR = new JSeparator();
 
-    public Component getListCellRendererComponent(JList list, Object value, int index, boolean isSelected, boolean cellHasFocus) {
+    public Component getListCellRendererComponent(JList<?> list, Object value, int index, boolean isSelected, boolean cellHasFocus) {
         if (SEPARATOR_TO_DOWNLOAD_MAP.equals(value))
             return SEPARATOR;
 

--- a/mapsforge-mapview/src/main/java/slash/navigation/mapview/mapsforge/renderer/LocalThemeListCellRenderer.java
+++ b/mapsforge-mapview/src/main/java/slash/navigation/mapview/mapsforge/renderer/LocalThemeListCellRenderer.java
@@ -37,7 +37,7 @@ public class LocalThemeListCellRenderer extends DefaultListCellRenderer {
     public static final LocalTheme DOWNLOAD_THEME = new VectorTheme(null, null, null);
     private static final JSeparator SEPARATOR = new JSeparator();
 
-    public Component getListCellRendererComponent(JList list, Object value, int index, boolean isSelected, boolean cellHasFocus) {
+    public Component getListCellRendererComponent(JList<?> list, Object value, int index, boolean isSelected, boolean cellHasFocus) {
         if (SEPARATOR_TO_DOWNLOAD_THEME.equals(value))
             return SEPARATOR;
 

--- a/mapsforge-mapview/src/main/java/slash/navigation/mapview/mapsforge/renderer/ThemeStyleListCellRenderer.java
+++ b/mapsforge-mapview/src/main/java/slash/navigation/mapview/mapsforge/renderer/ThemeStyleListCellRenderer.java
@@ -31,7 +31,7 @@ import java.awt.*;
  */
 
 public class ThemeStyleListCellRenderer extends DefaultListCellRenderer {
-    public Component getListCellRendererComponent(JList list, Object value, int index, boolean isSelected, boolean cellHasFocus) {
+    public Component getListCellRendererComponent(JList<?> list, Object value, int index, boolean isSelected, boolean cellHasFocus) {
         String text = "?";
         String tooltip = "?";
 


### PR DESCRIPTION
## Summary
- Widen the 3 hand-written `ListCellRenderer` overrides in `mapsforge-mapview` from raw `JList` to `JList<?>`, matching `DefaultListCellRenderer`'s own `JList<?>` interface signature:
  - `renderer/LocalMapListCellRenderer.java`
  - `renderer/LocalThemeListCellRenderer.java`
  - `renderer/ThemeStyleListCellRenderer.java`
- Add a documented `@SuppressWarnings("rawtypes")` on `MapSelector.$$$setupUI$$$()` for the one IntelliJ-GUI-designer-generated raw `JComboBox` initializer (`comboBoxZoom = new JComboBox();`), rather than hand-editing generated code that would drift out of sync the next time the `.form` is opened in the designer. The field itself is already correctly declared `JComboBox<Integer> comboBoxZoom`.

## Why
spec 00018 phase 3b (`specs/00018-rawtypes-generics-campaign.md`) measured exactly 4 Swing rawtypes warnings in `mapsforge-mapview`, unrelated to the route/format hierarchy the rest of the campaign targets. This closes that measured set to 0 live `-Xlint:rawtypes` hits (the `MapSelector` suppression is documented, not silent).

## Risk
Pure mechanical signature widening plus one documented suppression; no behavior change, no logic touched.

Closes #289.

🤖 Builder.

---
**Builder stats** · model `sonnet` · confidence `0.97` · 2m 53s across 1 round(s) · 4 file op(s)
[Workflow run](http://127.0.0.1:3000/cpesch/RouteConverter/actions/runs/19403)

⚠ UNVERIFIED: target not verifiable by the broker (non-rc/* target or no pom.xml — v1 is maven-only)

Closes #289

<!-- issue-body-sha:7806431b8232 -->