### PR TITLE
Bump bundled JRE 21.0.11 to 21.0.12

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -135,7 +135,7 @@ jobs:
       - uses: actions/setup-java@v5
         with:
           distribution: temurin
-          java-version: '21.0.11'
+          java-version: '21.0.12'
       - uses: actions/cache@v6
         with:
           path: ~/.m2

--- a/pom.xml
+++ b/pom.xml
@@ -74,7 +74,7 @@
              TimeAlbumProWindows (via NSI resource filtering, ${jre.version}),
              and the build-windows-jre / build-mac-jre / prerelease / release
              GitHub workflows (grep on this pom). -->
-        <jre.version>21.0.11</jre.version>
+        <jre.version>21.0.12</jre.version>
 
         <java.version>21</java.version>
         <maven.version>[3.6.3,)</maven.version>


### PR DESCRIPTION
## Summary
- Bump pinned JRE/JDK patch version 21.0.11 → 21.0.12 in pom.xml (`jre.version`) and `.github/workflows/release.yml` (`publish-javadoc` job).
- Upstream verified via Adoptium API: latest Java 21 GA is `jdk-21.0.12+8`.

Fixes #307

## Test plan
- [x] `./mvnw help:evaluate -Dexpression=jre.version -q -DforceStdout` prints `21.0.12`
- [x] `grep -c "21.0.11" pom.xml .github/workflows/release.yml` finds no remaining matches
- [ ] CI build workflow green on the PR