### PR TITLE
Add the straight-line route preview to the map in one batch

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -15,6 +15,7 @@
 
 - Map view (and profile view) could permanently stop updating after appending several files in quick succession; a race between the background map-update queue and newly loaded files could misclassify a pure append as a mid-list edit, desyncing the map from the position list and crashing the update worker (TimeAlbum Pro)
 - Opening a file while a long route was still being routed left the map empty for minutes: the discarded route kept calculating leg after leg on the single map-update thread and the new file's rendering had to wait behind it; replacing the route now cancels the in-flight rendering at the next leg
+- Opening a route with thousands of positions froze the map for minutes: every straight-line segment was added to the map as a separate AWT event with its own redraw cycle; the straight-line preview is now added in a single batch
 - A waypoint list containing a single position without coordinates showed no waypoint markers at all on the map; positions without coordinates are now skipped instead of suppressing every marker
 
 ## 3.5 — 2026-07-03

--- a/mapsforge-mapview/src/main/java/slash/navigation/mapview/mapsforge/renderer/RouteRenderer.java
+++ b/mapsforge-mapview/src/main/java/slash/navigation/mapview/mapsforge/renderer/RouteRenderer.java
@@ -40,7 +40,9 @@ import slash.navigation.routing.RoutingResult;
 import slash.navigation.routing.RoutingService;
 
 import java.util.ArrayList;
+import java.util.LinkedHashMap;
 import java.util.List;
+import java.util.Map;
 import java.util.logging.Logger;
 
 import static java.lang.String.format;
@@ -178,18 +180,31 @@ public class RouteRenderer {
             drawingStraightLine = true;
         }
         try {
+            // collect all lines and add them to the map in one batch: adding them one by one
+            // queues one AWT event plus a layer-manager pause/redraw cycle per line, which
+            // freezes the UI for minutes on routes with thousands of positions
+            Map<PairWithLayer, Line> pairsToLines = new LinkedHashMap<>();
             for (PairWithLayer pairWithLayer : pairWithLayers) {
+                synchronized (notificationMutex) {
+                    // cancelled: add nothing so no layer is set that never reached the map
+                    if (!drawingRoute)
+                        return;
+                }
+
                 if (!pairWithLayer.hasCoordinates())
                     continue;
 
                 Line line = new Line(mapView.asLatLong(pairWithLayer.getFirst()), mapView.asLatLong(pairWithLayer.getSecond()), getRouteDownloadingPaint(), mapView.getTileSize());
-                pairWithLayer.setLayer(line);
-                mapView.addLayer(line);
+                pairsToLines.put(pairWithLayer, line);
 
                 Double distance = pairWithLayer.getFirst().calculateDistance(pairWithLayer.getSecond());
                 Long time = pairWithLayer.getFirst().calculateTime(pairWithLayer.getSecond());
                 pairWithLayer.setDistanceAndTime(new DistanceAndTime(distance, time));
             }
+
+            for (Map.Entry<PairWithLayer, Line> entry : pairsToLines.entrySet())
+                entry.getKey().setLayer(entry.getValue());
+            mapView.addLayers(new ArrayList<>(pairsToLines.values()));
         } finally {
             synchronized (notificationMutex) {
                 drawingStraightLine = false;

--- a/mapsforge-mapview/src/test/java/slash/navigation/mapview/mapsforge/renderer/RouteRendererTest.java
+++ b/mapsforge-mapview/src/test/java/slash/navigation/mapview/mapsforge/renderer/RouteRendererTest.java
@@ -42,6 +42,7 @@ import static java.util.Collections.emptyList;
 import static org.junit.Assert.assertSame;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyList;
+import static org.mockito.ArgumentMatchers.argThat;
 import static org.mockito.Mockito.doAnswer;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.times;
@@ -145,6 +146,8 @@ public class RouteRendererTest {
 
         // legs 2 and 3 are not routed anymore after the cancellation
         verify(routingService, times(1)).getRouteBetween(any(), any(), any(), any());
+        // the straight lines went to the map as a single batch, not one AWT event per line
+        verify(mapView, times(1)).addLayers(argThat(layers -> layers.size() == 3));
     }
 
     @Test(timeout = 5000)


### PR DESCRIPTION
## Summary

Follow-up to #309. Opening a route with thousands of positions froze the map for minutes: `drawStraightLine` added every segment with its own `mapView.addLayer` call — one AWT event plus a LayerManager pause/redraw cycle per line, 11212 of them for an 11213-position catalog route. Clicking through several catalog files stacked these storms: the position list showed the new file while the map stayed frozen and empty.

`drawStraightLine` now collects the lines and adds them with a single `mapView.addLayers` call, and honors the `cancelRendering` flag per pair. Layers are attached to their `PairWithLayer` only after the batch is really added, so a cancelled preview never leaves layers behind that were never put on the map.

## Verification

Replayed the freeze scenario (7 catalog files opened 1.5s apart, including the 11213-position route twice): final state shows the last track fully drawn and zoomed, Länge/distances populated, and exactly 2773 line layers on the map — no stale layers, no leftover dotted segments. `mapsforge-mapview` suite: 113 tests green, batch assertion added to the cancellation test.

🤖 Generated with [Claude Code](https://claude.com/claude-code)