### PR TITLE
Fix the 22 pre-gate rawtypes warnings blocking spec 00018 phase 4

### DIFF
--- a/common-gui/src/main/java/slash/navigation/gui/helpers/WindowHelper.java
+++ b/common-gui/src/main/java/slash/navigation/gui/helpers/WindowHelper.java
@@ -185,7 +185,7 @@ public class WindowHelper {
                 getString("out-of-memory-error"), limitBefore, limitAfter)));
     }
 
-    public static void handleThrowable(Class clazz, ActionEvent e, Throwable throwable) {
+    public static void handleThrowable(Class<?> clazz, ActionEvent e, Throwable throwable) {
         boolean offline = isComputerOffline(throwable);
         String stacktrace = offline ? "" : printStackTrace(throwable);
         // for a wrapped/opaque failure show the whole cause chain (the real

--- a/navigation-formats/src/main/java/slash/navigation/gpx/Gpx11Format.java
+++ b/navigation-formats/src/main/java/slash/navigation/gpx/Gpx11Format.java
@@ -90,7 +90,7 @@ public class Gpx11Format extends GpxFormat {
             ExtensionsType extensions = wptType.getExtensions();
             if (extensions != null) {
                 for (Object any : extensions.getAny()) {
-                    if (any instanceof JAXBElement jaxbElement) {
+                    if (any instanceof JAXBElement<?> jaxbElement) {
                         Object anyValue = jaxbElement.getValue();
                         if(anyValue instanceof RoutePointExtensionT)
                             return true;
@@ -179,7 +179,7 @@ public class Gpx11Format extends GpxFormat {
                 ExtensionsType extensions = wptType.getExtensions();
                 if (extensions != null) {
                     for (Object any : extensions.getAny()) {
-                        if (any instanceof JAXBElement jaxbElement) {
+                        if (any instanceof JAXBElement<?> jaxbElement) {
                             Object anyValue = jaxbElement.getValue();
                             if (anyValue instanceof RoutePointExtensionT routePoint) {
                                 for (AutoroutePointT autoroutePoint : routePoint.getRpt()) {
@@ -230,7 +230,7 @@ public class Gpx11Format extends GpxFormat {
         while (iterator.hasNext()) {
             Object any = iterator.next();
 
-            if (any instanceof JAXBElement jaxbElement) {
+            if (any instanceof JAXBElement<?> jaxbElement) {
                 if (extensionNameToRemove.equals(jaxbElement.getName().getLocalPart())) {
                     iterator.remove();
                 } else if (extensionNameToAdd.equals(jaxbElement.getName().getLocalPart())) {

--- a/navigation-formats/src/main/java/slash/navigation/gpx/GpxPositionExtension.java
+++ b/navigation-formats/src/main/java/slash/navigation/gpx/GpxPositionExtension.java
@@ -70,7 +70,7 @@ public class GpxPositionExtension {
         ExtensionsType extensions = wptType.getExtensions();
         if (extensions != null) {
             for (Object any : extensions.getAny())
-                if (any instanceof JAXBElement jaxbElement) {
+                if (any instanceof JAXBElement<?> jaxbElement) {
                     Object anyValue = jaxbElement.getValue();
                     if (anyValue instanceof slash.navigation.gpx.garmin3.TrackPointExtensionT) {
                         extensionTypes.add(Garmin3);
@@ -357,7 +357,7 @@ public class GpxPositionExtension {
     private <T> T getExtension(Class<T> extensionClass) {
         List<Object> anys = wptType.getExtensions().getAny();
         for (Object any : anys) {
-            if (any instanceof JAXBElement jaxbElement) {
+            if (any instanceof JAXBElement<?> jaxbElement) {
                 Object anyValue = jaxbElement.getValue();
                 if (extensionClass.isInstance(anyValue)) {
                     return extensionClass.cast(anyValue);
@@ -442,7 +442,7 @@ public class GpxPositionExtension {
         List<Object> anys = wptType.getExtensions().getAny();
         for (Iterator<Object> iterator = anys.iterator(); iterator.hasNext(); ) {
             Object any = iterator.next();
-            if (any instanceof JAXBElement jaxbElement) {
+            if (any instanceof JAXBElement<?> jaxbElement) {
                 Object anyValue = jaxbElement.getValue();
                 if (anyValue.equals(extension))
                     iterator.remove();

--- a/navigation-formats/src/main/java/slash/navigation/kml/Kml20Format.java
+++ b/navigation-formats/src/main/java/slash/navigation/kml/Kml20Format.java
@@ -81,9 +81,9 @@ public class Kml20Format extends KmlFormat {
             extractTracks(extractName(elements), extractDescriptionList(elements), elements, context);
     }
 
-    private JAXBElement findElement(List elements, String name) {
+    private JAXBElement<?> findElement(List<?> elements, String name) {
         for (Object element : elements) {
-            if (element instanceof JAXBElement jaxbElement) {
+            if (element instanceof JAXBElement<?> jaxbElement) {
                 if (name.equals(jaxbElement.getName().getLocalPart()))
                     return jaxbElement;
             }
@@ -92,12 +92,12 @@ public class Kml20Format extends KmlFormat {
     }
 
     private String extractName(List<Object> elements) {
-        JAXBElement name = findElement(elements, "name");
+        JAXBElement<?> name = findElement(elements, "name");
         return name != null ? trim((String) name.getValue()) : null;
     }
 
     private String extractDescription(List<Object> elements) {
-        JAXBElement name = findElement(elements, "description");
+        JAXBElement<?> name = findElement(elements, "description");
         if (name == null)
             return null;
         String string = (String) name.getValue();
@@ -113,7 +113,7 @@ public class Kml20Format extends KmlFormat {
     }
 
     private CompactCalendar extractTime(List<Object> elements) {
-        JAXBElement element = findElement(elements, "TimePeriod");
+        JAXBElement<?> element = findElement(elements, "TimePeriod");
         if (element == null)
             return null;
         TimePeriod timePeriod = (TimePeriod) element.getValue();
@@ -126,7 +126,7 @@ public class Kml20Format extends KmlFormat {
     }
 
     private List<String> extractDescriptionList(List<Object> elements) {
-        JAXBElement name = findElement(elements, "description");
+        JAXBElement<?> name = findElement(elements, "description");
         return name != null ? asDescription((String) name.getValue()) : null;
     }
 
@@ -161,7 +161,7 @@ public class Kml20Format extends KmlFormat {
     }
 
     private String findStyleUrl(List<Object> elements) {
-        JAXBElement name = findElement(elements, "styleUrl");
+        JAXBElement<?> name = findElement(elements, "styleUrl");
         return name != null ? (String) name.getValue() : null;
     }
 

--- a/navigation-formats/src/main/java/slash/navigation/tcx/TcxUtil.java
+++ b/navigation-formats/src/main/java/slash/navigation/tcx/TcxUtil.java
@@ -54,7 +54,7 @@ public class TcxUtil {
     public static slash.navigation.tcx.binding1.TrainingCenterDatabaseT unmarshal1(InputStream in) throws IOException {
         slash.navigation.tcx.binding1.TrainingCenterDatabaseT result;
         try {
-            JAXBElement element = (JAXBElement) newUnmarshaller1().unmarshal(in);
+            JAXBElement<?> element = (JAXBElement<?>) newUnmarshaller1().unmarshal(in);
             result = (slash.navigation.tcx.binding1.TrainingCenterDatabaseT) element.getValue();
         } catch (ClassCastException | JAXBException e) {
             throw new IOException("Parse error: " + e, e);
@@ -80,7 +80,7 @@ public class TcxUtil {
     public static slash.navigation.tcx.binding2.TrainingCenterDatabaseT unmarshal2(InputStream in) throws IOException {
         slash.navigation.tcx.binding2.TrainingCenterDatabaseT result;
         try {
-            JAXBElement element = (JAXBElement) newUnmarshaller2().unmarshal(in);
+            JAXBElement<?> element = (JAXBElement<?>) newUnmarshaller2().unmarshal(in);
             result = (slash.navigation.tcx.binding2.TrainingCenterDatabaseT) element.getValue();
         } catch (ClassCastException | JAXBException e) {
             throw new IOException("Parse error: " + e, e);

--- a/profileview/src/main/java/slash/navigation/converter/gui/models/PatchedXYSeries.java
+++ b/profileview/src/main/java/slash/navigation/converter/gui/models/PatchedXYSeries.java
@@ -31,7 +31,7 @@ import org.jfree.data.xy.XYSeries;
 public class PatchedXYSeries extends XYSeries {
     private boolean fireSeriesChanged = true;
 
-    public PatchedXYSeries(Comparable key) {
+    public PatchedXYSeries(Comparable<?> key) {
         super(key);
     }
 

--- a/profileview/src/main/java/slash/navigation/converter/gui/models/ProfileModel.java
+++ b/profileview/src/main/java/slash/navigation/converter/gui/models/ProfileModel.java
@@ -88,7 +88,7 @@ public class ProfileModel extends PositionsModelToXYSeriesSynchronizer {
         if (itemCount > 0 && firstRow < itemCount)
             getSeries().delete(firstRow, itemCount - 1);
 
-        BaseRoute route = getPositions().getRoute();
+        BaseRoute<?, ?> route = getPositions().getRoute();
         if (route == null) {
             // re-enable and fire events even without a route or the series stays silent forever
             getSeries().setFireSeriesChanged(true);

--- a/route-catalog/src/main/java/slash/navigation/routes/remote/helpers/RoutesUtil.java
+++ b/route-catalog/src/main/java/slash/navigation/routes/remote/helpers/RoutesUtil.java
@@ -51,7 +51,7 @@ public class RoutesUtil {
     public static CatalogType unmarshal(Reader reader) throws JAXBException {
         CatalogType result;
         try {
-            JAXBElement element = (JAXBElement) newUnmarshaller().unmarshal(reader);
+            JAXBElement<?> element = (JAXBElement<?>) newUnmarshaller().unmarshal(reader);
             result = (CatalogType) element.getValue();
         } catch (ClassCastException e) {
             throw new JAXBException("Parse error: " + e);
@@ -62,7 +62,7 @@ public class RoutesUtil {
     public static CatalogType unmarshal(InputStream in) throws JAXBException {
         CatalogType result;
         try {
-            JAXBElement element = (JAXBElement) newUnmarshaller().unmarshal(in);
+            JAXBElement<?> element = (JAXBElement<?>) newUnmarshaller().unmarshal(in);
             result = (CatalogType) element.getValue();
         } catch (ClassCastException e) {
             throw new JAXBException("Parse error: " + e, e);

--- a/route-converter/src/main/java/slash/navigation/converter/gui/dialogs/ThemeStyleDialog.java
+++ b/route-converter/src/main/java/slash/navigation/converter/gui/dialogs/ThemeStyleDialog.java
@@ -123,6 +123,9 @@ public class ThemeStyleDialog extends SimpleDialog {
      *
      * @noinspection ALL
      */
+    // Generated code: ThemeStyleDialog.form has no concept of generics, so the JComboBox
+    // initializer below is unavoidably raw; suppress rather than hand-edit generated code.
+    @SuppressWarnings("rawtypes")
     private void $$$setupUI$$$() {
         contentPane = new JPanel();
         contentPane.setLayout(new GridLayoutManager(3, 2, new Insets(10, 10, 10, 10), -1, -1));


### PR DESCRIPTION
Closes #295.

## Summary

Fixes the last 22 `-Xlint:rawtypes` warnings in main sources across 5 modules (`navigation-formats`, `route-catalog`, `profileview`, `route-converter`, `common-gui`), per spec [00018](https://github.com/cpesch/RouteConverter/blob/master/specs/00018-rawtypes-generics-campaign.md) phase 4a. This is a prerequisite for the follow-up gate issue, which will flip `-Xlint:rawtypes` on for main sources — that PR must not land until this one merges.

All fixes are `<?>`/`<?, ?>` wildcard widening, mechanically identical to every prior phase in this campaign:

- `navigation-formats/.../kml/Kml20Format.java` — `findElement` return/param types, its `instanceof` pattern, and the 5 call sites assigning its result.
- `navigation-formats/.../gpx/GpxPositionExtension.java` — 3 `instanceof JAXBElement` sites in `getExtensionTypes()`, `getExtension()`, `removeExtension()`.
- `navigation-formats/.../gpx/Gpx11Format.java` — 3 `instanceof JAXBElement` sites (route-point-extension check, extension read, extension add/remove).
- `navigation-formats/.../tcx/TcxUtil.java` — `unmarshal1`/`unmarshal2` declaration + cast.
- `route-catalog/.../RoutesUtil.java` — both `unmarshal` overloads, same pattern as `TcxUtil`.
- `profileview/.../PatchedXYSeries.java` — constructor parameter (JFreeChart's own `XYSeries(Comparable)` ctor is raw by API design; a `Comparable<?>` argument still satisfies it).
- `profileview/.../ProfileModel.java` — local `BaseRoute` variable.
- `common-gui/.../WindowHelper.java` — `handleThrowable`'s `Class` parameter.
- `route-converter/.../ThemeStyleDialog.java` — the one designer-generated `$$$setupUI$$$()` site; suppressed with a documented `@SuppressWarnings("rawtypes")` rather than hand-edited, matching `MapSelector.$$$setupUI$$$()` from spec 00018 phase 3b (PR #290) — the `.form` format has no generics concept so the generated initializer is permanently raw. `ThemeStyleDialog.form` itself is untouched.

No design changes; every site keeps its existing runtime behavior.

## Why

Closes out the last un-scoped modules from the spec 00018 rawtypes campaign so the phase-4 gate PR (adding `-Xlint:rawtypes` to the root pom's `<compilerArgs>`) can land with zero day-one main-source failures.

## Risk

Low — every change is a type-declaration widening with no behavior change; the one non-mechanical site (`ThemeStyleDialog`) is a documented suppression on generated code, not a hand-edit.

🤖 Builder.

---
**Builder stats** · model `sonnet` · confidence `0.92` · 11m 29s across 2 round(s) · 9 file op(s)
[Workflow run](http://127.0.0.1:3000/cpesch/RouteConverter/actions/runs/19559)

⚠ UNVERIFIED: target not verifiable by the broker (non-rc/* target or no pom.xml — v1 is maven-only)

Closes #295

<!-- issue-body-sha:c20de2e9d576 -->