### PR TITLE
Fix map losing all waypoint markers when one waypoint lacks coordinates

### DIFF
--- a/mapsforge-mapview/src/main/java/slash/navigation/mapview/mapsforge/MapsforgeMapView.java
+++ b/mapsforge-mapview/src/main/java/slash/navigation/mapview/mapsforge/MapsforgeMapView.java
@@ -307,7 +307,7 @@ public class MapsforgeMapView extends BaseMapView {
                 List<PositionWithLayer> withLayers = new ArrayList<>();
                 for (PositionWithLayer positionWithLayer : positionWithLayers) {
                     if (!positionWithLayer.hasCoordinates())
-                        return;
+                        continue;
 
                     Marker marker = createMarker(positionWithLayer);
                     positionWithLayer.setLayer(marker);


### PR DESCRIPTION
## Summary

`WaypointOperation.add` in `MapsforgeMapView` bailed out with `return` on the first position without coordinates, dropping the markers of every remaining (and already prepared) waypoint in the batch. A single coordinate-less waypoint in a list made the map show **no waypoints at all** while the position list was fully populated.

The loop now skips such positions with `continue`, matching `SelectionOperation.add` in the same method and the track/route renderers, which already guard per element with `hasCoordinates()`/`continue`.

## Verification

Opened a GPX waypoint list whose first `wpt` has empty `lat`/`lon` followed by two valid waypoints:
- before: 0 markers on the map (heap shows 0 `org.mapsforge.map.layer.overlay.Marker`)
- after: 2 markers rendered, map zooms to the valid pair, the coordinate-less row stays in the position list

🤖 Generated with [Claude Code](https://claude.com/claude-code)