### PR TITLE
fix: wire the "?" button of every dialog, not just DownloadsDialog

### DIFF
--- a/common-gui/src/main/java/slash/navigation/gui/HelpManager.java
+++ b/common-gui/src/main/java/slash/navigation/gui/HelpManager.java
@@ -63,16 +63,17 @@ public class HelpManager {
     public void openTopic(String topicId) { browse(resolveBaseUrl() + "/help/" + topicId + "/"); }
     public void openContents() { browse(resolveBaseUrl() + "/help/"); }
 
-    public JButton helpButton(final JComponent owner) {
-        JButton button = new JButton("?");
+    /**
+     * Wires an existing {@code ?} button to the help topic of {@code owner}. A button declared in a
+     * GUI Designer form is instantiated by the generated {@code $$$setupUI$$$} method.
+     */
+    public void registerHelpButton(final AbstractButton button, final JComponent owner) {
         button.addActionListener(e -> openTopicForComponent(owner));
-        return button;
     }
 
     public void installF1KeyListener() {
         Toolkit.getDefaultToolkit().addAWTEventListener(event -> {
-            if (!(event instanceof java.awt.event.KeyEvent)) return;
-            java.awt.event.KeyEvent ke = (java.awt.event.KeyEvent) event;
+            if (!(event instanceof java.awt.event.KeyEvent ke)) return;
             if (ke.getID() != KEY_PRESSED || ke.getKeyCode() != VK_F1) return;
             openTopicForComponent(ke.getComponent());
             ke.consume();

--- a/common-gui/src/main/java/slash/navigation/gui/SimpleDialog.java
+++ b/common-gui/src/main/java/slash/navigation/gui/SimpleDialog.java
@@ -41,6 +41,27 @@ public abstract class SimpleDialog extends JDialog {
         setName(name);
     }
 
+    /**
+     * Wires the {@code ?} button that a dialog's GUI Designer form declares to the dialog's help
+     * topic (specs/00030 §11). Hooked here rather than in each dialog's constructor because the
+     * form-declared button is instantiated by the generated {@code $$$setupUI$$$} method, which
+     * the IDE rewrites from the {@code .form} - that is how the only hand-added wiring, in
+     * DownloadsDialog, silently turned into a dead button.
+     */
+    public void setContentPane(Container contentPane) {
+        super.setContentPane(contentPane);
+        registerHelpButtons(contentPane);
+    }
+
+    private void registerHelpButtons(Container container) {
+        for (Component component : container.getComponents()) {
+            if (component instanceof JButton button && "?".equals(button.getText()) && button.getActionListeners().length == 0)
+                Application.getInstance().getContext().getHelpManager().registerHelpButton(button, button);
+            if (component instanceof Container child)
+                registerHelpButtons(child);
+        }
+    }
+
     public void showWithPreferences() {
         pack();
         windowBounds = new WindowBounds(this, preferences, getName() + "-");

--- a/route-converter-gui/src/main/java/slash/navigation/converter/gui/dialogs/AboutRouteConverterDialog.java
+++ b/route-converter-gui/src/main/java/slash/navigation/converter/gui/dialogs/AboutRouteConverterDialog.java
@@ -216,7 +216,8 @@ public class AboutRouteConverterDialog extends SimpleDialog {
         final JPanel panel2 = new JPanel();
         panel2.setLayout(new GridLayoutManager(1, 3, new Insets(3, 0, 1, 0), -1, -1));
         panel1.add(panel2, new GridConstraints(7, 0, 1, 2, GridConstraints.ANCHOR_NORTH, GridConstraints.FILL_HORIZONTAL, GridConstraints.SIZEPOLICY_CAN_SHRINK | GridConstraints.SIZEPOLICY_CAN_GROW, GridConstraints.SIZEPOLICY_FIXED, null, null, null, 0, false));
-        buttonHelp = BaseRouteConverter.getInstance().getContext().getHelpManager().helpButton(contentPane);
+        buttonHelp = new JButton();
+        buttonHelp.setText("?");
         panel2.add(buttonHelp, new GridConstraints(0, 0, 1, 1, GridConstraints.ANCHOR_WEST, GridConstraints.FILL_NONE, GridConstraints.SIZEPOLICY_FIXED, GridConstraints.SIZEPOLICY_FIXED, null, null, null, 0, false));
         buttonClose = new JButton();
         this.$$$loadButtonText$$$(buttonClose, this.$$$getMessageFromBundle$$$("slash/navigation/converter/gui/RouteConverter", "close"));

--- a/route-converter-gui/src/main/java/slash/navigation/converter/gui/dialogs/AboutTimeAlbumProDialog.java
+++ b/route-converter-gui/src/main/java/slash/navigation/converter/gui/dialogs/AboutTimeAlbumProDialog.java
@@ -142,7 +142,8 @@ public class AboutTimeAlbumProDialog extends SimpleDialog {
         final JPanel panel2 = new JPanel();
         panel2.setLayout(new GridLayoutManager(1, 3, new Insets(3, 0, 1, 0), -1, -1));
         panel1.add(panel2, new GridConstraints(4, 0, 1, 1, GridConstraints.ANCHOR_NORTH, GridConstraints.FILL_HORIZONTAL, GridConstraints.SIZEPOLICY_CAN_SHRINK | GridConstraints.SIZEPOLICY_CAN_GROW, GridConstraints.SIZEPOLICY_FIXED, null, null, null, 0, false));
-        buttonHelp = BaseRouteConverter.getInstance().getContext().getHelpManager().helpButton(contentPane);
+        buttonHelp = new JButton();
+        buttonHelp.setText("?");
         panel2.add(buttonHelp, new GridConstraints(0, 0, 1, 1, GridConstraints.ANCHOR_WEST, GridConstraints.FILL_NONE, GridConstraints.SIZEPOLICY_FIXED, GridConstraints.SIZEPOLICY_FIXED, null, null, null, 0, false));
         buttonClose = new JButton();
         this.$$$loadButtonText$$$(buttonClose, this.$$$getMessageFromBundle$$$("slash/navigation/converter/gui/RouteConverter", "close"));

--- a/route-converter-gui/src/main/java/slash/navigation/converter/gui/dialogs/AddFileDialog.java
+++ b/route-converter-gui/src/main/java/slash/navigation/converter/gui/dialogs/AddFileDialog.java
@@ -157,7 +157,8 @@ public class AddFileDialog extends SimpleDialog {
         final JPanel panel2 = new JPanel();
         panel2.setLayout(new GridLayoutManager(1, 4, new Insets(0, 0, 0, 0), -1, -1));
         panel1.add(panel2, new GridConstraints(0, 0, 1, 1, GridConstraints.ANCHOR_CENTER, GridConstraints.FILL_BOTH, GridConstraints.SIZEPOLICY_CAN_SHRINK | GridConstraints.SIZEPOLICY_CAN_GROW, GridConstraints.SIZEPOLICY_CAN_SHRINK | GridConstraints.SIZEPOLICY_CAN_GROW, null, null, null, 0, false));
-        buttonHelp = BaseRouteConverter.getInstance().getContext().getHelpManager().helpButton(contentPane);
+        buttonHelp = new JButton();
+        buttonHelp.setText("?");
         panel2.add(buttonHelp, new GridConstraints(0, 0, 1, 1, GridConstraints.ANCHOR_WEST, GridConstraints.FILL_NONE, GridConstraints.SIZEPOLICY_FIXED, GridConstraints.SIZEPOLICY_FIXED, null, null, null, 0, false));
         buttonAdd = new JButton();
         this.$$$loadButtonText$$$(buttonAdd, this.$$$getMessageFromBundle$$$("slash/navigation/converter/gui/RouteConverter", "add"));

--- a/route-converter-gui/src/main/java/slash/navigation/converter/gui/dialogs/AddUrlDialog.java
+++ b/route-converter-gui/src/main/java/slash/navigation/converter/gui/dialogs/AddUrlDialog.java
@@ -154,7 +154,8 @@ public class AddUrlDialog extends SimpleDialog {
         final JPanel panel2 = new JPanel();
         panel2.setLayout(new GridLayoutManager(1, 4, new Insets(0, 0, 0, 0), -1, -1));
         panel1.add(panel2, new GridConstraints(0, 0, 1, 1, GridConstraints.ANCHOR_CENTER, GridConstraints.FILL_BOTH, GridConstraints.SIZEPOLICY_CAN_SHRINK | GridConstraints.SIZEPOLICY_CAN_GROW, GridConstraints.SIZEPOLICY_CAN_SHRINK | GridConstraints.SIZEPOLICY_CAN_GROW, null, null, null, 0, false));
-        buttonHelp = BaseRouteConverter.getInstance().getContext().getHelpManager().helpButton(contentPane);
+        buttonHelp = new JButton();
+        buttonHelp.setText("?");
         panel2.add(buttonHelp, new GridConstraints(0, 0, 1, 1, GridConstraints.ANCHOR_WEST, GridConstraints.FILL_NONE, GridConstraints.SIZEPOLICY_FIXED, GridConstraints.SIZEPOLICY_FIXED, null, null, null, 0, false));
         buttonAdd = new JButton();
         this.$$$loadButtonText$$$(buttonAdd, this.$$$getMessageFromBundle$$$("slash/navigation/converter/gui/RouteConverter", "add"));

--- a/route-converter-gui/src/main/java/slash/navigation/converter/gui/dialogs/CompleteFlightPlanDialog.java
+++ b/route-converter-gui/src/main/java/slash/navigation/converter/gui/dialogs/CompleteFlightPlanDialog.java
@@ -229,7 +229,8 @@ public class CompleteFlightPlanDialog extends SimpleDialog {
         buttonNextOrFinish = new JButton();
         this.$$$loadButtonText$$$(buttonNextOrFinish, this.$$$getMessageFromBundle$$$("slash/navigation/converter/gui/RouteConverter", "next"));
         panel2.add(buttonNextOrFinish, new GridConstraints(0, 0, 1, 1, GridConstraints.ANCHOR_CENTER, GridConstraints.FILL_HORIZONTAL, GridConstraints.SIZEPOLICY_CAN_SHRINK | GridConstraints.SIZEPOLICY_CAN_GROW, GridConstraints.SIZEPOLICY_FIXED, null, null, null, 0, false));
-        buttonHelp = BaseRouteConverter.getInstance().getContext().getHelpManager().helpButton(contentPane);
+        buttonHelp = new JButton();
+        buttonHelp.setText("?");
         panel1.add(buttonHelp, new GridConstraints(0, 0, 1, 1, GridConstraints.ANCHOR_WEST, GridConstraints.FILL_NONE, GridConstraints.SIZEPOLICY_FIXED, GridConstraints.SIZEPOLICY_FIXED, null, null, null, 0, false));
         buttonPrevious = new JButton();
         this.$$$loadButtonText$$$(buttonPrevious, this.$$$getMessageFromBundle$$$("slash/navigation/converter/gui/RouteConverter", "previous"));

--- a/route-converter-gui/src/main/java/slash/navigation/converter/gui/dialogs/DeletePositionsDialog.java
+++ b/route-converter-gui/src/main/java/slash/navigation/converter/gui/dialogs/DeletePositionsDialog.java
@@ -308,7 +308,8 @@ public class DeletePositionsDialog extends SimpleDialog {
         panel2.add(panel8, new GridConstraints(5, 0, 1, 4, GridConstraints.ANCHOR_CENTER, GridConstraints.FILL_BOTH, GridConstraints.SIZEPOLICY_CAN_SHRINK | GridConstraints.SIZEPOLICY_CAN_GROW, GridConstraints.SIZEPOLICY_CAN_SHRINK | GridConstraints.SIZEPOLICY_CAN_GROW, new Dimension(-1, 10), null, null, 0, false));
         final JSeparator separator3 = new JSeparator();
         panel8.add(separator3, new GridConstraints(0, 0, 1, 1, GridConstraints.ANCHOR_CENTER, GridConstraints.FILL_HORIZONTAL, GridConstraints.SIZEPOLICY_WANT_GROW, GridConstraints.SIZEPOLICY_WANT_GROW, null, null, null, 0, false));
-        buttonHelp = BaseRouteConverter.getInstance().getContext().getHelpManager().helpButton(contentPane);
+        buttonHelp = new JButton();
+        buttonHelp.setText("?");
         panel2.add(buttonHelp, new GridConstraints(6, 0, 1, 1, GridConstraints.ANCHOR_WEST, GridConstraints.FILL_NONE, GridConstraints.SIZEPOLICY_FIXED, GridConstraints.SIZEPOLICY_FIXED, null, null, null, 0, false));
         buttonDeletePositions = new JButton();
         this.$$$loadButtonText$$$(buttonDeletePositions, this.$$$getMessageFromBundle$$$("slash/navigation/converter/gui/RouteConverter", "delete-selected-positions"));

--- a/route-converter-gui/src/main/java/slash/navigation/converter/gui/dialogs/DepartureTimeDialog.java
+++ b/route-converter-gui/src/main/java/slash/navigation/converter/gui/dialogs/DepartureTimeDialog.java
@@ -178,7 +178,8 @@ public class DepartureTimeDialog extends SimpleDialog {
         final JPanel panelButtons = new JPanel();
         panelButtons.setLayout(new GridLayoutManager(1, 4, new Insets(0, 0, 0, 0), -1, -1));
         contentPane.add(panelButtons, new GridConstraints(2, 0, 1, 1, GridConstraints.ANCHOR_CENTER, GridConstraints.FILL_BOTH, GridConstraints.SIZEPOLICY_CAN_SHRINK | GridConstraints.SIZEPOLICY_CAN_GROW, 1, null, null, null, 0, false));
-        buttonHelp = BaseRouteConverter.getInstance().getContext().getHelpManager().helpButton(contentPane);
+        buttonHelp = new JButton();
+        buttonHelp.setText("?");
         panelButtons.add(buttonHelp, new GridConstraints(0, 0, 1, 1, GridConstraints.ANCHOR_WEST, GridConstraints.FILL_NONE, GridConstraints.SIZEPOLICY_FIXED, GridConstraints.SIZEPOLICY_FIXED, null, null, null, 0, false));
         buttonOk = new JButton();
         this.$$$loadButtonText$$$(buttonOk, this.$$$getMessageFromBundle$$$("slash/navigation/converter/gui/RouteConverter", "ok"));

--- a/route-converter-gui/src/main/java/slash/navigation/converter/gui/dialogs/DownloadsDialog.form
+++ b/route-converter-gui/src/main/java/slash/navigation/converter/gui/dialogs/DownloadsDialog.form
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <form xmlns="http://www.intellij.com/uidesigner/form/" version="1" bind-to-class="slash.navigation.converter.gui.dialogs.DownloadsDialog">
-  <grid id="27dc6" binding="contentPane" layout-manager="GridLayoutManager" row-count="4" column-count="1" same-size-horizontally="false" same-size-vertically="false" hgap="-1" vgap="-1">
+  <grid id="27dc6" binding="contentPane" layout-manager="GridLayoutManager" row-count="3" column-count="1" same-size-horizontally="false" same-size-vertically="false" hgap="-1" vgap="-1">
     <margin top="10" left="10" bottom="10" right="10"/>
     <constraints>
       <xy x="20" y="20" width="1462" height="400"/>
@@ -33,31 +33,8 @@
           </component>
         </children>
       </scrollpane>
-      <grid id="dc7c4" layout-manager="GridLayoutManager" row-count="1" column-count="2" same-size-horizontally="false" same-size-vertically="false" hgap="-1" vgap="-1">
+      <grid id="da982" layout-manager="GridLayoutManager" row-count="1" column-count="6" same-size-horizontally="false" same-size-vertically="false" hgap="-1" vgap="-1">
         <margin top="2" left="0" bottom="1" right="0"/>
-        <constraints>
-          <grid row="3" column="0" row-span="1" col-span="1" vsize-policy="3" hsize-policy="3" anchor="0" fill="3" indent="0" use-parent-layout="false"/>
-        </constraints>
-        <properties/>
-        <border type="none"/>
-        <children>
-          <component id="1f161" class="javax.swing.JButton" binding="buttonClose">
-            <constraints>
-              <grid row="0" column="1" row-span="1" col-span="1" vsize-policy="0" hsize-policy="3" anchor="0" fill="0" indent="0" use-parent-layout="false"/>
-            </constraints>
-            <properties>
-              <text resource-bundle="slash/navigation/converter/gui/RouteConverter" key="close"/>
-            </properties>
-          </component>
-          <hspacer id="223ab">
-            <constraints>
-              <grid row="0" column="0" row-span="1" col-span="1" vsize-policy="1" hsize-policy="6" anchor="0" fill="1" indent="0" use-parent-layout="false"/>
-            </constraints>
-          </hspacer>
-        </children>
-      </grid>
-      <grid id="da982" layout-manager="GridLayoutManager" row-count="1" column-count="5" same-size-horizontally="false" same-size-vertically="false" hgap="-1" vgap="-1">
-        <margin top="0" left="0" bottom="0" right="0"/>
         <constraints>
           <grid row="2" column="0" row-span="1" col-span="1" vsize-policy="3" hsize-policy="3" anchor="0" fill="3" indent="0" use-parent-layout="false"/>
         </constraints>
@@ -90,11 +67,6 @@
               <toolTipText resource-bundle="slash/navigation/converter/gui/RouteConverter" key="stop-download-action-tooltip"/>
             </properties>
           </component>
-          <hspacer id="7899">
-            <constraints>
-              <grid row="0" column="4" row-span="1" col-span="1" vsize-policy="1" hsize-policy="6" anchor="0" fill="1" indent="0" use-parent-layout="false"/>
-            </constraints>
-          </hspacer>
           <component id="ca5f2" class="javax.swing.JButton" binding="buttonRemove">
             <constraints>
               <grid row="0" column="3" row-span="1" col-span="1" vsize-policy="0" hsize-policy="3" anchor="0" fill="1" indent="0" use-parent-layout="false"/>
@@ -102,6 +74,19 @@
             <properties>
               <text resource-bundle="slash/navigation/converter/gui/RouteConverter" key="remove-download-action"/>
               <toolTipText resource-bundle="slash/navigation/converter/gui/RouteConverter" key="remove-download-action-tooltip"/>
+            </properties>
+          </component>
+          <hspacer id="7899">
+            <constraints>
+              <grid row="0" column="4" row-span="1" col-span="1" vsize-policy="1" hsize-policy="6" anchor="0" fill="1" indent="0" use-parent-layout="false"/>
+            </constraints>
+          </hspacer>
+          <component id="1f161" class="javax.swing.JButton" binding="buttonClose">
+            <constraints>
+              <grid row="0" column="5" row-span="1" col-span="1" vsize-policy="0" hsize-policy="3" anchor="0" fill="0" indent="0" use-parent-layout="false"/>
+            </constraints>
+            <properties>
+              <text resource-bundle="slash/navigation/converter/gui/RouteConverter" key="close"/>
             </properties>
           </component>
         </children>

--- a/route-converter-gui/src/main/java/slash/navigation/converter/gui/dialogs/DownloadsDialog.java
+++ b/route-converter-gui/src/main/java/slash/navigation/converter/gui/dialogs/DownloadsDialog.java
@@ -99,7 +99,8 @@ public class DownloadsDialog extends SimpleDialog {
         }
         TableRowSorter<TableModel> sorter = new TableRowSorter<>(tableDownloads.getModel());
         sorter.setSortsOnUpdates(true);
-        sorter.setComparator(DESCRIPTION_COLUMN, (Comparator<Download>) (d1, d2) -> d1.getDescription().compareToIgnoreCase(d2.getDescription()));
+        sorter.setComparator(DESCRIPTION_COLUMN,
+                (Comparator<Download>) (d1, d2) -> d1.getDescription().compareToIgnoreCase(d2.getDescription()));
         sorter.setComparator(STATE_COLUMN, Comparator.comparing(Download::getState));
         sorter.setComparator(SIZE_COLUMN, new Comparator<Download>() {
             private long getSize(Download download) {
@@ -111,10 +112,12 @@ public class DownloadsDialog extends SimpleDialog {
             }
         });
         sorter.setComparator(DATE_COLUMN, (Comparator<Download>) (d1, d2) -> {
-            if (d1.getLastModified() == null)
+            if (d1.getLastModified() == null) {
                 return -1;
-            if (d2.getLastModified() == null)
+            }
+            if (d2.getLastModified() == null) {
                 return 1;
+            }
             return d1.getLastModified().getCalendar().compareTo(d2.getLastModified().getCalendar());
         });
         tableDownloads.setRowSorter(sorter);
@@ -177,44 +180,64 @@ public class DownloadsDialog extends SimpleDialog {
      */
     private void $$$setupUI$$$() {
         contentPane = new JPanel();
-        contentPane.setLayout(new GridLayoutManager(4, 1, new Insets(10, 10, 10, 10), -1, -1));
+        contentPane.setLayout(new GridLayoutManager(3, 1, new Insets(10, 10, 10, 10), -1, -1));
         final JLabel label1 = new JLabel();
-        this.$$$loadLabelText$$$(label1, this.$$$getMessageFromBundle$$$("slash/navigation/converter/gui/RouteConverter", "downloads-colon"));
-        contentPane.add(label1, new GridConstraints(0, 0, 1, 1, GridConstraints.ANCHOR_WEST, GridConstraints.FILL_NONE, GridConstraints.SIZEPOLICY_FIXED, GridConstraints.SIZEPOLICY_FIXED, null, null, null, 0, false));
+        this.$$$loadLabelText$$$(label1,
+                this.$$$getMessageFromBundle$$$("slash/navigation/converter/gui/RouteConverter", "downloads-colon"));
+        contentPane.add(label1,
+                new GridConstraints(0, 0, 1, 1, GridConstraints.ANCHOR_WEST, GridConstraints.FILL_NONE, GridConstraints.SIZEPOLICY_FIXED,
+                        GridConstraints.SIZEPOLICY_FIXED, null, null, null, 0, false));
         final JScrollPane scrollPane1 = new JScrollPane();
-        contentPane.add(scrollPane1, new GridConstraints(1, 0, 1, 1, GridConstraints.ANCHOR_CENTER, GridConstraints.FILL_BOTH, GridConstraints.SIZEPOLICY_CAN_SHRINK | GridConstraints.SIZEPOLICY_WANT_GROW, GridConstraints.SIZEPOLICY_CAN_SHRINK | GridConstraints.SIZEPOLICY_WANT_GROW, null, null, null, 0, false));
+        contentPane.add(scrollPane1, new GridConstraints(1, 0, 1, 1, GridConstraints.ANCHOR_CENTER, GridConstraints.FILL_BOTH,
+                GridConstraints.SIZEPOLICY_CAN_SHRINK | GridConstraints.SIZEPOLICY_WANT_GROW,
+                GridConstraints.SIZEPOLICY_CAN_SHRINK | GridConstraints.SIZEPOLICY_WANT_GROW, null, null, null, 0, false));
         tableDownloads = new JTable();
         tableDownloads.setPreferredScrollableViewportSize(new Dimension(550, 400));
         tableDownloads.setShowHorizontalLines(false);
         tableDownloads.setShowVerticalLines(false);
         scrollPane1.setViewportView(tableDownloads);
         final JPanel panel1 = new JPanel();
-        panel1.setLayout(new GridLayoutManager(1, 2, new Insets(2, 0, 1, 0), -1, -1));
-        contentPane.add(panel1, new GridConstraints(3, 0, 1, 1, GridConstraints.ANCHOR_CENTER, GridConstraints.FILL_BOTH, GridConstraints.SIZEPOLICY_CAN_SHRINK | GridConstraints.SIZEPOLICY_CAN_GROW, GridConstraints.SIZEPOLICY_CAN_SHRINK | GridConstraints.SIZEPOLICY_CAN_GROW, null, null, null, 0, false));
+        panel1.setLayout(new GridLayoutManager(1, 6, new Insets(2, 0, 1, 0), -1, -1));
+        contentPane.add(panel1, new GridConstraints(2, 0, 1, 1, GridConstraints.ANCHOR_CENTER, GridConstraints.FILL_BOTH,
+                GridConstraints.SIZEPOLICY_CAN_SHRINK | GridConstraints.SIZEPOLICY_CAN_GROW,
+                GridConstraints.SIZEPOLICY_CAN_SHRINK | GridConstraints.SIZEPOLICY_CAN_GROW, null, null, null, 0, false));
+        buttonHelp = new JButton();
+        buttonHelp.setText("?");
+        panel1.add(buttonHelp,
+                new GridConstraints(0, 0, 1, 1, GridConstraints.ANCHOR_WEST, GridConstraints.FILL_NONE, GridConstraints.SIZEPOLICY_FIXED,
+                        GridConstraints.SIZEPOLICY_FIXED, null, null, null, 0, false));
+        buttonRestart = new JButton();
+        this.$$$loadButtonText$$$(buttonRestart,
+                this.$$$getMessageFromBundle$$$("slash/navigation/converter/gui/RouteConverter", "restart-download-action"));
+        buttonRestart.setToolTipText(
+                this.$$$getMessageFromBundle$$$("slash/navigation/converter/gui/RouteConverter", "restart-download-action-tooltip"));
+        panel1.add(buttonRestart, new GridConstraints(0, 1, 1, 1, GridConstraints.ANCHOR_CENTER, GridConstraints.FILL_HORIZONTAL,
+                GridConstraints.SIZEPOLICY_CAN_SHRINK | GridConstraints.SIZEPOLICY_CAN_GROW, GridConstraints.SIZEPOLICY_FIXED, null, null,
+                null, 0, false));
+        buttonStop = new JButton();
+        this.$$$loadButtonText$$$(buttonStop,
+                this.$$$getMessageFromBundle$$$("slash/navigation/converter/gui/RouteConverter", "stop-download-action"));
+        buttonStop.setToolTipText(
+                this.$$$getMessageFromBundle$$$("slash/navigation/converter/gui/RouteConverter", "stop-download-action-tooltip"));
+        panel1.add(buttonStop, new GridConstraints(0, 2, 1, 1, GridConstraints.ANCHOR_CENTER, GridConstraints.FILL_HORIZONTAL,
+                GridConstraints.SIZEPOLICY_CAN_SHRINK | GridConstraints.SIZEPOLICY_CAN_GROW, GridConstraints.SIZEPOLICY_FIXED, null, null,
+                null, 0, false));
+        buttonRemove = new JButton();
+        this.$$$loadButtonText$$$(buttonRemove,
+                this.$$$getMessageFromBundle$$$("slash/navigation/converter/gui/RouteConverter", "remove-download-action"));
+        buttonRemove.setToolTipText(
+                this.$$$getMessageFromBundle$$$("slash/navigation/converter/gui/RouteConverter", "remove-download-action-tooltip"));
+        panel1.add(buttonRemove, new GridConstraints(0, 3, 1, 1, GridConstraints.ANCHOR_CENTER, GridConstraints.FILL_HORIZONTAL,
+                GridConstraints.SIZEPOLICY_CAN_SHRINK | GridConstraints.SIZEPOLICY_CAN_GROW, GridConstraints.SIZEPOLICY_FIXED, null, null,
+                null, 0, false));
+        final Spacer spacer1 = new Spacer();
+        panel1.add(spacer1, new GridConstraints(0, 4, 1, 1, GridConstraints.ANCHOR_CENTER, GridConstraints.FILL_HORIZONTAL,
+                GridConstraints.SIZEPOLICY_WANT_GROW, 1, null, null, null, 0, false));
         buttonClose = new JButton();
         this.$$$loadButtonText$$$(buttonClose, this.$$$getMessageFromBundle$$$("slash/navigation/converter/gui/RouteConverter", "close"));
-        panel1.add(buttonClose, new GridConstraints(0, 1, 1, 1, GridConstraints.ANCHOR_CENTER, GridConstraints.FILL_NONE, GridConstraints.SIZEPOLICY_CAN_SHRINK | GridConstraints.SIZEPOLICY_CAN_GROW, GridConstraints.SIZEPOLICY_FIXED, null, null, null, 0, false));
-        final Spacer spacer1 = new Spacer();
-        panel1.add(spacer1, new GridConstraints(0, 0, 1, 1, GridConstraints.ANCHOR_CENTER, GridConstraints.FILL_HORIZONTAL, GridConstraints.SIZEPOLICY_WANT_GROW, 1, null, null, null, 0, false));
-        final JPanel panel2 = new JPanel();
-        panel2.setLayout(new GridLayoutManager(1, 5, new Insets(0, 0, 0, 0), -1, -1));
-        contentPane.add(panel2, new GridConstraints(2, 0, 1, 1, GridConstraints.ANCHOR_CENTER, GridConstraints.FILL_BOTH, GridConstraints.SIZEPOLICY_CAN_SHRINK | GridConstraints.SIZEPOLICY_CAN_GROW, GridConstraints.SIZEPOLICY_CAN_SHRINK | GridConstraints.SIZEPOLICY_CAN_GROW, null, null, null, 0, false));
-        buttonHelp = BaseRouteConverter.getInstance().getContext().getHelpManager().helpButton(contentPane);
-        panel2.add(buttonHelp, new GridConstraints(0, 0, 1, 1, GridConstraints.ANCHOR_WEST, GridConstraints.FILL_NONE, GridConstraints.SIZEPOLICY_FIXED, GridConstraints.SIZEPOLICY_FIXED, null, null, null, 0, false));
-        buttonRestart = new JButton();
-        this.$$$loadButtonText$$$(buttonRestart, this.$$$getMessageFromBundle$$$("slash/navigation/converter/gui/RouteConverter", "restart-download-action"));
-        buttonRestart.setToolTipText(this.$$$getMessageFromBundle$$$("slash/navigation/converter/gui/RouteConverter", "restart-download-action-tooltip"));
-        panel2.add(buttonRestart, new GridConstraints(0, 1, 1, 1, GridConstraints.ANCHOR_CENTER, GridConstraints.FILL_HORIZONTAL, GridConstraints.SIZEPOLICY_CAN_SHRINK | GridConstraints.SIZEPOLICY_CAN_GROW, GridConstraints.SIZEPOLICY_FIXED, null, null, null, 0, false));
-        buttonStop = new JButton();
-        this.$$$loadButtonText$$$(buttonStop, this.$$$getMessageFromBundle$$$("slash/navigation/converter/gui/RouteConverter", "stop-download-action"));
-        buttonStop.setToolTipText(this.$$$getMessageFromBundle$$$("slash/navigation/converter/gui/RouteConverter", "stop-download-action-tooltip"));
-        panel2.add(buttonStop, new GridConstraints(0, 2, 1, 1, GridConstraints.ANCHOR_CENTER, GridConstraints.FILL_HORIZONTAL, GridConstraints.SIZEPOLICY_CAN_SHRINK | GridConstraints.SIZEPOLICY_CAN_GROW, GridConstraints.SIZEPOLICY_FIXED, null, null, null, 0, false));
-        final Spacer spacer2 = new Spacer();
-        panel2.add(spacer2, new GridConstraints(0, 4, 1, 1, GridConstraints.ANCHOR_CENTER, GridConstraints.FILL_HORIZONTAL, GridConstraints.SIZEPOLICY_WANT_GROW, 1, null, null, null, 0, false));
-        buttonRemove = new JButton();
-        this.$$$loadButtonText$$$(buttonRemove, this.$$$getMessageFromBundle$$$("slash/navigation/converter/gui/RouteConverter", "remove-download-action"));
-        buttonRemove.setToolTipText(this.$$$getMessageFromBundle$$$("slash/navigation/converter/gui/RouteConverter", "remove-download-action-tooltip"));
-        panel2.add(buttonRemove, new GridConstraints(0, 3, 1, 1, GridConstraints.ANCHOR_CENTER, GridConstraints.FILL_HORIZONTAL, GridConstraints.SIZEPOLICY_CAN_SHRINK | GridConstraints.SIZEPOLICY_CAN_GROW, GridConstraints.SIZEPOLICY_FIXED, null, null, null, 0, false));
+        panel1.add(buttonClose, new GridConstraints(0, 5, 1, 1, GridConstraints.ANCHOR_CENTER, GridConstraints.FILL_NONE,
+                GridConstraints.SIZEPOLICY_CAN_SHRINK | GridConstraints.SIZEPOLICY_CAN_GROW, GridConstraints.SIZEPOLICY_FIXED, null, null,
+                null, 0, false));
     }
 
     private static Method $$$cachedGetBundleMethod$$$ = null;
@@ -248,7 +271,9 @@ public class DownloadsDialog extends SimpleDialog {
         for (int i = 0; i < text.length(); i++) {
             if (text.charAt(i) == '&') {
                 i++;
-                if (i == text.length()) break;
+                if (i == text.length()) {
+                    break;
+                }
                 if (!haveMnemonic && text.charAt(i) != '&') {
                     haveMnemonic = true;
                     mnemonic = text.charAt(i);
@@ -275,7 +300,9 @@ public class DownloadsDialog extends SimpleDialog {
         for (int i = 0; i < text.length(); i++) {
             if (text.charAt(i) == '&') {
                 i++;
-                if (i == text.length()) break;
+                if (i == text.length()) {
+                    break;
+                }
                 if (!haveMnemonic && text.charAt(i) != '&') {
                     haveMnemonic = true;
                     mnemonic = text.charAt(i);

--- a/route-converter-gui/src/main/java/slash/navigation/converter/gui/dialogs/FindPlaceDialog.java
+++ b/route-converter-gui/src/main/java/slash/navigation/converter/gui/dialogs/FindPlaceDialog.java
@@ -302,7 +302,8 @@ public class FindPlaceDialog extends SimpleDialog {
         final JPanel panel3 = new JPanel();
         panel3.setLayout(new GridLayoutManager(1, 3, new Insets(0, 0, 0, 0), -1, -1));
         panel1.add(panel3, new GridConstraints(2, 0, 1, 1, GridConstraints.ANCHOR_CENTER, GridConstraints.FILL_BOTH, GridConstraints.SIZEPOLICY_CAN_SHRINK | GridConstraints.SIZEPOLICY_CAN_GROW, GridConstraints.SIZEPOLICY_CAN_SHRINK | GridConstraints.SIZEPOLICY_CAN_GROW, null, null, null, 0, false));
-        buttonHelp = BaseRouteConverter.getInstance().getContext().getHelpManager().helpButton(contentPane);
+        buttonHelp = new JButton();
+        buttonHelp.setText("?");
         panel3.add(buttonHelp, new GridConstraints(0, 0, 1, 1, GridConstraints.ANCHOR_WEST, GridConstraints.FILL_NONE, GridConstraints.SIZEPOLICY_FIXED, GridConstraints.SIZEPOLICY_FIXED, null, null, null, 0, false));
         final Spacer spacer1 = new Spacer();
         panel3.add(spacer1, new GridConstraints(0, 1, 1, 1, GridConstraints.ANCHOR_CENTER, GridConstraints.FILL_HORIZONTAL, GridConstraints.SIZEPOLICY_WANT_GROW, 1, null, null, null, 0, false));

--- a/route-converter-gui/src/main/java/slash/navigation/converter/gui/dialogs/InsertPositionsDialog.java
+++ b/route-converter-gui/src/main/java/slash/navigation/converter/gui/dialogs/InsertPositionsDialog.java
@@ -280,7 +280,8 @@ public class InsertPositionsDialog extends SimpleDialog {
         final JPanel panelHelp = new JPanel();
         panelHelp.setLayout(new FlowLayout(FlowLayout.LEFT, 5, 5));
         panel1.add(panelHelp, new GridConstraints(3, 0, 1, 1, GridConstraints.ANCHOR_CENTER, GridConstraints.FILL_BOTH, GridConstraints.SIZEPOLICY_CAN_SHRINK | GridConstraints.SIZEPOLICY_CAN_GROW, GridConstraints.SIZEPOLICY_CAN_SHRINK | GridConstraints.SIZEPOLICY_CAN_GROW, null, null, null, 0, false));
-        buttonHelp = BaseRouteConverter.getInstance().getContext().getHelpManager().helpButton(contentPane);
+        buttonHelp = new JButton();
+        buttonHelp.setText("?");
         panelHelp.add(buttonHelp);
     }
 

--- a/route-converter-gui/src/main/java/slash/navigation/converter/gui/dialogs/LoginDialog.java
+++ b/route-converter-gui/src/main/java/slash/navigation/converter/gui/dialogs/LoginDialog.java
@@ -290,7 +290,8 @@ public class LoginDialog extends SimpleDialog {
         final JPanel panelHelp = new JPanel();
         panelHelp.setLayout(new FlowLayout(FlowLayout.LEFT, 5, 5));
         contentPane.add(panelHelp, new GridConstraints(1, 0, 1, 1, GridConstraints.ANCHOR_CENTER, GridConstraints.FILL_BOTH, GridConstraints.SIZEPOLICY_CAN_SHRINK | GridConstraints.SIZEPOLICY_CAN_GROW, GridConstraints.SIZEPOLICY_FIXED, null, null, null, 0, false));
-        buttonHelp = BaseRouteConverter.getInstance().getContext().getHelpManager().helpButton(contentPane);
+        buttonHelp = new JButton();
+        buttonHelp.setText("?");
         panelHelp.add(buttonHelp);
         final JPanel panel1 = new JPanel();
         panel1.setLayout(new GridLayoutManager(6, 2, new Insets(10, 10, 10, 10), -1, -1));

--- a/route-converter-gui/src/main/java/slash/navigation/converter/gui/dialogs/MaximumPositionCountDialog.java
+++ b/route-converter-gui/src/main/java/slash/navigation/converter/gui/dialogs/MaximumPositionCountDialog.java
@@ -134,7 +134,8 @@ public class MaximumPositionCountDialog extends SimpleDialog {
         contentPane.add(panel1, new GridConstraints(0, 0, 1, 1, GridConstraints.ANCHOR_CENTER, GridConstraints.FILL_BOTH, GridConstraints.SIZEPOLICY_CAN_SHRINK | GridConstraints.SIZEPOLICY_CAN_GROW, GridConstraints.SIZEPOLICY_CAN_SHRINK | GridConstraints.SIZEPOLICY_CAN_GROW, null, null, null, 0, false));
         labelDescription = new JLabel();
         panel1.add(labelDescription, new GridConstraints(0, 0, 1, 5, GridConstraints.ANCHOR_WEST, GridConstraints.FILL_NONE, GridConstraints.SIZEPOLICY_CAN_SHRINK | GridConstraints.SIZEPOLICY_WANT_GROW, GridConstraints.SIZEPOLICY_FIXED, new Dimension(300, -1), null, null, 1, false));
-        buttonHelp = BaseRouteConverter.getInstance().getContext().getHelpManager().helpButton(contentPane);
+        buttonHelp = new JButton();
+        buttonHelp.setText("?");
         panel1.add(buttonHelp, new GridConstraints(1, 0, 1, 1, GridConstraints.ANCHOR_WEST, GridConstraints.FILL_NONE, GridConstraints.SIZEPOLICY_FIXED, GridConstraints.SIZEPOLICY_FIXED, null, null, null, 0, false));
         buttonSplit = new JButton();
         this.$$$loadButtonText$$$(buttonSplit, this.$$$getMessageFromBundle$$$("slash/navigation/converter/gui/RouteConverter", "split"));

--- a/route-converter-gui/src/main/java/slash/navigation/converter/gui/dialogs/OptionsDialog.java
+++ b/route-converter-gui/src/main/java/slash/navigation/converter/gui/dialogs/OptionsDialog.java
@@ -785,7 +785,8 @@ public class OptionsDialog extends SimpleDialog {
         final JPanel panel1 = new JPanel();
         panel1.setLayout(new GridLayoutManager(1, 3, new Insets(3, 3, 0, 3), -1, -1));
         contentPane.add(panel1, new GridConstraints(1, 0, 1, 1, GridConstraints.ANCHOR_NORTH, GridConstraints.FILL_HORIZONTAL, GridConstraints.SIZEPOLICY_CAN_SHRINK | GridConstraints.SIZEPOLICY_CAN_GROW, GridConstraints.SIZEPOLICY_FIXED, null, null, null, 0, false));
-        buttonHelp = BaseRouteConverter.getInstance().getContext().getHelpManager().helpButton(contentPane);
+        buttonHelp = new JButton();
+        buttonHelp.setText("?");
         panel1.add(buttonHelp, new GridConstraints(0, 0, 1, 1, GridConstraints.ANCHOR_WEST, GridConstraints.FILL_NONE, GridConstraints.SIZEPOLICY_FIXED, GridConstraints.SIZEPOLICY_FIXED, null, null, null, 0, false));
         final Spacer spacer1 = new Spacer();
         panel1.add(spacer1, new GridConstraints(0, 1, 1, 1, GridConstraints.ANCHOR_CENTER, GridConstraints.FILL_HORIZONTAL, GridConstraints.SIZEPOLICY_WANT_GROW, 1, null, null, null, 0, false));

--- a/route-converter-gui/src/main/java/slash/navigation/converter/gui/dialogs/RenameDialog.java
+++ b/route-converter-gui/src/main/java/slash/navigation/converter/gui/dialogs/RenameDialog.java
@@ -143,7 +143,8 @@ public class RenameDialog extends SimpleDialog {
         final JPanel panel2 = new JPanel();
         panel2.setLayout(new GridLayoutManager(1, 4, new Insets(0, 0, 0, 0), -1, -1));
         panel1.add(panel2, new GridConstraints(0, 0, 1, 1, GridConstraints.ANCHOR_CENTER, GridConstraints.FILL_BOTH, GridConstraints.SIZEPOLICY_CAN_SHRINK | GridConstraints.SIZEPOLICY_CAN_GROW, GridConstraints.SIZEPOLICY_CAN_SHRINK | GridConstraints.SIZEPOLICY_CAN_GROW, null, null, null, 0, false));
-        buttonHelp = BaseRouteConverter.getInstance().getContext().getHelpManager().helpButton(contentPane);
+        buttonHelp = new JButton();
+        buttonHelp.setText("?");
         panel2.add(buttonHelp, new GridConstraints(0, 0, 1, 1, GridConstraints.ANCHOR_WEST, GridConstraints.FILL_NONE, GridConstraints.SIZEPOLICY_FIXED, GridConstraints.SIZEPOLICY_FIXED, null, null, null, 0, false));
         buttonRename = new JButton();
         this.$$$loadButtonText$$$(buttonRename, this.$$$getMessageFromBundle$$$("slash/navigation/converter/gui/RouteConverter", "rename"));

--- a/route-converter-gui/src/main/java/slash/navigation/converter/gui/dialogs/SendErrorReportDialog.java
+++ b/route-converter-gui/src/main/java/slash/navigation/converter/gui/dialogs/SendErrorReportDialog.java
@@ -189,7 +189,8 @@ public class SendErrorReportDialog extends SimpleDialog {
         final JPanel panel2 = new JPanel();
         panel2.setLayout(new GridLayoutManager(1, 5, new Insets(0, 0, 0, 0), -1, -1));
         panel1.add(panel2, new GridConstraints(0, 0, 1, 1, GridConstraints.ANCHOR_CENTER, GridConstraints.FILL_BOTH, GridConstraints.SIZEPOLICY_CAN_SHRINK | GridConstraints.SIZEPOLICY_CAN_GROW, GridConstraints.SIZEPOLICY_CAN_SHRINK | GridConstraints.SIZEPOLICY_CAN_GROW, null, null, null, 0, false));
-        buttonHelp = BaseRouteConverter.getInstance().getContext().getHelpManager().helpButton(contentPane);
+        buttonHelp = new JButton();
+        buttonHelp.setText("?");
         panel2.add(buttonHelp, new GridConstraints(0, 0, 1, 1, GridConstraints.ANCHOR_WEST, GridConstraints.FILL_NONE, GridConstraints.SIZEPOLICY_FIXED, GridConstraints.SIZEPOLICY_FIXED, null, null, null, 0, false));
         buttonSend = new JButton();
         this.$$$loadButtonText$$$(buttonSend, this.$$$getMessageFromBundle$$$("slash/navigation/converter/gui/RouteConverter", "send"));

--- a/route-converter/src/main/java/slash/navigation/converter/gui/dialogs/MapsDialog.java
+++ b/route-converter/src/main/java/slash/navigation/converter/gui/dialogs/MapsDialog.java
@@ -322,7 +322,8 @@ public class MapsDialog extends SimpleDialog {
         final JPanel panel1 = new JPanel();
         panel1.setLayout(new GridLayoutManager(1, 3, new Insets(0, 0, 0, 0), -1, -1));
         contentPane.add(panel1, new GridConstraints(3, 0, 1, 1, GridConstraints.ANCHOR_CENTER, GridConstraints.FILL_BOTH, GridConstraints.SIZEPOLICY_CAN_SHRINK | GridConstraints.SIZEPOLICY_CAN_GROW, 1, null, null, null, 0, false));
-        buttonHelp = BaseRouteConverter.getInstance().getContext().getHelpManager().helpButton(contentPane);
+        buttonHelp = new JButton();
+        buttonHelp.setText("?");
         panel1.add(buttonHelp, new GridConstraints(0, 0, 1, 1, GridConstraints.ANCHOR_WEST, GridConstraints.FILL_NONE, GridConstraints.SIZEPOLICY_FIXED, GridConstraints.SIZEPOLICY_FIXED, null, null, null, 0, false));
         final Spacer spacer1 = new Spacer();
         panel1.add(spacer1, new GridConstraints(0, 1, 1, 1, GridConstraints.ANCHOR_CENTER, GridConstraints.FILL_HORIZONTAL, GridConstraints.SIZEPOLICY_WANT_GROW, 1, null, null, null, 0, false));

--- a/route-converter/src/main/java/slash/navigation/converter/gui/dialogs/ThemeStyleDialog.java
+++ b/route-converter/src/main/java/slash/navigation/converter/gui/dialogs/ThemeStyleDialog.java
@@ -142,7 +142,8 @@ public class ThemeStyleDialog extends SimpleDialog {
         final JPanel panel1 = new JPanel();
         panel1.setLayout(new GridLayoutManager(1, 3, new Insets(0, 0, 0, 0), -1, -1));
         contentPane.add(panel1, new GridConstraints(2, 0, 1, 2, GridConstraints.ANCHOR_CENTER, GridConstraints.FILL_BOTH, GridConstraints.SIZEPOLICY_CAN_SHRINK | GridConstraints.SIZEPOLICY_CAN_GROW, GridConstraints.SIZEPOLICY_CAN_SHRINK | GridConstraints.SIZEPOLICY_CAN_GROW, null, null, null, 0, false));
-        buttonHelp = BaseRouteConverter.getInstance().getContext().getHelpManager().helpButton(contentPane);
+        buttonHelp = new JButton();
+        buttonHelp.setText("?");
         panel1.add(buttonHelp, new GridConstraints(0, 0, 1, 1, GridConstraints.ANCHOR_WEST, GridConstraints.FILL_NONE, GridConstraints.SIZEPOLICY_FIXED, GridConstraints.SIZEPOLICY_FIXED, null, null, null, 0, false));
         final Spacer spacer1 = new Spacer();
         panel1.add(spacer1, new GridConstraints(0, 1, 1, 1, GridConstraints.ANCHOR_CENTER, GridConstraints.FILL_HORIZONTAL, GridConstraints.SIZEPOLICY_WANT_GROW, 1, null, null, null, 0, false));

--- a/route-converter/src/main/java/slash/navigation/converter/gui/dialogs/ThemesDialog.java
+++ b/route-converter/src/main/java/slash/navigation/converter/gui/dialogs/ThemesDialog.java
@@ -230,7 +230,8 @@ public class ThemesDialog extends SimpleDialog {
         final JPanel panel6 = new JPanel();
         panel6.setLayout(new GridLayoutManager(1, 4, new Insets(0, 0, 0, 0), -1, -1));
         contentPane.add(panel6, new GridConstraints(3, 0, 1, 1, GridConstraints.ANCHOR_CENTER, GridConstraints.FILL_BOTH, GridConstraints.SIZEPOLICY_CAN_SHRINK | GridConstraints.SIZEPOLICY_CAN_GROW, GridConstraints.SIZEPOLICY_CAN_SHRINK | GridConstraints.SIZEPOLICY_CAN_GROW, null, null, null, 0, false));
-        buttonHelp = BaseRouteConverter.getInstance().getContext().getHelpManager().helpButton(contentPane);
+        buttonHelp = new JButton();
+        buttonHelp.setText("?");
         panel6.add(buttonHelp, new GridConstraints(0, 0, 1, 1, GridConstraints.ANCHOR_WEST, GridConstraints.FILL_NONE, GridConstraints.SIZEPOLICY_FIXED, GridConstraints.SIZEPOLICY_FIXED, null, null, null, 0, false));
         buttonDownload = new JButton();
         this.$$$loadButtonText$$$(buttonDownload, this.$$$getMessageFromBundle$$$("slash/navigation/converter/gui/RouteConverter", "download-maps-action"));


### PR DESCRIPTION
## Problem

Every dialog wired its help button *inside* the GUI Designer generated `$$$setupUI$$$`:

```java
buttonHelp = BaseRouteConverter.getInstance().getContext().getHelpManager().helpButton(contentPane);
```

That method is regenerated from the `.form` whenever the form is touched in the IDE, and regeneration replaces the call with a plain `new JButton()` + `setText("?")` — no listener. DownloadsDialog is where it happened: the `?` button was dead, and F1 was the only way to reach the topic.

## Fix

`SimpleDialog.setContentPane` walks the content pane and hands every still-unwired `JButton` labelled `"?"` to the new `HelpManager.registerHelpButton(button, owner)`. Every dialog already calls `setContentPane(contentPane)` in its constructor, so all 18 forms are covered, the hook lives outside the generated method, and a new dialog needs nothing beyond the button in its form.

The follow-up commit drops the now-redundant `helpButton(contentPane)` call from all 17 remaining dialogs' generated methods, so no generated code carries wiring any more. `HelpManager.helpButton` goes away with its last call site; `registerHelpButton` replaces it.

The topic id still comes from the dialog's `getName()` via `HelpManager.resolveTopicId`, so each dialog opens its own page rather than the help contents.

DownloadsDialog additionally gets its buttons into a single row (`?` left, `Schließen` right) instead of the `?`/restart/stop/remove row plus a separate `Schließen` row.

## Verification

Ran the GUI with `-Dhelp.dryRun=true` and clicked each dialog's `?` from an injected agent:

```
downloads listeners=1  → https://www.routeconverter.de/help/downloads/
options   listeners=1  → https://www.routeconverter.de/help/options/
themes    listeners=1  → https://www.routeconverter.de/help/themes/
style     listeners=1  → https://www.routeconverter.de/help/style/
about     listeners=1  → https://www.routeconverter.de/help/about/
```

One button, one listener, one browser open per click — the `getActionListeners().length == 0` guard means a dialog that wires its own button is left alone. Downloads button row measured live: all five buttons at the same `y`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
