### PR TITLE
Retire raw types in the tail modules (spec 00018 phase 3a)

### DIFF
--- a/datasource/src/main/java/slash/navigation/datasources/helpers/DataSourcesUtil.java
+++ b/datasource/src/main/java/slash/navigation/datasources/helpers/DataSourcesUtil.java
@@ -60,7 +60,7 @@ public class DataSourcesUtil {
     public static CatalogType unmarshal(InputStream in) throws JAXBException {
         CatalogType result;
         try {
-            JAXBElement element = (JAXBElement) newUnmarshaller().unmarshal(in);
+            JAXBElement<?> element = (JAXBElement<?>) newUnmarshaller().unmarshal(in);
             result = (CatalogType) element.getValue();
         } catch (ClassCastException e) {
             throw new JAXBException("Parse error: " + e, e);
@@ -197,7 +197,7 @@ public class DataSourcesUtil {
         return fragmentType;
     }
 
-    public static FragmentType createFragmentType(Fragment fragment, Set<FileAndChecksum> fileAndChecksums) {
+    public static FragmentType createFragmentType(Fragment<?> fragment, Set<FileAndChecksum> fileAndChecksums) {
         FragmentType fragmentType = new ObjectFactory().createFragmentType();
         fragmentType.setKey(fragment.getKey());
         List<ChecksumType> checksumTypes = asChecksumTypes(asChecksums(fileAndChecksums));

--- a/download/src/main/java/slash/navigation/download/DownloadManager.java
+++ b/download/src/main/java/slash/navigation/download/DownloadManager.java
@@ -61,7 +61,7 @@ public class DownloadManager {
 
     private final EventListenerList listenerList = new EventListenerList();
     private final DownloadTableModel model = new DownloadTableModel();
-    private final Map<Download,Future> downloadToFutures = new HashMap<>();
+    private final Map<Download,Future<?>> downloadToFutures = new HashMap<>();
     private final Map<Download,DownloadExecutor> downloadToExecutors = new HashMap<>();
     private final ThreadPoolExecutor pool;
 
@@ -129,7 +129,7 @@ public class DownloadManager {
                 continue;
 
             log.info("Stopping download " + download);
-            Future future = downloadToFutures.get(download);
+            Future<?> future = downloadToFutures.get(download);
             if(future != null)
                 future.cancel(true);
 

--- a/download/src/main/java/slash/navigation/download/queue/QueueUtil.java
+++ b/download/src/main/java/slash/navigation/download/queue/QueueUtil.java
@@ -46,7 +46,7 @@ class QueueUtil {
     public static QueueType unmarshal(InputStream in) throws JAXBException {
         QueueType result;
         try {
-            JAXBElement element = (JAXBElement) newUnmarshaller().unmarshal(in);
+            JAXBElement<?> element = (JAXBElement<?>) newUnmarshaller().unmarshal(in);
             result = (QueueType) element.getValue();
         } catch (ClassCastException e) {
             throw new JAXBException("Parse error: " + e, e);

--- a/mapsforge-mapview/src/main/java/slash/navigation/mapview/mapsforge/AwtGraphicMapView.java
+++ b/mapsforge-mapview/src/main/java/slash/navigation/mapview/mapsforge/AwtGraphicMapView.java
@@ -103,7 +103,7 @@ public class AwtGraphicMapView extends Container implements org.mapsforge.map.vi
             // this delays stopping RouteConverter for a very long time since all layers have to be removed one by one
             // layerManager.getLayers().remove(layer);
             layer.onDestroy();
-            if (layer instanceof TileLayer tileLayer) {
+            if (layer instanceof TileLayer<?> tileLayer) {
                 tileLayer.getTileCache().destroy();
             }
             if (layer instanceof TileRendererLayer) {

--- a/mapsforge-mapview/src/main/java/slash/navigation/mapview/mapsforge/MapsforgeMapView.java
+++ b/mapsforge-mapview/src/main/java/slash/navigation/mapview/mapsforge/MapsforgeMapView.java
@@ -637,7 +637,7 @@ public class MapsforgeMapView extends BaseMapView {
             layers.remove(remove);
             remove.onDestroy();
 
-            if (remove instanceof TileLayer tileLayer)
+            if (remove instanceof TileLayer<?> tileLayer)
                 tileLayer.getTileCache().destroy();
         }
         mapsToLayers.clear();
@@ -893,10 +893,13 @@ public class MapsforgeMapView extends BaseMapView {
         return mapView.getModel().displayModel.getTileSize();
     }
 
+    // getRoute()'s position type is an independent wildcard capture; every
+    // element is a BaseNavigationPosition (hence a NavigationPosition)
+    // regardless -- cast bypasses the capture, same as showAllPositions() above.
     @SuppressWarnings("unchecked")
     private BoundingBox getRouteBoundingBox() {
-        BaseRoute route = positionsModel.getRoute();
-        return route != null && !route.getPositions().isEmpty() ? asBoundingBox(route.getPositions()) : null;
+        BaseRoute<?, ?> route = positionsModel.getRoute();
+        return route != null && !route.getPositions().isEmpty() ? asBoundingBox((List<NavigationPosition>) (List) route.getPositions()) : null;
     }
 
     private boolean isGoogleMap(LocalMap map) {

--- a/mapsforge-mapview/src/main/java/slash/navigation/mapview/mapsforge/renderer/NonSelectedPositionListsRenderer.java
+++ b/mapsforge-mapview/src/main/java/slash/navigation/mapview/mapsforge/renderer/NonSelectedPositionListsRenderer.java
@@ -113,9 +113,9 @@ public class NonSelectedPositionListsRenderer {
             layer.layers.clear();
 
             List<BaseRoute<?, ?>> routes = positionListsModel.getRoutes();
-            BaseRoute selectedRoute = positionListsModel.getSelectedRoute();
+            BaseRoute<?, ?> selectedRoute = positionListsModel.getSelectedRoute();
             if (routes != null) {
-                for (BaseRoute route : routes) {
+                for (BaseRoute<?, ?> route : routes) {
                     if (route == null || route == selectedRoute)
                         continue;
                     addPositionList(route);
@@ -126,9 +126,8 @@ public class NonSelectedPositionListsRenderer {
         layer.requestRedraw();
     }
 
-    @SuppressWarnings("unchecked")
-    private void addPositionList(BaseRoute route) {
-        List<NavigationPosition> positions = route.getPositions();
+    private void addPositionList(BaseRoute<?, ?> route) {
+        List<? extends NavigationPosition> positions = route.getPositions();
         DisplayModel displayModel = mapView.getMapView().getModel().displayModel;
 
         if (route.getCharacteristics().equals(Waypoints)) {

--- a/mapsforge-mapview/src/test/java/slash/navigation/mapview/mapsforge/updater/UpdateDecouplerTest.java
+++ b/mapsforge-mapview/src/test/java/slash/navigation/mapview/mapsforge/updater/UpdateDecouplerTest.java
@@ -103,7 +103,7 @@ public class UpdateDecouplerTest {
     @Test
     @SuppressWarnings("unchecked")
     public void replaceRouteClearsPreviousUpdaterAndFillsSelectedOne() throws Exception {
-        BaseRoute route = mock(BaseRoute.class);
+        BaseRoute<?, ?> route = mock(BaseRoute.class);
         when(route.getCharacteristics()).thenReturn(Route);
         when(positionsModel.getRoute()).thenReturn(route);
         when(positionsModel.getRowCount()).thenReturn(10);

--- a/mapsforge-mapview/src/test/java/slash/navigation/mapview/mapsforge/updater/UpdateDecouplerTest.java
+++ b/mapsforge-mapview/src/test/java/slash/navigation/mapview/mapsforge/updater/UpdateDecouplerTest.java
@@ -105,7 +105,10 @@ public class UpdateDecouplerTest {
     public void replaceRouteClearsPreviousUpdaterAndFillsSelectedOne() throws Exception {
         BaseRoute<?, ?> route = mock(BaseRoute.class);
         when(route.getCharacteristics()).thenReturn(Route);
-        when(positionsModel.getRoute()).thenReturn(route);
+        // route's and getRoute()'s wildcards are independent captures -- bridge through
+        // the raw type, same as MapsforgeMapView.getRouteBoundingBox's cast, rather than
+        // widening this local back to a raw BaseRoute.
+        when(positionsModel.getRoute()).thenReturn((BaseRoute) route);
         when(positionsModel.getRowCount()).thenReturn(10);
 
         decoupler.replaceRoute();

--- a/route-converter-cmdline/src/main/java/slash/navigation/base/CmdLineNavigationFormatRegistry.java
+++ b/route-converter-cmdline/src/main/java/slash/navigation/base/CmdLineNavigationFormatRegistry.java
@@ -25,7 +25,7 @@ package slash.navigation.base;
  * @author Christian Pesch
  */
 public class CmdLineNavigationFormatRegistry extends NavigationFormatRegistry {
-    protected boolean includeReadFormat(NavigationFormat format) {
+    protected boolean includeReadFormat(NavigationFormat<?> format) {
         return true;
     }
 }

--- a/route-converter-cmdline/src/main/java/slash/navigation/converter/cmdline/FileAnalyzer.java
+++ b/route-converter-cmdline/src/main/java/slash/navigation/converter/cmdline/FileAnalyzer.java
@@ -77,7 +77,7 @@ public class FileAnalyzer {
         // Treat it as broken so the caller marks it broken rather than creating
         // an empty metadata row / rescuing a non-route (specs/00055, 00056).
         int total = 0;
-        for (BaseRoute route : routes)
+        for (BaseRoute<?, ?> route : routes)
             total += route.getPositionCount();
         if (total == 0)
             throw new IOException("No positions found in '" + source.getAbsolutePath() + "'");
@@ -111,7 +111,7 @@ public class FileAnalyzer {
 
         String firstName = null;
 
-        for (BaseRoute route : routes) {
+        for (BaseRoute<?, ?> route : routes) {
             positions += route.getPositionCount();
 
             if (firstName == null) {

--- a/route-converter-cmdline/src/main/java/slash/navigation/converter/cmdline/RouteConverterCmdLine.java
+++ b/route-converter-cmdline/src/main/java/slash/navigation/converter/cmdline/RouteConverterCmdLine.java
@@ -63,11 +63,11 @@ public class RouteConverterCmdLine {
             log.info(format.getClass().getSimpleName() + " for " + format.getName());
     }
 
-    private BaseNavigationFormat findFormat(String formatName) {
+    private BaseNavigationFormat<?> findFormat(String formatName) {
         List<NavigationFormat<?>> formats = registry.getWriteFormats();
         for (NavigationFormat<?> format : formats)
             if (formatName.equals(format.getClass().getSimpleName()))
-                return (BaseNavigationFormat) format;
+                return (BaseNavigationFormat<?>) format;
         return null;
     }
 
@@ -92,7 +92,7 @@ public class RouteConverterCmdLine {
             return 10;
         }
 
-        BaseNavigationFormat format = findFormat(args[1]);
+        BaseNavigationFormat<?> format = findFormat(args[1]);
         if (format == null) {
             log.severe("Format '" + args[1] + "' does not exist; stopping.");
             logFormatNames(false);
@@ -176,7 +176,7 @@ public class RouteConverterCmdLine {
         return new PointToPointLengthComputer();
     }
 
-    private void convert(File source, NavigationFormat format, File target) throws IOException {
+    private void convert(File source, NavigationFormat<?> format, File target) throws IOException {
         NavigationFormatParser parser = new NavigationFormatParser(new NavigationFormatRegistry());
         ParserResult result = parser.read(source);
         if (!result.isSuccessful()) {

--- a/tileserver-maps/src/main/java/slash/navigation/maps/tileserver/TileServerMapManager.java
+++ b/tileserver-maps/src/main/java/slash/navigation/maps/tileserver/TileServerMapManager.java
@@ -47,7 +47,7 @@ public class TileServerMapManager {
     private final ItemTableModel<TileServer> availableMapsModel = new ItemTableModel<>(1);
     private final ItemTableModel<TileServer> availableOverlaysModel = new ItemTableModel<>(1);
     private final ItemTableModel<TileServer> appliedOverlaysModel = new ItemTableModel<>(1);
-    private ItemPreferencesMediator itemPreferencesMediator;
+    private ItemPreferencesMediator<TileServer> itemPreferencesMediator;
 
     public TileServerMapManager(File tileServerDirectory) {
         this.tileServerService = new TileServerService(tileServerDirectory);

--- a/tileserver-maps/src/main/java/slash/navigation/maps/tileserver/helpers/MapServerUtil.java
+++ b/tileserver-maps/src/main/java/slash/navigation/maps/tileserver/helpers/MapServerUtil.java
@@ -38,7 +38,7 @@ public class MapServerUtil {
     public static CatalogType unmarshal(InputStream in) throws JAXBException {
         CatalogType result;
         try {
-            JAXBElement element = (JAXBElement) newUnmarshaller().unmarshal(in);
+            JAXBElement<?> element = (JAXBElement<?>) newUnmarshaller().unmarshal(in);
             result = (CatalogType) element.getValue();
         } catch (ClassCastException e) {
             throw new JAXBException("Parse error: " + e, e);

--- a/tileserver-maps/src/main/java/slash/navigation/maps/tileserver/helpers/OverlayServerUtil.java
+++ b/tileserver-maps/src/main/java/slash/navigation/maps/tileserver/helpers/OverlayServerUtil.java
@@ -38,7 +38,7 @@ public class OverlayServerUtil {
     public static CatalogType unmarshal(InputStream in) throws JAXBException {
         CatalogType result;
         try {
-            JAXBElement element = (JAXBElement) newUnmarshaller().unmarshal(in);
+            JAXBElement<?> element = (JAXBElement<?>) newUnmarshaller().unmarshal(in);
             result = (CatalogType) element.getValue();
         } catch (ClassCastException e) {
             throw new JAXBException("Parse error: " + e, e);


### PR DESCRIPTION
## Summary

Eliminates the remaining `-Xlint:rawtypes` warnings in `route-converter-cmdline`, the route-family/JAXB/misc hits in `mapsforge-mapview` (its 4 Swing-only hits are out of scope — filed separately per the spec), `download`, `tileserver-maps` and `datasource` — the exact 21 call sites across 13 files enumerated in the issue. Every fix is a mechanical `<?>`/`<?, ?>` wildcard widening or a concrete type argument matching an already-used type at the same call site; no behaviour change.

## Changes

- `route-converter-cmdline`: `CmdLineNavigationFormatRegistry.includeReadFormat`, `FileAnalyzer`'s two `BaseRoute` loop variables, `RouteConverterCmdLine.findFormat`'s signature/cast + its call-site local, `RouteConverterCmdLine.convert`'s `NavigationFormat` parameter.
- `mapsforge-mapview`: `AwtGraphicMapView`'s and `MapsforgeMapView`'s `instanceof TileLayer` patterns; `MapsforgeMapView.getRouteBoundingBox`'s local `BaseRoute` (kept the pre-existing `@SuppressWarnings("unchecked")` — the wildcard capture still requires the same cast-through-raw-`List` pattern already used in this file's `showAllPositions()`); `NonSelectedPositionListsRenderer`'s two `BaseRoute` locals/loop variable and `addPositionList`'s parameter (its `@SuppressWarnings("unchecked")` is now vacuous — the local was widened to `List<? extends NavigationPosition>` instead of the invariant `List<NavigationPosition>` — and was removed); `UpdateDecouplerTest`'s one mocked `BaseRoute` local.
- `download`: `DownloadManager`'s `Future` map value type and local; `QueueUtil`'s raw `JAXBElement`.
- `tileserver-maps`: `TileServerMapManager`'s `ItemPreferencesMediator<TileServer>` field (already matches its instantiation site); `MapServerUtil`/`OverlayServerUtil`'s raw `JAXBElement`.
- `datasource`: `DataSourcesUtil`'s raw `JAXBElement`; `createFragmentType`'s `Fragment<?>` parameter (`Fragment<T extends Downloadable>` was already correctly generic — only this call site was raw).

## Why

Spec [00018](https://github.com/cpesch/RouteConverter/blob/master/specs/00018-rawtypes-generics-campaign.md), phase 3a (`tail-modules`). Successor to phase 1 (`navigation-formats`, #282/#286) and sibling to phase 2 (`route-converter-gui`, #287). Approach and every fix site were locked by the maintainer before this issue was filed.

## Risk

Low — every hit is a single-site wildcard widening or a type argument that already matches a concrete usage at the same call site (e.g. `ItemPreferencesMediator<TileServer>` matches its own `new ItemPreferencesMediator<TileServer>(...)`). No public API narrows; two signatures widen (`findFormat`'s return type, `convert`'s parameter type), which is a backward-compatible change for callers.

Note: this environment has no Maven/JDK available to run the issue's compile-verification loop or the temporary root-pom `-Xlint:rawtypes` count, so the before/after warning counts could not be pasted here as the acceptance criteria ask — please confirm 0 remaining rawtypes warnings in these five modules (and the expected 4 Swing-only remainder in `mapsforge-mapview`) via CI/local build before merge.

Closes #288.

🤖 Builder.

---
**Builder stats** · model `sonnet` · confidence `0.85` · 5m 12s across 2 round(s) · 13 file op(s)
[Workflow run](http://127.0.0.1:3000/cpesch/RouteConverter/actions/runs/19413)

⚠ UNVERIFIED: target not verifiable by the broker (non-rc/* target or no pom.xml — v1 is maven-only)

Closes #288

<!-- issue-body-sha:aa05a84adbe7 -->