### PR TITLE
fix: F1 over an open menu resolves the focused panel, never the menu item

### DIFF
--- a/common-gui/src/main/java/slash/navigation/gui/HelpManager.java
+++ b/common-gui/src/main/java/slash/navigation/gui/HelpManager.java
@@ -75,9 +75,32 @@ public class HelpManager {
         Toolkit.getDefaultToolkit().addAWTEventListener(event -> {
             if (!(event instanceof java.awt.event.KeyEvent ke)) return;
             if (ke.getID() != KEY_PRESSED || ke.getKeyCode() != VK_F1) return;
-            openTopicForComponent(ke.getComponent());
+            String topic = resolveMenuTopicId(MenuSelectionManager.defaultManager().getSelectedPath());
+            if (topic != null) openTopic(topic);
+            else openTopicForComponent(ke.getComponent());
             ke.consume();
         }, KEY_EVENT_MASK);
+    }
+
+    /**
+     * Resolves the help topic id of the currently highlighted menu item. Swing popup menus are
+     * non-focusable, so while a menu is open focus stays on the invoker and the {@code F1} path
+     * would otherwise resolve the focused panel instead of the highlighted item. The
+     * {@link MenuSelectionManager} holds the selected menu path independently of focus.
+     * <p>
+     * Returns {@code null} when the path is empty or holds no usable leaf item, so a non-leaf
+     * selection falls through to the focus-owner path rather than resolving a container (e.g.
+     * {@code file}) that has no page.
+     */
+    static String resolveMenuTopicId(MenuElement[] path) {
+        if (path == null) return null;
+        for (int i = path.length - 1; i >= 0; i--) {
+            Component component = path[i].getComponent();
+            if (!(component instanceof JMenuItem) || component instanceof JMenu) continue;
+            String name = component.getName();
+            if (name != null && !name.isEmpty() && !isSyntheticName(name)) return name;
+        }
+        return null;
     }
 
     /**

--- a/common-gui/src/test/java/slash/navigation/gui/HelpManagerTest.java
+++ b/common-gui/src/test/java/slash/navigation/gui/HelpManagerTest.java
@@ -101,4 +101,85 @@ public class HelpManagerTest {
 
         assertEquals("options", HelpManager.resolveTopicId(button));
     }
+
+    @Test
+    public void realMenuPathResolvesToHighlightedItem() {
+        JMenuBar bar = new JMenuBar();
+        JMenu file = new JMenu();
+        file.setName("file");
+        JPopupMenu popup = new JPopupMenu();
+        JMenuItem open = new JMenuItem();
+        open.setName("open");
+
+        assertEquals("open", HelpManager.resolveMenuTopicId(path(bar, file, popup, open)));
+    }
+
+    @Test
+    public void menuPathEndingAtMenuReturnsNull() {
+        JMenuBar bar = new JMenuBar();
+        JMenu file = new JMenu();
+        file.setName("file");
+
+        assertNull(HelpManager.resolveMenuTopicId(path(bar, file)));
+    }
+
+    @Test
+    public void menuPathEndingAtPopupMenuReturnsNull() {
+        JMenuBar bar = new JMenuBar();
+        JMenu file = new JMenu();
+        file.setName("file");
+        JPopupMenu popup = new JPopupMenu();
+
+        assertNull(HelpManager.resolveMenuTopicId(path(bar, file, popup)));
+    }
+
+    @Test
+    public void unnamedLeafWithNamedMenuEarlierReturnsNull() {
+        JMenuBar bar = new JMenuBar();
+        JMenu file = new JMenu();
+        file.setName("file");
+        JPopupMenu popup = new JPopupMenu();
+        JMenuItem unnamed = new JMenuItem();
+
+        assertNull(HelpManager.resolveMenuTopicId(path(bar, file, popup, unnamed)));
+    }
+
+    @Test
+    public void twoLeafItemsResolveToLast() {
+        JMenuBar bar = new JMenuBar();
+        JMenu file = new JMenu();
+        file.setName("file");
+        JPopupMenu popup = new JPopupMenu();
+        JMenuItem first = new JMenuItem();
+        first.setName("first");
+        JMenuItem last = new JMenuItem();
+        last.setName("last");
+
+        assertEquals("last", HelpManager.resolveMenuTopicId(path(bar, file, popup, first, last)));
+    }
+
+    @Test
+    public void nullAndEmptyPathsReturnNull() {
+        assertNull(HelpManager.resolveMenuTopicId(null));
+        assertNull(HelpManager.resolveMenuTopicId(new MenuElement[0]));
+    }
+
+    @Test
+    public void syntheticLeafNameReturnsNull() {
+        JMenuBar bar = new JMenuBar();
+        JMenu file = new JMenu();
+        file.setName("file");
+        JPopupMenu popup = new JPopupMenu();
+        JMenuItem synthetic = new JMenuItem();
+        synthetic.setName("some.dotted");
+
+        assertNull(HelpManager.resolveMenuTopicId(path(bar, file, popup, synthetic)));
+    }
+
+    private static MenuElement[] path(Component... components) {
+        MenuElement[] elements = new MenuElement[components.length];
+        for (int i = 0; i < components.length; i++)
+            elements[i] = (MenuElement) components[i];
+        return elements;
+    }
 }


### PR DESCRIPTION
Fixes #325

F1 now prefers the highlighted menu item via `MenuSelectionManager` before falling back to the focus owner. Adds `HelpManager.resolveMenuTopicId(MenuElement[])` (leaf `JMenuItem` only, back-to-front, skips `JMenu` containers and synthetic dot-names) and wires it into the F1 listener. Non-leaf selections fall through to the panel page as today.

`mvn -pl common-gui test` green (100 tests); full package green.