### PR TITLE
Fail non-zero when a catalog write is rejected by the server

### DIFF
--- a/download-tools/src/main/java/slash/navigation/download/tools/ScanWebsite.java
+++ b/download-tools/src/main/java/slash/navigation/download/tools/ScanWebsite.java
@@ -214,15 +214,11 @@ public class ScanWebsite extends BaseDownloadTool {
         request.addFile("file", xml.getBytes(StandardCharsets.UTF_8));
         request.setAccept(APPLICATION_JSON);
 
-        String result = null;
-        try {
-            result = request.executeAsString();
-            log.info(format("Added URIs with result:%n%s", result));
-            addCount += uris.size();
-        }
-        catch(Exception e) {
-            log.severe(format("Cannot add URIs: %s", e));
-        }
+        String result = request.executeAsString();
+        if (!request.isSuccessful())
+            throw new IOException(format("Cannot add URIs, status %d: %s", request.getStatusCode(), result));
+        log.info(format("Added URIs with result:%n%s", result));
+        addCount += uris.size();
         return result;
     }
 
@@ -234,15 +230,11 @@ public class ScanWebsite extends BaseDownloadTool {
         request.addFile("file", xml.getBytes(StandardCharsets.UTF_8));
         request.setAccept(APPLICATION_JSON);
 
-        String result = null;
-        try {
-            result = request.executeAsString();
-            log.info(format("Removed URIs with result:%n%s", result));
-            removeCount += uris.size();
-        }
-        catch(Exception e) {
-            log.severe(format("Cannot remove URIs: %s", e));
-        }
+        String result = request.executeAsString();
+        if (!request.isSuccessful())
+            throw new IOException(format("Cannot remove URIs, status %d: %s", request.getStatusCode(), result));
+        log.info(format("Removed URIs with result:%n%s", result));
+        removeCount += uris.size();
         return result;
     }
 

--- a/download-tools/src/main/java/slash/navigation/download/tools/UpdateCatalog.java
+++ b/download-tools/src/main/java/slash/navigation/download/tools/UpdateCatalog.java
@@ -372,15 +372,11 @@ public class UpdateCatalog extends BaseDownloadTool {
         request.addFile("file", xml.getBytes(StandardCharsets.UTF_8));
         request.setAccept(APPLICATION_JSON);
 
-        String result = null;
-        try {
-            result = request.executeAsString();
-            log.info(format("Updated URIs with result:%n%s", result));
-            updateCount += getDownloadableCount(dataSourceType);
-        }
-        catch(Exception e) {
-            log.severe(format("Cannot update URIs: %s", e));
-        }
+        String result = request.executeAsString();
+        if (!request.isSuccessful())
+            throw new IOException(format("Cannot update URIs, status %d: %s", request.getStatusCode(), result));
+        log.info(format("Updated URIs with result:%n%s", result));
+        updateCount += getDownloadableCount(dataSourceType);
         return result;
     }
 


### PR DESCRIPTION
ScanWebsite and UpdateCatalog swallowed every write error: `addUris`/`removeUris`/`updateUris` caught all exceptions, logged SEVERE, and the tool exited 0. A server-side rejection was indistinguishable from success for systemd and CI — this is how the daily update-catalog timer on the datasource host failed silently for weeks when the server stopped accepting POST on the datasource detail URL (fixed server-side in rc-site#33).

Now each write checks `isSuccessful()` and throws `IOException` with status + response body; `main()` already turns an uncaught exception into a non-zero exit.

- 40 download-tools tests pass; shaded jars build.
- Behavior change: a failed chunk aborts the run instead of continuing with the remaining chunks — desired, since continuing masks partial writes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)