### PR TITLE
fix: IndexOutOfBoundsException when the position model shrinks during augmentation

### DIFF
--- a/common-gui/src/main/java/slash/navigation/gui/events/ContinousRange.java
+++ b/common-gui/src/main/java/slash/navigation/gui/events/ContinousRange.java
@@ -60,9 +60,9 @@ public class ContinousRange {
     private void perform(List<List<Integer>> ranges) {
         for (List<Integer> range : ranges) {
             for (Integer index : range) {
-                operation.performOnIndex(index);
                 if (operation.isInterrupted())
                     return;
+                operation.performOnIndex(index);
             }
             if (range.isEmpty())
                 continue;

--- a/common-gui/src/test/java/slash/navigation/gui/events/ContinousRangeTest.java
+++ b/common-gui/src/test/java/slash/navigation/gui/events/ContinousRangeTest.java
@@ -155,6 +155,74 @@ public class ContinousRangeTest {
         assertEquals(2, op.ranges.size());
     }
 
+    // --- interruption ---
+
+    private static class InterruptedOperation implements RangeOperation {
+        boolean interrupted;
+        final List<Integer> indices = new ArrayList<>();
+        final List<int[]> ranges = new ArrayList<>();
+
+        @Override
+        public void performOnIndex(int index) {
+            indices.add(index);
+        }
+
+        @Override
+        public void performOnRange(int firstIndex, int lastIndex) {
+            ranges.add(new int[]{firstIndex, lastIndex});
+        }
+
+        @Override
+        public boolean isInterrupted() {
+            return interrupted;
+        }
+    }
+
+    private static class FlippingOperation implements RangeOperation {
+        final int flipOnIndex;
+        boolean interrupted;
+        final List<Integer> indices = new ArrayList<>();
+        final List<int[]> ranges = new ArrayList<>();
+
+        FlippingOperation(int flipOnIndex) {
+            this.flipOnIndex = flipOnIndex;
+        }
+
+        @Override
+        public void performOnIndex(int index) {
+            indices.add(index);
+            if (index == flipOnIndex)
+                interrupted = true;
+        }
+
+        @Override
+        public void performOnRange(int firstIndex, int lastIndex) {
+            ranges.add(new int[]{firstIndex, lastIndex});
+        }
+
+        @Override
+        public boolean isInterrupted() {
+            return interrupted;
+        }
+    }
+
+    @Test
+    public void testInterruptedFromStartExecutesNothing() {
+        InterruptedOperation op = new InterruptedOperation();
+        op.interrupted = true;
+        new ContinousRange(new int[]{1, 2, 3}, op).performMonotonicallyIncreasing();
+        assertTrue(op.indices.isEmpty());
+        assertTrue(op.ranges.isEmpty());
+    }
+
+    @Test
+    public void testInterruptedDuringIndexExecutesUpToThatIndexOnly() {
+        FlippingOperation op = new FlippingOperation(2);
+        new ContinousRange(new int[]{0, 1, 2, 3, 4}, op).performMonotonicallyIncreasing();
+        assertEquals(List.of(0, 1, 2), op.indices);
+        assertTrue(op.ranges.isEmpty());
+    }
+
     // --- Range.allButEveryNthAndFirstAndLast ---
 
     @Test

--- a/route-converter-gui/src/main/java/slash/navigation/converter/gui/helpers/PositionAugmenter.java
+++ b/route-converter-gui/src/main/java/slash/navigation/converter/gui/helpers/PositionAugmenter.java
@@ -170,6 +170,7 @@ public class PositionAugmenter {
                     final int maximumRangeLength = rows.length > 99 ? rows.length / (slowOperation ? 100 : 10) : rows.length;
                     new ContinousRange(rows, new RangeOperation() {
                         public void performOnIndex(final int index) {
+                            if (index >= positionsModel.getRowCount()) return; // stale index after concurrent model change
                             NavigationPosition position = positionsModel.getPosition(index);
                             if (predicate.shouldOverwrite(position)) {
                                 try {


### PR DESCRIPTION
Fixes #327

Race between background augmentation and a concurrently shrinking positions model. `ContinousRange.perform` now checks `isInterrupted()` before each `performOnIndex` (was after), and `PositionAugmenter`'s `performOnIndex` silently skips a stale index beyond the current row count.

`mvn -pl common-gui test` green (95 tests); `mvn -pl route-converter-gui -am -Dskip.unit.tests -Dskip.integration.tests package` green.