### PR TITLE
F1 help opens /help/null.layeredPane/ instead of dialog topic

### DIFF
--- a/common-gui/src/main/java/slash/navigation/gui/HelpManager.java
+++ b/common-gui/src/main/java/slash/navigation/gui/HelpManager.java
@@ -85,6 +85,7 @@ public class HelpManager {
 
     private void openTopicForComponent(Component component) {
         for (Component c = component; c != null; c = c.getParent()) {
+            if (c instanceof JLayeredPane) continue;
             String name = c.getName();
             if (name != null && !name.isEmpty()) { openTopic(name); return; }
         }


### PR DESCRIPTION
The change is minimal and complete — exactly the one-line fix specified in the issue.

## Summary

**Fix:** `HelpManager.openTopicForComponent` now skips `JLayeredPane` instances when walking up the component tree to find a named ancestor for the F1-help topic lookup.

**Root cause:** `JRootPane.createLayeredPane()` names its `JLayeredPane` from the root pane's name *at construction time*, before app code (e.g. `SimpleDialog`) calls `setName(...)` on the dialog. This permanently bakes in `"null.layeredPane"` as the layered pane's name, which the parent walk then picked up as the first non-empty name — short-circuiting before it ever reached the correctly-named `JDialog`/`JRootPane` further up the tree.

**Fix:** Skip over `JLayeredPane` in the walk, since it's a Swing-internal container the app never intentionally names, unlike `JRootPane`/`JDialog`/`JFrame`.

`JLayeredPane` is already covered by the existing `import javax.swing.*;`, so no import changes were needed.

**Verify result: unavailable.** `factory-verify` returned exit code 2 with a broker error (`repo not allowed (rc/* only)`) — the sandbox rejected this repo slug outright, not a build/test failure. The change is a single-line, well-contained edit matching the issue's locked-in behavior spec exactly, so I did not attempt further ad-hoc build workarounds per the agentic-run instructions.


Source issue: cpesch/RouteConverter#303

---
**Builder stats** · model `sonnet` · confidence `0` · 0m 28s across 1 round(s) · 1 file op(s)
[Workflow run](http://127.0.0.1:3000/cpesch/RouteConverter/actions/runs/21044)

⚠ UNVERIFIED: target not verifiable by the broker (non-rc/* target or no pom.xml — v1 is maven-only)

Closes #303

<!-- issue-body-sha:b63ae05476ff -->