### PR TITLE
Support current Google Maps URL formats (/place/, ?q=, short links) in GoogleMapsUrlFormat

### DIFF
--- a/navigation-formats/src/main/java/slash/navigation/url/GoogleMapsUrlFormat.java
+++ b/navigation-formats/src/main/java/slash/navigation/url/GoogleMapsUrlFormat.java
@@ -116,8 +116,9 @@ public class GoogleMapsUrlFormat extends BaseUrlParsingFormat {
 
     protected void processURL(String url, String encoding, ParserContext<Wgs84Route> context) {
         if (url.startsWith("SHORTLINK:")) {
-            String resolved = resolveShortUrl(url.substring(10), HTTP_HEAD_REDIRECT_RESOLVER);
-            if (resolved == null)
+            String shortUrl = url.substring(10);
+            String resolved = resolveShortUrl(shortUrl, HTTP_HEAD_REDIRECT_RESOLVER);
+            if (resolved == null || resolved.equals(shortUrl))
                 return;
             String innerFound = internalFindUrl(resolved);
             if (innerFound != null)

--- a/navigation-formats/src/main/java/slash/navigation/url/GoogleMapsUrlFormat.java
+++ b/navigation-formats/src/main/java/slash/navigation/url/GoogleMapsUrlFormat.java
@@ -24,7 +24,9 @@ import slash.navigation.base.BaseUrlParsingFormat;
 import slash.navigation.base.ParserContext;
 import slash.navigation.base.Wgs84Position;
 import slash.navigation.base.Wgs84Route;
+import slash.navigation.rest.Head;
 
+import java.io.IOException;
 import java.io.PrintWriter;
 import java.net.URL;
 import java.util.ArrayList;
@@ -37,6 +39,7 @@ import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
 import static java.lang.Math.max;
+import static java.util.Collections.singletonList;
 import static slash.common.io.Transfer.*;
 import static slash.navigation.base.RouteCalculations.asWgs84Position;
 import static slash.navigation.base.RouteCharacteristics.Route;
@@ -58,6 +61,21 @@ public class GoogleMapsUrlFormat extends BaseUrlParsingFormat {
                     "(@?(" + WHITE_SPACE + "[-|\\d|\\.]+" + WHITE_SPACE + ")," +
                     "(" + WHITE_SPACE + "[-|\\d|\\.]+" + WHITE_SPACE + "))?");
     private static final String DESTINATION_SEPARATOR = "to:";
+    private static final Pattern SHORT_URL_PATTERN = Pattern.compile(".*(http[s]?://(?:maps\\.app\\.goo\\.gl|goo\\.gl/maps)/[^\\s]+).*");
+    private static final int MAX_REDIRECT_HOPS = 5;
+    private static final Pattern PLACE_COORDINATE_PATTERN = Pattern.compile(".*?!3d(-?\\d+\\.\\d+)!4d(-?\\d+\\.\\d+).*");
+
+    interface RedirectResolver {
+        String resolveLocation(String url) throws IOException;
+    }
+
+    private static final RedirectResolver HTTP_HEAD_REDIRECT_RESOLVER = url -> {
+        Head head = new Head(url);
+        head.disableRedirectHandling();
+        head.executeAsString();
+        int status = head.getStatusCode();
+        return status >= 300 && status < 400 ? head.getLocationHeader() : null;
+    };
 
     public String getExtension() {
         return ".url";
@@ -73,7 +91,8 @@ public class GoogleMapsUrlFormat extends BaseUrlParsingFormat {
 
     public boolean isParseableUrl(String url) {
         String found = internalFindUrl(url);
-        return found != null && (found.startsWith("?") || found.startsWith("/dir/"));
+        return found != null && (found.startsWith("?") || found.startsWith("/dir/") ||
+                found.startsWith("/place/") || found.startsWith("SHORTLINK:"));
     }
 
     public static boolean isGoogleMapsProfileUrl(URL url) {
@@ -83,6 +102,9 @@ public class GoogleMapsUrlFormat extends BaseUrlParsingFormat {
 
     private static String internalFindUrl(String text) {
         text = replaceLineFeeds(text, "&");
+        Matcher shortUrlMatcher = SHORT_URL_PATTERN.matcher(text);
+        if (shortUrlMatcher.matches())
+            return "SHORTLINK:" + shortUrlMatcher.group(1);
         Matcher bookmarkMatcher = BOOKMARK_PATTERN.matcher(text);
         if (bookmarkMatcher.matches())
             text = bookmarkMatcher.group(1);
@@ -93,12 +115,54 @@ public class GoogleMapsUrlFormat extends BaseUrlParsingFormat {
     }
 
     protected void processURL(String url, String encoding, ParserContext<Wgs84Route> context) {
-        if (url.startsWith("/dir/")) {
+        if (url.startsWith("SHORTLINK:")) {
+            String resolved = resolveShortUrl(url.substring(10), HTTP_HEAD_REDIRECT_RESOLVER);
+            if (resolved == null)
+                return;
+            String innerFound = internalFindUrl(resolved);
+            if (innerFound != null)
+                processURL(innerFound, encoding, context);
+        } else if (url.startsWith("/dir/")) {
             List<Wgs84Position> positions = parsePositions(url.substring(5));
             if (!positions.isEmpty())
                 context.appendRoute(createRoute(Route, null, positions));
+        } else if (url.startsWith("/place/")) {
+            Wgs84Position position = parsePlacePosition(url.substring(7));
+            if (position != null)
+                context.appendRoute(createRoute(Route, null, singletonList(position)));
         } else
             super.processURL(url, encoding, context);
+    }
+
+    String resolveShortUrl(String url, RedirectResolver resolver) {
+        String current = url;
+        for (int hop = 0; hop < MAX_REDIRECT_HOPS; hop++) {
+            String location;
+            try {
+                location = resolver.resolveLocation(current);
+            } catch (IOException e) {
+                log.warning("Cannot resolve redirect for " + current + ": " + e);
+                return null;
+            }
+            if (location == null)
+                return current;
+            current = location;
+        }
+        log.warning("Too many redirects resolving " + url);
+        return null;
+    }
+
+    Wgs84Position parsePlacePosition(String url) {
+        int slash = url.indexOf('/');
+        String namePart = slash == -1 ? url : url.substring(0, slash);
+        String name = trim(decodeUri(namePart));
+        Matcher matcher = PLACE_COORDINATE_PATTERN.matcher(url);
+        Double latitude = null, longitude = null;
+        if (matcher.matches()) {
+            latitude = parseDouble(matcher.group(1));
+            longitude = parseDouble(matcher.group(2));
+        }
+        return asWgs84Position(longitude, latitude, name);
     }
 
     List<Wgs84Position> parsePositions(String url) {
@@ -203,7 +267,23 @@ public class GoogleMapsUrlFormat extends BaseUrlParsingFormat {
                 }
             }
         }
+
+        if (result.isEmpty()) {
+            List<String> queryPositions = parameters.get("q");
+            if (queryPositions != null) {
+                for (String q : queryPositions) {
+                    result.add(parseQueryPosition(q));
+                }
+            }
+        }
         return result;
+    }
+
+    Wgs84Position parseQueryPosition(String q) {
+        String trimmed = trim(q);
+        if (PLAIN_POSITION_PATTERN.matcher(trimmed).matches())
+            return parsePlainPosition(trimmed);
+        return asWgs84Position(null, null, trimmed);
     }
 
     String createURL(List<Wgs84Position> positions, int startIndex, int endIndex) {

--- a/navigation-formats/src/test/java/slash/navigation/url/GoogleMapsUrlFormatTest.java
+++ b/navigation-formats/src/test/java/slash/navigation/url/GoogleMapsUrlFormatTest.java
@@ -63,6 +63,8 @@ public class GoogleMapsUrlFormatTest {
 
     private static final String INPUT10_NEW_GOOGLE_MAPS_2015 = "https://www.google.at/maps/dir/Sterzing,+Bozen,+Italien/Jaufenpass,+Sankt+Leonhard+in+Passeier,+Bozen,+Italien/Ofenpass,+7532+Cierfs,+Schweiz/Albulapassstrasse,+7482+Berg%C3%BCn%2FBravuogn,+Schweiz/Spl%C3%BCgenpass,+Spl%C3%BCgen,+Schweiz/Via+Roma,+53,+22023+Castiglione+CO,+Italien/@46.4115893,9.1625277,8z/data=!3m1!4b1!4m42!4m41!1m5!1m1!1s0x479d5340912b4fed:0xeccf91de29d6fcf9!2m2!1d11.4336186!2d46.8926725!1m5!1m1!1s0x4782b27a89809711:0xbfb1348a6269dc1!2m2!1d11.3214111!2d46.8395577!1m5!1m1!1s0x47831519f57d6e8b:0xa4a9db7fa9393319!2m2!1d10.2870515!2d46.6418315!1m5!1m1!1s0x47849d1f1792adb3:0x1b8f8898b9521cba!2m2!1d9.8000555!2d46.5815557!1m5!1m1!1s0x4784f6a1054aa397:0x1ffb7aed566559ff!2m2!1d9.33028!2d46.5056!1m5!1m1!1s0x478425a384f4a881:0xcec114200a27651!2m2!1d9.089271!2d45.95557!2m3!1b1!2b1!3b1!3e0";
 
+    private static final String INPUT11_PLACE_2026 = "https://www.google.com/maps/place/Berlin/@52.5068767,13.4247534,10z/data=!3m1!4b1!4m6!3m5!1s0x47a84e373f035901:0x42120465b5e3b70!8m2!3d52.5200066!4d13.404954!16zL20vMDE1NnE?entry=ttu&g_ep=EgoyMDI2MDgxMi4wIKXMDSoASAFQAw%3D%3D";
+
     private final GoogleMapsUrlFormat format = new GoogleMapsUrlFormat();
 
     @Test
@@ -340,6 +342,85 @@ public class GoogleMapsUrlFormatTest {
     public void testIsGoogleMapsLinkUrl() throws MalformedURLException {
         assertTrue(format.isParseableUrl("https://maps.google.com/maps?saddr=Hamburg&daddr=Hannover+to:M%C3%BCnchen&hl=en&ie=UTF8&sll=50.844236,10.557014&sspn=6.272277,10.777588&geocode=Fe0fMQMd0n2YACm5Exh-g2GxRzGgOtZ78j0mBA%3BFVQxHwMdqn-UACmFT0lNUQuwRzEgR6yUbawlBA%3BFRCC3gIdsqWwACnZX4yj-XWeRzF9mLF9SrgMAQ&mra=ls&t=m&z=7"));
         assertTrue(format.isParseableUrl("https://www.google.de/maps/dir/Hamburg/Hannover/M%C3%BCnchen/@50.8213415,8.3587982,7z/data=!3m1!4b1!4m20!4m19!1m5!1m1!1s0x47b161837e1813b9:0x4263df27bd63aa0!2m2!1d9.9936818!2d53.5510846!1m5!1m1!1s0x47b00b514d494f85:0x425ac6d94ac4720!2m2!1d9.7320104!2d52.3758916!1m5!1m1!1s0x479e75f9a38c5fd9:0x10cb84a7db1987d!2m2!1d11.5819806!2d48.1351253!3e0"));
+    }
+
+    @Test
+    public void testParsePlaceFromLiveCapture() {
+        String url = format.findURL(INPUT11_PLACE_2026);
+        assertNotNull(url);
+        assertTrue(url.startsWith("/place/"));
+        Wgs84Position position = format.parsePlacePosition(url.substring(7));
+        assertNotNull(position);
+        assertEquals("Berlin", position.getDescription());
+        assertDoubleEquals(52.5200066, position.getLatitude());
+        assertDoubleEquals(13.404954, position.getLongitude());
+    }
+
+    @Test
+    public void testParseQueryCoordinates() {
+        List<Wgs84Position> positions = parsePositions("https://maps.google.com/maps?q=52.520008,13.404954");
+        assertNotNull(positions);
+        assertEquals(1, positions.size());
+        Wgs84Position position = positions.get(0);
+        assertNull(position.getDescription());
+        assertDoubleEquals(52.520008, position.getLatitude());
+        assertDoubleEquals(13.404954, position.getLongitude());
+    }
+
+    @Test
+    public void testParseQueryPlaceName() {
+        List<Wgs84Position> positions = parsePositions("https://maps.google.com/maps?q=Berlin,+Germany");
+        assertNotNull(positions);
+        assertEquals(1, positions.size());
+        Wgs84Position position = positions.get(0);
+        assertEquals("Berlin, Germany", position.getDescription());
+        assertNull(position.getLatitude());
+        assertNull(position.getLongitude());
+    }
+
+    @Test
+    public void testIsParseableShortLink() {
+        assertTrue(format.isParseableUrl("https://maps.app.goo.gl/AbCdEfGhiJ"));
+        assertTrue(format.isParseableUrl("https://goo.gl/maps/AbCdEfGhiJ"));
+    }
+
+    @Test
+    public void testResolveShortUrlSingleHop() {
+        String target = "https://www.google.com/maps/place/Berlin/@52.52,13.40,10z";
+        GoogleMapsUrlFormat.RedirectResolver resolver = url -> url.equals("https://maps.app.goo.gl/x") ? target : null;
+        String resolved = format.resolveShortUrl("https://maps.app.goo.gl/x", resolver);
+        assertEquals(target, resolved);
+    }
+
+    @Test
+    public void testResolveShortUrlMultipleHops() {
+        String hop1 = "https://maps.app.goo.gl/hop1";
+        String hop2 = "https://maps.app.goo.gl/hop2";
+        String hop3 = "https://maps.app.goo.gl/hop3";
+        String target = "https://www.google.com/maps/place/Berlin/@52.52,13.40,10z";
+        GoogleMapsUrlFormat.RedirectResolver resolver = url -> {
+            if (url.equals("https://maps.app.goo.gl/start")) return hop1;
+            if (url.equals(hop1)) return hop2;
+            if (url.equals(hop2)) return hop3;
+            if (url.equals(hop3)) return target;
+            return null;
+        };
+        String resolved = format.resolveShortUrl("https://maps.app.goo.gl/start", resolver);
+        assertEquals(target, resolved);
+    }
+
+    @Test
+    public void testResolveShortUrlTooManyHops() {
+        GoogleMapsUrlFormat.RedirectResolver resolver = url -> url + "/next";
+        String resolved = format.resolveShortUrl("https://maps.app.goo.gl/start", resolver);
+        assertNull(resolved);
+    }
+
+    @Test
+    public void testResolveShortUrlIOException() {
+        GoogleMapsUrlFormat.RedirectResolver resolver = url -> { throw new java.io.IOException("boom"); };
+        String resolved = format.resolveShortUrl("https://maps.app.goo.gl/x", resolver);
+        assertNull(resolved);
     }
 
     @Test

--- a/rest/src/main/java/slash/navigation/rest/HttpRequest.java
+++ b/rest/src/main/java/slash/navigation/rest/HttpRequest.java
@@ -108,6 +108,10 @@ public abstract class HttpRequest {
         clientBuilder.disableContentCompression();
     }
 
+    protected void disableRedirectHandling() {
+        clientBuilder.disableRedirectHandling();
+    }
+
     protected boolean throwsSocketExceptionIfUnAuthorized() {
         return false;
     }

--- a/rest/src/main/java/slash/navigation/rest/ReadRequest.java
+++ b/rest/src/main/java/slash/navigation/rest/ReadRequest.java
@@ -67,6 +67,14 @@ public abstract class ReadRequest extends HttpRequest {
         return getHeader(ETAG);
     }
 
+    public void disableRedirectHandling() {
+        super.disableRedirectHandling();
+    }
+
+    public String getLocationHeader() throws IOException {
+        return getHeader(LOCATION);
+    }
+
     public void setCacheControlNoCache() {
         setHeader(CACHE_CONTROL, "no-cache");
         setHeader(PRAGMA, "no-cache");


### PR DESCRIPTION
All four files listed in the issue's "Files" section are modified, nothing else touched. Here's the summary.

## Summary

Fixed three URL shapes that `GoogleMapsUrlFormat` couldn't handle, per the maintainer's spec in issue #301:

**`rest` module** — new redirect-control API (no behavior change to existing callers):
- `HttpRequest.java`: added `protected disableRedirectHandling()`, mirroring the existing `disableContentCompression()`.
- `ReadRequest.java`: added public `disableRedirectHandling()` and `getLocationHeader()` (reusing the already-imported `HttpHeaders.LOCATION`). `Head`/`Get` inherit both for free.

**`navigation-formats` module** — `GoogleMapsUrlFormat.java`:
1. **`/place/<name>/...` single-location links** — new `PLACE_COORDINATE_PATTERN` (`!3d<lat>!4d<lng>`) and `parsePlacePosition`, wired into `isParseableUrl` and a new `/place/` branch in `processURL`. Left `/dir/` parsing untouched as instructed.
2. **`?q=<value>` parameter** — `parsePositions(Map)` now falls back to the `q` parameter (coordinate or place name) only when `saddr`/`daddr`/`geocode` produced nothing, via new `parseQueryPosition`.
3. **`maps.app.goo.gl`/`goo.gl/maps` short links** — new `SHORT_URL_PATTERN` detected in `internalFindUrl` before the existing `URL_PATTERN`, tagged `"SHORTLINK:"`, and resolved via a bounded (`MAX_REDIRECT_HOPS = 5`) `resolveShortUrl` loop using an injectable `RedirectResolver` (production impl: HTTP HEAD via the new `Head`/redirect-disable API). The resolved URL is re-run through `internalFindUrl`/`processURL`.

Added all the test cases specified (`testParsePlaceFromLiveCapture`, `testParseQueryCoordinates`, `testParseQueryPlaceName`, `testIsParseableShortLink`, and the four `resolveShortUrl` hop/exception tests) to `GoogleMapsUrlFormatTest.java`, and left every existing test untouched.

**Verify result: unavailable.** `factory-verify` returned exit 2 with a broker error (`repo not allowed (rc/* only)`), and direct `mvn` invocation was blocked by the sandbox's approval gate with no user present to approve it in this run. I compensated with a careful manual trace of every regex and control-flow path against the live-capture fixtures and the new test expectations (documented reasoning above), but this has **not** been compiled or executed — that should be double-checked in CI before merge.


Source issue: cpesch/RouteConverter#301

---
**Builder stats** · model `sonnet` · confidence `0` · 3m 45s across 1 round(s) · 4 file op(s)
[Workflow run](http://127.0.0.1:3000/cpesch/RouteConverter/actions/runs/21037)

⚠ UNVERIFIED: target not verifiable by the broker (non-rc/* target or no pom.xml — v1 is maven-only)

Closes #301

<!-- issue-body-sha:00b3870b2d2e -->