### PR TITLE
fix: an SVG icon that fails to load no longer breaks the map view for the whole session

### DIFF
--- a/common/src/main/java/slash/common/log/LoggingHelper.java
+++ b/common/src/main/java/slash/common/log/LoggingHelper.java
@@ -150,6 +150,7 @@ public class LoggingHelper {
     private static final Filter FILTER = record ->
             record.getLoggerName().startsWith("slash") ||
                     record.getLoggerName().startsWith("com.graphhopper") ||
+                    record.getLoggerName().startsWith("com.kitfox") ||
                     record.getLoggerName().startsWith("org.mapsforge");
 
     private File getLogFile() {

--- a/mapsforge-mapview/src/main/java/slash/navigation/mapview/mapsforge/MapsforgeMapView.java
+++ b/mapsforge-mapview/src/main/java/slash/navigation/mapview/mapsforge/MapsforgeMapView.java
@@ -123,6 +123,7 @@ import static slash.navigation.mapview.mapsforge.helpers.MapViewCalculations.col
 import static slash.navigation.mapview.mapsforge.helpers.MapViewCalculations.computeAddRow;
 import static slash.navigation.mapview.mapsforge.helpers.MapViewCalculations.thresholdForPixel;
 import static slash.navigation.mapview.mapsforge.helpers.SVGHelper.getResourceBitmap;
+import static slash.navigation.mapview.mapsforge.helpers.SVGHelper.removeDocument;
 import static slash.navigation.mapview.mapsforge.helpers.WithLayerHelper.*;
 import static slash.navigation.mapview.mapsforge.models.LocalNames.MAP;
 
@@ -229,16 +230,22 @@ public class MapsforgeMapView extends BaseMapView {
 
         this.selectionUpdater = new SelectionUpdater(positionsModel, new SelectionOperation() {
             private Bitmap markerIcon;
-            {
-                try {
-                    markerIcon = GRAPHIC_FACTORY.renderSvg(MapsforgeMapView.class.getResourceAsStream("marker.svg"), 1.0f, 32, 54, 100, 1234567892);
-                } catch (IOException e) {
-                    log.severe("Cannot create marker icon: " + e);
+
+            // created on demand and retried after a failure: an icon that failed to load once
+            // used to leave the session with markers that cannot be drawn or tapped at all
+            private synchronized Bitmap getMarkerIcon() {
+                if (markerIcon == null) {
+                    try {
+                        markerIcon = createIcon("marker.svg", MARKER_ICON_HASH, 32, 54);
+                    } catch (IOException e) {
+                        log.severe("Cannot create marker icon: " + e);
+                    }
                 }
+                return markerIcon;
             }
 
             private Marker createMarker(PositionWithLayer positionWithLayer, LatLong latLong) {
-                return new DraggableMarker(MapsforgeMapView.this, positionWithLayer, latLong, markerIcon, 0, -25);
+                return new DraggableMarker(MapsforgeMapView.this, positionWithLayer, latLong, getMarkerIcon(), 0, -25);
             }
 
             public void add(List<PositionWithLayer> positionWithLayers) {
@@ -540,6 +547,19 @@ public class MapsforgeMapView extends BaseMapView {
         return mapView;
     }
 
+    private static final int MAGNIFIER_ICON_HASH = 1234567891;
+    private static final int MARKER_ICON_HASH = 1234567892;
+
+    private static Bitmap createIcon(String resource, int hash, int width, int height) throws IOException {
+        try {
+            return GRAPHIC_FACTORY.renderSvg(MapsforgeMapView.class.getResourceAsStream(resource), 1.0f, width, height, 100, hash);
+        } catch (IOException e) {
+            // a failed load may leave a half loaded document behind that fails every later load, too
+            removeDocument(Integer.toString(hash));
+            throw e;
+        }
+    }
+
     private Bitmap waypointIcon;
 
     private synchronized Bitmap createWaypointIcon() {
@@ -566,8 +586,15 @@ public class MapsforgeMapView extends BaseMapView {
                 return tokenName;
             }
         });
-        BufferedImage bufferedImage = getResourceBitmap(reader, "waypoint-" + color + "-" + opacity, getDeviceScaleFactor(), 100f, 16, 16, 100);
-        return new AwtBitmap(bufferedImage);
+        try {
+            BufferedImage bufferedImage = getResourceBitmap(reader, "waypoint-" + color + "-" + opacity, getDeviceScaleFactor(), 100f, 16, 16, 100);
+            return new AwtBitmap(bufferedImage);
+        } catch (IOException e) {
+            // returning null keeps the position lists renderable and lets the next repaint retry:
+            // throwing here used to desync the WaypointUpdater for the rest of the session
+            log.severe("Cannot create waypoint icon: " + e);
+            return null;
+        }
     }
 
     private void handleUnitSystem() {
@@ -1335,14 +1362,19 @@ public class MapsforgeMapView extends BaseMapView {
 
     private class MagnifierPainter {
         private Bitmap magnifierIcon;
-        {
-            try {
-                magnifierIcon = GRAPHIC_FACTORY.renderSvg(MapsforgeMapView.class.getResourceAsStream("magnifier.svg"), 1.0f, 57, 56, 100, 1234567891);
-            } catch (IOException e) {
-                log.severe("Cannot create magnifier icon: " + e);
-            }
-        }
         private final List<Layer> markers = new ArrayList<>();
+
+        // created on demand and retried after a failure, see SelectionOperation#getMarkerIcon()
+        private synchronized Bitmap getMagnifierIcon() {
+            if (magnifierIcon == null) {
+                try {
+                    magnifierIcon = createIcon("magnifier.svg", MAGNIFIER_ICON_HASH, 57, 56);
+                } catch (IOException e) {
+                    log.severe("Cannot create magnifier icon: " + e);
+                }
+            }
+            return magnifierIcon;
+        }
 
         public void showPositionMagnifier(List<NavigationPosition> positions) {
             if(!markers.isEmpty()) {
@@ -1352,7 +1384,7 @@ public class MapsforgeMapView extends BaseMapView {
 
             if(positions != null && !positions.isEmpty()) {
                 List<Layer> icons = positions.stream()
-                        .map(position -> new Marker(asLatLong(position), magnifierIcon, -10, 13))
+                        .map(position -> new Marker(asLatLong(position), getMagnifierIcon(), -10, 13))
                         .collect(Collectors.toList());
                 addLayers(icons);
                 markers.addAll(icons);

--- a/mapsforge-mapview/src/main/java/slash/navigation/mapview/mapsforge/helpers/SVGHelper.java
+++ b/mapsforge-mapview/src/main/java/slash/navigation/mapview/mapsforge/helpers/SVGHelper.java
@@ -7,6 +7,7 @@ import com.kitfox.svg.app.beans.SVGIcon;
 import org.mapsforge.core.graphics.GraphicUtils;
 
 import java.awt.image.BufferedImage;
+import java.io.IOException;
 import java.io.Reader;
 import java.net.URI;
 
@@ -20,10 +21,14 @@ import static java.awt.image.BufferedImage.TYPE_INT_ARGB;
  */
 
 public class SVGHelper {
-    public static BufferedImage getResourceBitmap(Reader reader, String name, float scaleFactor, float defaultSize, int width, int height, int percent) {
+    public static BufferedImage getResourceBitmap(Reader reader, String name, float scaleFactor, float defaultSize, int width, int height, int percent) throws IOException {
         SVGUniverse universe = SVGCache.getSVGUniverse();
         URI uri = universe.loadSVG(reader, name);
         SVGDiagram diagram = universe.getDiagram(uri);
+        if (diagram == null || diagram.getRoot() == null) {
+            removeDocument(name);
+            throw new IOException("Cannot load SVG " + name);
+        }
 
         double scale = scaleFactor / Math.sqrt((diagram.getHeight() * diagram.getWidth()) / defaultSize);
         float[] bmpSize = GraphicUtils.imageSize(diagram.getWidth(), diagram.getHeight(), (float) scale, width, height, percent);
@@ -37,5 +42,17 @@ public class SVGHelper {
         BufferedImage bufferedImage = new BufferedImage(icon.getIconWidth(), icon.getIconHeight(), TYPE_INT_ARGB);
         icon.paintIcon(null, bufferedImage.createGraphics(), 0, 0);
         return bufferedImage;
+    }
+
+    /**
+     * Removes a document from the {@link SVGUniverse} cache, so that a later load of the same name
+     * reads it again. A failed load leaves a half loaded document behind - only a SAXParseException
+     * removes it - which makes every later load of that name fail, too.
+     */
+    public static void removeDocument(String name) {
+        SVGUniverse universe = SVGCache.getSVGUniverse();
+        URI uri = universe.getStreamBuiltURI(name);
+        if (uri != null)
+            universe.removeDocument(uri);
     }
 }

--- a/mapsforge-mapview/src/main/java/slash/navigation/mapview/mapsforge/overlays/DraggableMarker.java
+++ b/mapsforge-mapview/src/main/java/slash/navigation/mapview/mapsforge/overlays/DraggableMarker.java
@@ -45,6 +45,10 @@ public class DraggableMarker extends Marker {
     }
 
     public boolean onTap(LatLong tapLatLong, Point viewPosition, Point tapPoint) {
+        // Marker#contains dereferences the bitmap - unlike Marker#draw, which checks for null -
+        // so a marker whose icon failed to load would throw a NullPointerException on every click
+        if (getBitmap() == null)
+            return false;
         return contains(viewPosition, tapPoint, mapsforgeMapView.getMapView());
     }
 

--- a/mapsforge-mapview/src/main/java/slash/navigation/mapview/mapsforge/updater/UpdateDecoupler.java
+++ b/mapsforge-mapview/src/main/java/slash/navigation/mapview/mapsforge/updater/UpdateDecoupler.java
@@ -28,6 +28,7 @@ import java.util.logging.Logger;
 
 import static java.lang.Integer.MAX_VALUE;
 import static java.lang.String.format;
+import static java.util.logging.Level.SEVERE;
 import static javax.swing.event.TableModelEvent.*;
 import static slash.common.helpers.ThreadHelper.createSingleThreadExecutor;
 import static slash.navigation.base.RouteCharacteristics.Waypoints;
@@ -70,7 +71,7 @@ public class UpdateDecoupler {
                 eventMapUpdater = updaterFactory.apply(positionsModel.getRoute().getCharacteristics());
                 eventMapUpdater.handleAdd(0, positionsModel.getRowCount() - 1);
             } catch (RuntimeException e) {
-                log.severe("Cannot replace route: " + e);
+                log.log(SEVERE, "Cannot replace route: " + e, e);
                 rebuild(e);
             }
         });
@@ -85,7 +86,7 @@ public class UpdateDecoupler {
                     case DELETE -> eventMapUpdater.handleRemove(firstRow, lastRow);
                 }
             } catch (RuntimeException e) {
-                log.severe(format("Cannot handle event type %d for rows %d..%d: %s", eventType, firstRow, lastRow, e));
+                log.log(SEVERE, format("Cannot handle event type %d for rows %d..%d: %s", eventType, firstRow, lastRow, e), e);
                 rebuild(e);
             }
         });
@@ -102,7 +103,7 @@ public class UpdateDecoupler {
             if (rowCount > 0)
                 eventMapUpdater.handleAdd(0, rowCount - 1);
         } catch (RuntimeException e) {
-            log.severe("Cannot rebuild after " + cause + ": " + e);
+            log.log(SEVERE, "Cannot rebuild after " + cause + ": " + e, e);
         }
     }
 


### PR DESCRIPTION
## Problem

Observed while switching a position list between waypoints and tracks: every click on the map threw

```
java.lang.NullPointerException: Cannot invoke "org.mapsforge.core.graphics.Bitmap.getWidth()" because "this.bitmap" is null
	at org.mapsforge.map.layer.overlay.Marker.contains(Marker.java:58)
	at slash.navigation.mapview.mapsforge.overlays.DraggableMarker.onTap(DraggableMarker.java:48)
	at slash.navigation.mapview.mapsforge.helpers.MapViewMoverAndZoomer.getMarkerFor(MapViewMoverAndZoomer.java:127)
```

and the position list was no longer updated:

```
SCHWERWIEGEND: Cannot replace route: java.lang.NullPointerException
SCHWERWIEGEND: Cannot rebuild after java.lang.NullPointerException: java.lang.NullPointerException
WARNUNG: Could not find layer to remove for PositionWithLayer@...[position=..., layer=null]
WARNUNG: Cannot remove layers []
```

## Root cause

Two minutes earlier the log has the trigger:

```
SCHWERWIEGEND: Cannot create magnifier icon: java.io.IOException: java.io.IOException: Stream closed
SCHWERWIEGEND: Cannot create marker icon: java.io.IOException: java.io.IOException: Stream closed
```

* `markerIcon` was created once in an instance initializer, so after that single failure it stayed `null` for the whole session. `Marker` accepts a `null` bitmap, `Marker#draw` checks for it, but `Marker#contains` does not - so every `mousePressed` near a selected position crashed.
* `waypoint.svg` failed the same way. `SVGUniverse#loadSVG` returns `null` on failure, so `SVGHelper#getResourceBitmap` dereferenced a `null` `SVGDiagram`. That `NullPointerException` escaped `WaypointOperation#add` before `positionWithLayer.setLayer(marker)` ran, and `UpdateDecoupler#rebuild` failed the same way - hence the permanent `layer=null` warnings.
* A failed load also leaves a half loaded document in the `SVGUniverse` (only a `SAXParseException` removes it), so every later load of the same name fails too - the reason a single glitch never recovered.
* `UpdateDecoupler` logged only `e.toString()`, so the second `NullPointerException` had no stack trace at all, and the `com.kitfox` warning naming the failing SVG was filtered out of the log file.

## Changes

* `DraggableMarker#onTap` - no hit test without a bitmap
* `SVGHelper` - throw an `IOException` instead of dereferencing null, and drop the half loaded document so a later load retries
* `MapsforgeMapView` - marker, magnifier and waypoint icons are created on demand and retried after a failure; a failed `renderSvg` purges its cache entry
* `UpdateDecoupler` - log the stack trace
* `LoggingHelper` - pass `com.kitfox` records into the log file

## Verification

`javac` over `mapsforge-mapview` and `mvn compile` for `common` are clean (the reactor build of `mapsforge-mapview` fails only on unrelated uncommitted `MapSelector.java` warnings in my working tree). Behaviour verified by reading the failure path; the original glitch (an unreadable classpath resource stream, most likely the module rebuilt while the app was running) is not reproducible on demand.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
