### PR TITLE
Add POI data download checkbox with remaining-size calculation

### DIFF
--- a/mapsforge-poi/src/main/java/slash/navigation/pois/mapsforge/MapsforgePoiLookup.java
+++ b/mapsforge-poi/src/main/java/slash/navigation/pois/mapsforge/MapsforgePoiLookup.java
@@ -22,6 +22,7 @@ package slash.navigation.pois.mapsforge;
 import org.mapsforge.core.model.LatLong;
 import org.mapsforge.core.model.Tag;
 import slash.navigation.common.BoundingBox;
+import slash.navigation.common.MapDescriptor;
 import slash.navigation.common.NavigationPosition;
 import slash.navigation.datasources.DataSource;
 import slash.navigation.datasources.DataSourceManager;
@@ -54,7 +55,7 @@ import static slash.navigation.pois.mapsforge.MapsforgeTagMatcher.*;
  *
  * @author Christian Pesch
  */
-class MapsforgePoiLookup {
+public class MapsforgePoiLookup {
     private static final Logger log = Logger.getLogger(MapsforgePoiLookup.class.getName());
 
     static final int MAX_RESULTS = 50;
@@ -123,8 +124,37 @@ class MapsforgePoiLookup {
 
     private final DataSourceManager dataSourceManager;
 
-    MapsforgePoiLookup(DataSourceManager dataSourceManager) {
+    public MapsforgePoiLookup(DataSourceManager dataSourceManager) {
         this.dataSourceManager = dataSourceManager;
+    }
+
+    public long calculateRemainingDownloadSize(List<MapDescriptor> mapDescriptors) {
+        long size = 0L;
+        for (slash.navigation.datasources.File file : findRemotePoiFiles(mapDescriptors)) {
+            Long contentLength = file.getLatestChecksum() != null ? file.getLatestChecksum().getContentLength() : null;
+            if (contentLength != null)
+                size += contentLength;
+        }
+        return size;
+    }
+
+    public void downloadPoiData(List<MapDescriptor> mapDescriptors) {
+        for (slash.navigation.datasources.File file : findRemotePoiFiles(mapDescriptors))
+            dataSourceManager.queueForDownload(file.getDataSource(), file);
+    }
+
+    private Set<slash.navigation.datasources.File> findRemotePoiFiles(List<MapDescriptor> mapDescriptors) {
+        Set<slash.navigation.datasources.File> result = new LinkedHashSet<>();
+        for (MapDescriptor mapDescriptor : mapDescriptors) {
+            BoundingBox bounds = mapDescriptor.getBoundingBox();
+            for (DataSource dataSource : dataSourceManager.getDataSourceService().getDataSources()) {
+                for (slash.navigation.datasources.File file : dataSource.getFiles()) {
+                    if (DOT_POI.equals(getExtension(file.getUri())) && matches(file.getBoundingBox(), bounds) && !createFile(file).exists())
+                        result.add(file);
+                }
+            }
+        }
+        return result;
     }
 
     PoiFile findPoiFile(BoundingBox mapBoundingBox) {

--- a/mapsforge-poi/src/test/java/slash/navigation/pois/mapsforge/MapsforgePoiLookupTest.java
+++ b/mapsforge-poi/src/test/java/slash/navigation/pois/mapsforge/MapsforgePoiLookupTest.java
@@ -5,11 +5,18 @@ import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.TemporaryFolder;
 import slash.navigation.common.BoundingBox;
+import slash.navigation.common.MapDescriptor;
 import slash.navigation.common.NavigationPosition;
 import slash.navigation.common.SimpleNavigationPosition;
 import slash.navigation.datasources.DataSource;
 import slash.navigation.datasources.DataSourceManager;
+import slash.navigation.datasources.binding.DatasourceType;
+import slash.navigation.datasources.binding.FileType;
+import slash.navigation.datasources.binding.ObjectFactory;
 import slash.navigation.datasources.helpers.DataSourceService;
+import slash.navigation.datasources.helpers.DataSourcesUtil;
+import slash.navigation.datasources.impl.DataSourceImpl;
+import slash.navigation.download.Checksum;
 import slash.navigation.download.Download;
 import slash.navigation.download.DownloadManager;
 import slash.navigation.geocoding.CategorizedNavigationPosition;
@@ -379,6 +386,98 @@ public class MapsforgePoiLookupTest {
         assertNull(MapsforgePoiLookup.toFtsMatchExpression("---"));
         assertNull(MapsforgePoiLookup.toFtsMatchExpression(""));
         assertNull(MapsforgePoiLookup.toFtsMatchExpression(null));
+    }
+
+    @Test
+    public void calculatesRemainingDownloadSizeForMissingRemoteFile() throws Exception {
+        String directory = "test-pois/" + UUID.randomUUID();
+        applicationDirectoriesToDelete.add(getApplicationDirectory(directory));
+        DataSource dataSource = poiDataSource(directory, poiFileType("missing.poi", MAP_BOUNDS, 12345L));
+        MapsforgePoiLookup lookup = new MapsforgePoiLookup(dataSourceManagerWith(dataSource));
+
+        long size = lookup.calculateRemainingDownloadSize(List.of(mapDescriptor(MAP_BOUNDS)));
+
+        assertEquals(12345L, size);
+    }
+
+    @Test
+    public void calculatesZeroWhenRemoteFileAlreadyExistsLocally() throws Exception {
+        String directory = "test-pois/" + UUID.randomUUID();
+        applicationDirectoriesToDelete.add(getApplicationDirectory(directory));
+        DataSource dataSource = poiDataSource(directory, poiFileType("present.poi", MAP_BOUNDS, 12345L));
+        markAsExistingLocally(directory, "present.poi");
+        MapsforgePoiLookup lookup = new MapsforgePoiLookup(dataSourceManagerWith(dataSource));
+
+        long size = lookup.calculateRemainingDownloadSize(List.of(mapDescriptor(MAP_BOUNDS)));
+
+        assertEquals(0L, size);
+    }
+
+    @Test
+    public void calculatesZeroWhenBoundingBoxIntersectsNoRemoteFile() throws Exception {
+        String directory = "test-pois/" + UUID.randomUUID();
+        applicationDirectoriesToDelete.add(getApplicationDirectory(directory));
+        BoundingBox farAway = new BoundingBox(-60.0, -10.0, -61.0, -11.0);
+        DataSource dataSource = poiDataSource(directory, poiFileType("far.poi", farAway, 999L));
+        MapsforgePoiLookup lookup = new MapsforgePoiLookup(dataSourceManagerWith(dataSource));
+
+        long size = lookup.calculateRemainingDownloadSize(List.of(mapDescriptor(MAP_BOUNDS)));
+
+        assertEquals(0L, size);
+    }
+
+    @Test
+    public void sumsOnlyMissingFilesAcrossMultipleRemotePoiFiles() throws Exception {
+        String directory = "test-pois/" + UUID.randomUUID();
+        applicationDirectoriesToDelete.add(getApplicationDirectory(directory));
+        DataSource dataSource = poiDataSource(directory,
+                poiFileType("missing.poi", MAP_BOUNDS, 500L),
+                poiFileType("present.poi", MAP_BOUNDS, 700L));
+        markAsExistingLocally(directory, "present.poi");
+        MapsforgePoiLookup lookup = new MapsforgePoiLookup(dataSourceManagerWith(dataSource));
+
+        long size = lookup.calculateRemainingDownloadSize(List.of(mapDescriptor(MAP_BOUNDS)));
+
+        assertEquals(500L, size);
+    }
+
+    private DataSource poiDataSource(String directory, FileType... fileTypes) {
+        ObjectFactory factory = new ObjectFactory();
+        DatasourceType datasourceType = factory.createDatasourceType();
+        datasourceType.setId("mapsforge-pois");
+        datasourceType.setDirectory(directory);
+        for (FileType fileType : fileTypes)
+            datasourceType.getFile().add(fileType);
+        return new DataSourceImpl(datasourceType);
+    }
+
+    private FileType poiFileType(String uri, BoundingBox boundingBox, long contentLength) {
+        return DataSourcesUtil.createFileType(uri, List.of(new Checksum(null, contentLength, null)), boundingBox);
+    }
+
+    private void markAsExistingLocally(String directory, String uri) throws Exception {
+        File file = new File(getApplicationDirectory(directory), uri);
+        assertTrue(file.createNewFile());
+    }
+
+    private MapDescriptor mapDescriptor(BoundingBox boundingBox) {
+        return new MapDescriptor() {
+            public String getIdentifier() {
+                return "test-map";
+            }
+
+            public BoundingBox getBoundingBox() {
+                return boundingBox;
+            }
+        };
+    }
+
+    private DataSourceManager dataSourceManagerWith(DataSource dataSource) {
+        DataSourceService dataSourceService = new DataSourceService();
+        dataSourceService.getDataSources().add(dataSource);
+        DataSourceManager dataSourceManager = mock(DataSourceManager.class);
+        when(dataSourceManager.getDataSourceService()).thenReturn(dataSourceService);
+        return dataSourceManager;
     }
 
     private DataSourceManager mockDataSourceManager() {

--- a/route-converter-gui/src/main/resources/slash/navigation/converter/gui/RouteConverter_de.properties
+++ b/route-converter-gui/src/main/resources/slash/navigation/converter/gui/RouteConverter_de.properties
@@ -541,6 +541,7 @@ downloadable-themes=Herunterladbare Kartenthemen:
 download-complete-coverage=Vollständige Abdeckung
 download-routing-data=Lade zusätzlich {0} Routingdaten für {1} herunter
 download-elevation-data=Lade zusätzlich {0} Höhendaten für {1} herunter
+download-poi-data=Lade zusätzlich {0} POI-Daten herunter
 download-map-text=Karten herunterladen…
 download-map-tooltip=Lädt mehr Offline-Karten herunter
 download-theme-text=Kartenthemen herunterladen…

--- a/route-converter-gui/src/main/resources/slash/navigation/converter/gui/RouteConverter_en.properties
+++ b/route-converter-gui/src/main/resources/slash/navigation/converter/gui/RouteConverter_en.properties
@@ -541,6 +541,7 @@ downloadable-themes=Themes available for download:
 download-complete-coverage=Complete Coverage
 download-routing-data=Additionally, download {0} routing data for {1}
 download-elevation-data=Additionally, download {0} elevation data for {1}
+download-poi-data=Additionally, download {0} POI data
 download-map-text=Download maps…
 download-map-tooltip=Download more offline maps
 download-theme-text=Download themes…

--- a/route-converter/src/main/java/slash/navigation/converter/gui/RouteConverter.java
+++ b/route-converter/src/main/java/slash/navigation/converter/gui/RouteConverter.java
@@ -44,6 +44,7 @@ import slash.navigation.nominatim.NominatimService;
 import slash.navigation.photon.PhotonService;
 import slash.navigation.pois.mapsforge.MapsforgeMapGeocodingService;
 import slash.navigation.pois.mapsforge.MapsforgePoiGeocodingService;
+import slash.navigation.pois.mapsforge.MapsforgePoiLookup;
 import slash.navigation.routing.StraightLine;
 
 import javax.swing.*;
@@ -70,6 +71,7 @@ import static slash.navigation.gui.helpers.JMenuHelper.*;
 public class RouteConverter extends BaseRouteConverter {
     private HgtFilesService hgtFilesService;
     private MapsforgeMapManager mapsforgeMapManager;
+    private MapsforgePoiLookup mapsforgePoiLookup;
     private LocalMap mapAfterStart;
 
     public static void main(String[] args) {
@@ -98,6 +100,7 @@ public class RouteConverter extends BaseRouteConverter {
         super.initializeServices();
         hgtFilesService = new HgtFilesService(getDataSourceManager());
         mapsforgeMapManager = new MapsforgeMapManager(getDataSourceManager(), getTileServerMapManager());
+        mapsforgePoiLookup = new MapsforgePoiLookup(getDataSourceManager());
         mapAfterStart = getMapsforgeMapManager().getDisplayedMapModel().getItem();
     }
 
@@ -125,6 +128,10 @@ public class RouteConverter extends BaseRouteConverter {
 
     public MapsforgeMapManager getMapsforgeMapManager() {
         return mapsforgeMapManager;
+    }
+
+    public MapsforgePoiLookup getMapsforgePoiLookup() {
+        return mapsforgePoiLookup;
     }
 
     protected MapsforgeMapViewCallback getMapViewCallback() {

--- a/route-converter/src/main/java/slash/navigation/converter/gui/actions/DownloadMapsAction.java
+++ b/route-converter/src/main/java/slash/navigation/converter/gui/actions/DownloadMapsAction.java
@@ -22,6 +22,7 @@ package slash.navigation.converter.gui.actions;
 
 import slash.navigation.common.MapDescriptor;
 import slash.navigation.converter.gui.BaseRouteConverter;
+import slash.navigation.converter.gui.RouteConverter;
 import slash.navigation.converter.gui.helpers.RemoteMapDescriptor;
 import slash.navigation.gui.Application;
 import slash.navigation.gui.actions.DialogAction;
@@ -56,14 +57,17 @@ public class DownloadMapsAction extends DialogAction {
     private final MapsforgeMapManager mapManager;
     private final JCheckBox checkBoxDownloadRoutingData;
     private final JCheckBox checkBoxDownloadElevationData;
+    private final JCheckBox checkBoxDownloadPoiData;
 
     public DownloadMapsAction(JDialog dialog, JTable table, MapsforgeMapManager mapManager,
-                              JCheckBox checkBoxDownloadRoutingData, JCheckBox checkBoxDownloadElevationData) {
+                              JCheckBox checkBoxDownloadRoutingData, JCheckBox checkBoxDownloadElevationData,
+                              JCheckBox checkBoxDownloadPoiData) {
         super(dialog);
         this.table = table;
         this.mapManager = mapManager;
         this.checkBoxDownloadRoutingData = checkBoxDownloadRoutingData;
         this.checkBoxDownloadElevationData = checkBoxDownloadElevationData;
+        this.checkBoxDownloadPoiData = checkBoxDownloadPoiData;
     }
 
     private Action getAction() {
@@ -101,6 +105,8 @@ public class DownloadMapsAction extends DialogAction {
                         r.getRoutingServiceFacade().getRoutingService().downloadRoutingData(mapDescriptors);
                     if (checkBoxDownloadElevationData.isSelected())
                         r.getElevationServiceFacade().getElevationService().downloadElevationData(mapDescriptors);
+                    if (checkBoxDownloadPoiData.isSelected())
+                        ((RouteConverter) r).getMapsforgePoiLookup().downloadPoiData(mapDescriptors);
 
                     mapManager.scanMaps();
                 } catch (Exception e) {

--- a/route-converter/src/main/java/slash/navigation/converter/gui/dialogs/MapsDialog.form
+++ b/route-converter/src/main/java/slash/navigation/converter/gui/dialogs/MapsDialog.form
@@ -66,7 +66,7 @@
             <properties/>
             <border type="none"/>
             <children>
-              <grid id="94766" layout-manager="GridLayoutManager" row-count="6" column-count="1" same-size-horizontally="false" same-size-vertically="false" hgap="-1" vgap="-1">
+              <grid id="94766" layout-manager="GridLayoutManager" row-count="7" column-count="1" same-size-horizontally="false" same-size-vertically="false" hgap="-1" vgap="-1">
                 <margin top="0" left="0" bottom="0" right="0"/>
                 <constraints>
                   <grid row="1" column="0" row-span="1" col-span="1" vsize-policy="1" hsize-policy="3" anchor="0" fill="3" indent="0" use-parent-layout="false"/>
@@ -109,6 +109,14 @@
                   <component id="36aa9" class="javax.swing.JCheckBox" binding="checkBoxDownloadRoutingData">
                     <constraints>
                       <grid row="4" column="0" row-span="1" col-span="1" vsize-policy="0" hsize-policy="3" anchor="8" fill="0" indent="0" use-parent-layout="false"/>
+                    </constraints>
+                    <properties>
+                      <selected value="true"/>
+                    </properties>
+                  </component>
+                  <component id="c14a2" class="javax.swing.JCheckBox" binding="checkBoxDownloadPoiData">
+                    <constraints>
+                      <grid row="6" column="0" row-span="1" col-span="1" vsize-policy="0" hsize-policy="3" anchor="8" fill="0" indent="0" use-parent-layout="false"/>
                     </constraints>
                     <properties>
                       <selected value="true"/>

--- a/route-converter/src/main/java/slash/navigation/converter/gui/dialogs/MapsDialog.java
+++ b/route-converter/src/main/java/slash/navigation/converter/gui/dialogs/MapsDialog.java
@@ -42,6 +42,7 @@ import slash.navigation.maps.mapsforge.LocalMap;
 import slash.navigation.maps.mapsforge.MapsforgeMapManager;
 import slash.navigation.maps.mapsforge.RemoteMap;
 import slash.navigation.maps.mapsforge.impl.TileDownloadMap;
+import slash.navigation.pois.mapsforge.MapsforgePoiLookup;
 import slash.navigation.routing.RoutingService;
 
 import javax.swing.*;
@@ -86,6 +87,7 @@ public class MapsDialog extends SimpleDialog {
     private JButton buttonClose;
     private JCheckBox checkBoxDownloadElevationData;
     private JCheckBox checkBoxDownloadRoutingData;
+    private JCheckBox checkBoxDownloadPoiData;
 
     public MapsDialog() {
         super(BaseRouteConverter.getInstance().getFrame(), "maps");
@@ -211,7 +213,7 @@ public class MapsDialog extends SimpleDialog {
         actionManager.register("display-offline-map", new DisplayMapAction(this, tableAvailableOfflineMaps, getMapsforgeMapManager()));
         actionManager.register("delete-offline-maps", new DeleteMapsAction(this, tableAvailableOfflineMaps, getMapsforgeMapManager()));
         actionManager.register("download-maps", new DownloadMapsAction(this, tableDownloadableMaps, getMapsforgeMapManager(),
-                checkBoxDownloadRoutingData, checkBoxDownloadElevationData));
+                checkBoxDownloadRoutingData, checkBoxDownloadElevationData, checkBoxDownloadPoiData));
         new AvailableOfflineMapsTablePopupMenu(tableAvailableOfflineMaps).createPopupMenu();
         new DownloadableMapsTablePopupMenu(tableDownloadableMaps).createPopupMenu();
         registerAction(buttonDisplayOfflineMap, "display-offline-map");
@@ -271,10 +273,21 @@ public class MapsDialog extends SimpleDialog {
                 elevationService.getName();
         checkBoxDownloadElevationData.setText(format(BaseRouteConverter.getBundle().getString("download-elevation-data"),
                 formatSize(elevationServiceDownloadSize), elevationServiceName));
+
+        MapsforgePoiLookup poiLookup = getMapsforgePoiLookup();
+        long poiDownloadSize = poiLookup.calculateRemainingDownloadSize(selectedMaps);
+        checkBoxDownloadPoiData.setEnabled(poiDownloadSize > 0);
+        checkBoxDownloadPoiData.setSelected(checkBoxDownloadPoiData.isEnabled());
+        checkBoxDownloadPoiData.setText(format(BaseRouteConverter.getBundle().getString("download-poi-data"),
+                formatSize(poiDownloadSize)));
     }
 
     private MapsforgeMapManager getMapsforgeMapManager() {
         return ((RouteConverter) BaseRouteConverter.getInstance()).getMapsforgeMapManager();
+    }
+
+    private MapsforgePoiLookup getMapsforgePoiLookup() {
+        return ((RouteConverter) BaseRouteConverter.getInstance()).getMapsforgePoiLookup();
     }
 
     private void close() {
@@ -325,7 +338,7 @@ public class MapsDialog extends SimpleDialog {
         panel3.setLayout(new GridLayoutManager(3, 1, new Insets(0, 0, 0, 0), -1, -1));
         tabbedPane1.addTab(this.$$$getMessageFromBundle$$$("slash/navigation/converter/gui/RouteConverter", "offline-tab"), panel3);
         final JPanel panel4 = new JPanel();
-        panel4.setLayout(new GridLayoutManager(6, 1, new Insets(0, 0, 0, 0), -1, -1));
+        panel4.setLayout(new GridLayoutManager(7, 1, new Insets(0, 0, 0, 0), -1, -1));
         panel3.add(panel4, new GridConstraints(1, 0, 1, 1, GridConstraints.ANCHOR_CENTER, GridConstraints.FILL_BOTH, GridConstraints.SIZEPOLICY_CAN_SHRINK | GridConstraints.SIZEPOLICY_CAN_GROW, 1, null, null, null, 0, false));
         final JPanel panel5 = new JPanel();
         panel5.setLayout(new GridLayoutManager(1, 2, new Insets(0, 0, 0, 0), -1, -1));
@@ -342,6 +355,9 @@ public class MapsDialog extends SimpleDialog {
         checkBoxDownloadRoutingData = new JCheckBox();
         checkBoxDownloadRoutingData.setSelected(true);
         panel4.add(checkBoxDownloadRoutingData, new GridConstraints(4, 0, 1, 1, GridConstraints.ANCHOR_WEST, GridConstraints.FILL_NONE, GridConstraints.SIZEPOLICY_CAN_SHRINK | GridConstraints.SIZEPOLICY_CAN_GROW, GridConstraints.SIZEPOLICY_FIXED, null, null, null, 0, false));
+        checkBoxDownloadPoiData = new JCheckBox();
+        checkBoxDownloadPoiData.setSelected(true);
+        panel4.add(checkBoxDownloadPoiData, new GridConstraints(6, 0, 1, 1, GridConstraints.ANCHOR_WEST, GridConstraints.FILL_NONE, GridConstraints.SIZEPOLICY_CAN_SHRINK | GridConstraints.SIZEPOLICY_CAN_GROW, GridConstraints.SIZEPOLICY_FIXED, null, null, null, 0, false));
         final JLabel label1 = new JLabel();
         this.$$$loadLabelText$$$(label1, this.$$$getMessageFromBundle$$$("slash/navigation/converter/gui/RouteConverter", "download-complete-coverage"));
         panel4.add(label1, new GridConstraints(2, 0, 1, 1, GridConstraints.ANCHOR_WEST, GridConstraints.FILL_NONE, GridConstraints.SIZEPOLICY_FIXED, GridConstraints.SIZEPOLICY_FIXED, null, null, null, 0, false));


### PR DESCRIPTION
All 8 files listed in the issue's file list are modified, matching expectations exactly. The changes are complete.

## Summary

Implemented POI-data download parity in the Maps dialog, matching the routing/elevation checkbox pattern:

- **`MapsforgePoiLookup.java`**: made the class and its constructor `public`; added `calculateRemainingDownloadSize(List<MapDescriptor>)` and `downloadPoiData(List<MapDescriptor>)`, backed by a new private `findRemotePoiFiles()` helper that reuses the existing `.poi`-extension filter and `matches()` bounding-box check, then filters to files not yet present locally (via the existing `createFile()` helper) and dedupes across selected maps.
- **`RouteConverter.java`**: added an independent `mapsforgePoiLookup` field, initialized in `initializeServices()` after `super.initializeServices()` (same point where `hgtFilesService`/`mapsforgeMapManager` are set, since `getDataSourceManager()` isn't available before then — a literal field-initializer as sketched in the issue text would have captured a null `DataSourceManager`), plus a public getter.
- **`MapsDialog.java`/`.form`**: added `checkBoxDownloadPoiData` (row 6, grid `94766` bumped from 6 to 7 rows), a `updateLabel()` block mirroring the routing block, a private `getMapsforgePoiLookup()` helper (mirrors `getMapsforgeMapManager()`'s cast-to-`RouteConverter` pattern), and passed the checkbox into `DownloadMapsAction`'s constructor.
- **`DownloadMapsAction.java`**: added the checkbox as a 5th constructor param/field; `run()` now calls `((RouteConverter) r).getMapsforgePoiLookup().downloadPoiData(...)` when checked.
- **i18n**: added `download-poi-data` to both `_en` and `_de` properties (single `{0}` placeholder, no provider name, per spec).
- **Test**: added 4 new cases to `MapsforgePoiLookupTest` covering missing/present/no-intersection/multi-file-sum, using real JAXB binding objects (`ObjectFactory`, `DatasourceType`, `FileType`, `DataSourceImpl`) per this repo's stated testing convention rather than mocks.

**Verify: unavailable.** `factory-verify` rejected this repo ("repo not allowed (rc/* only)"), and no JDK/Maven is present in this sandbox, so I could not run `mvn test`. I traced call sites and type signatures by hand (constructor params, `Downloadable`/`File` interfaces, `DataSourceManager.queueForDownload`, `DataSourcesUtil.createFileType`) and everything lines up, but this has not been compiled or executed.


Source issue: cpesch/RouteConverter#315

---
**Builder stats** · model `sonnet` · confidence `0` · 8m 10s across 1 round(s) · 8 file op(s)
[Workflow run](http://127.0.0.1:3000/cpesch/RouteConverter/actions/runs/21395)

⚠ UNVERIFIED: target not verifiable by the broker (non-rc/* target or no pom.xml — v1 is maven-only)

Closes #315

<!-- issue-body-sha:d52f30608dcf -->