### PR TITLE
Add UI font-size setting (positions table shrunk after uiScale=1.0 fix)

### DIFF
--- a/common-gui/src/main/java/slash/navigation/gui/helpers/UIHelper.java
+++ b/common-gui/src/main/java/slash/navigation/gui/helpers/UIHelper.java
@@ -20,6 +20,7 @@
 package slash.navigation.gui.helpers;
 
 import javax.swing.*;
+import javax.swing.plaf.FontUIResource;
 import java.awt.*;
 import java.io.File;
 import java.util.MissingResourceException;
@@ -41,6 +42,25 @@ import static slash.common.system.Platform.*;
 public class UIHelper {
     private static final Preferences preferences = userNodeForPackage(UIHelper.class);
     private static final String LOOK_AND_FEEL_CLASS_PREFERENCE = "lookAndFeelClass";
+    private static final String UI_FONT_SCALE_PERCENTAGE_PREFERENCE = "uiFontScalePercentage";
+    private static final int DEFAULT_UI_FONT_SCALE_PERCENTAGE = 100;
+
+    public static int getUiFontScalePercentage() {
+        return preferences.getInt(UI_FONT_SCALE_PERCENTAGE_PREFERENCE, DEFAULT_UI_FONT_SCALE_PERCENTAGE);
+    }
+
+    public static void setUiFontScalePercentage(int percentage) {
+        preferences.putInt(UI_FONT_SCALE_PERCENTAGE_PREFERENCE, percentage);
+    }
+
+    public static Font scaleFont(Font font, int percentage) {
+        float newSize = Math.round(font.getSize2D() * percentage / 100f);
+        // Clamp to minimum of 1 to prevent invalid font size
+        if (newSize < 1) {
+            newSize = 1;
+        }
+        return font.deriveFont(newSize);
+    }
 
     public static void setLookAndFeel() {
         try {
@@ -48,6 +68,18 @@ public class UIHelper {
             if ("default".equals(lookAndFeelClass))
                 lookAndFeelClass = UIManager.getSystemLookAndFeelClassName();
             UIManager.setLookAndFeel(lookAndFeelClass);
+
+            int percentage = getUiFontScalePercentage();
+            if (percentage != DEFAULT_UI_FONT_SCALE_PERCENTAGE) {
+                UIDefaults defaults = UIManager.getLookAndFeelDefaults();
+                // Iterate over a copy of keySet to avoid ConcurrentModificationException
+                for (Object key : new java.util.Vector<>(defaults.keySet())) {
+                    Object value = defaults.get(key);
+                    if (value instanceof FontUIResource) {
+                        defaults.put(key, new FontUIResource(scaleFont((Font) value, percentage)));
+                    }
+                }
+            }
         } catch (Exception e) {
             // intentionally do nothing
         }

--- a/common-gui/src/test/java/slash/navigation/gui/helpers/UIHelperTest.java
+++ b/common-gui/src/test/java/slash/navigation/gui/helpers/UIHelperTest.java
@@ -1,0 +1,88 @@
+/*
+    This file is part of RouteConverter.
+
+    RouteConverter is free software; you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation; either version 2 of the License, or
+    (at your option) any later version.
+
+    RouteConverter is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with RouteConverter; if not, write to the Free Software
+    Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
+
+    Copyright (C) 2007 Christian Pesch. All Rights Reserved.
+*/
+package slash.navigation.gui.helpers;
+
+import org.junit.Test;
+
+import java.awt.Font;
+
+import static org.junit.Assert.assertEquals;
+
+/**
+ * Tests for {@link UIHelper}.
+ *
+ * @author Christian Pesch
+ */
+public class UIHelperTest {
+
+    @Test
+    public void testScaleFont100PercentReturnsSameSize() {
+        Font base = new Font("SansSerif", Font.PLAIN, 12);
+        Font result = UIHelper.scaleFont(base, 100);
+        assertEquals(12, result.getSize());
+        assertEquals("SansSerif", result.getFamily());
+        assertEquals(Font.PLAIN, result.getStyle());
+    }
+
+    @Test
+    public void testScaleFont150PercentIncreasesSize() {
+        Font base = new Font("SansSerif", Font.PLAIN, 12);
+        Font result = UIHelper.scaleFont(base, 150);
+        assertEquals(18, result.getSize());
+        assertEquals("SansSerif", result.getFamily());
+        assertEquals(Font.PLAIN, result.getStyle());
+    }
+
+    @Test
+    public void testScaleFont50PercentDecreasesSize() {
+        Font base = new Font("SansSerif", Font.PLAIN, 12);
+        Font result = UIHelper.scaleFont(base, 50);
+        assertEquals(6, result.getSize());
+        assertEquals("SansSerif", result.getFamily());
+        assertEquals(Font.PLAIN, result.getStyle());
+    }
+
+    @Test
+    public void testScaleFontRoundsToNearestInt() {
+        Font base = new Font("SansSerif", Font.PLAIN, 11);
+        Font result = UIHelper.scaleFont(base, 125);
+        assertEquals(14, result.getSize()); // 11 * 1.25 = 13.75 -> rounds to 14
+        assertEquals("SansSerif", result.getFamily());
+        assertEquals(Font.PLAIN, result.getStyle());
+    }
+
+    @Test
+    public void testScaleFontClampsToMinimumOnePoint() {
+        Font base = new Font("SansSerif", Font.PLAIN, 4);
+        Font result = UIHelper.scaleFont(base, 10);
+        assertEquals(1, result.getSize()); // 4 * 0.10 = 0.4 -> rounds to 0 -> clamped to 1
+        assertEquals("SansSerif", result.getFamily());
+        assertEquals(Font.PLAIN, result.getStyle());
+    }
+
+    @Test
+    public void testScaleFontPreservesFamilyAndStyle() {
+        Font base = new Font("Serif", Font.BOLD | Font.ITALIC, 12);
+        Font result = UIHelper.scaleFont(base, 150);
+        assertEquals(18, result.getSize());
+        assertEquals("Serif", result.getFamily());
+        assertEquals(Font.BOLD | Font.ITALIC, result.getStyle());
+    }
+}

--- a/route-converter-gui/src/main/java/slash/navigation/converter/gui/dialogs/OptionsDialog.form
+++ b/route-converter-gui/src/main/java/slash/navigation/converter/gui/dialogs/OptionsDialog.form
@@ -56,7 +56,7 @@
             <properties/>
             <border type="none"/>
             <children>
-              <grid id="5015e" layout-manager="GridLayoutManager" row-count="5" column-count="2" same-size-horizontally="false" same-size-vertically="false" hgap="-1" vgap="-1">
+              <grid id="5015e" layout-manager="GridLayoutManager" row-count="6" column-count="2" same-size-horizontally="false" same-size-vertically="false" hgap="-1" vgap="-1">
                 <margin top="3" left="3" bottom="3" right="3"/>
                 <constraints>
                   <grid row="0" column="0" row-span="1" col-span="1" vsize-policy="3" hsize-policy="3" anchor="0" fill="3" indent="0" use-parent-layout="false"/>
@@ -106,10 +106,24 @@
                     </constraints>
                     <properties/>
                   </component>
+                  <component id="dff3f" class="javax.swing.JLabel">
+                    <constraints>
+                      <grid row="4" column="0" row-span="1" col-span="1" vsize-policy="0" hsize-policy="0" anchor="8" fill="0" indent="0" use-parent-layout="false"/>
+                    </constraints>
+                    <properties>
+                      <text resource-bundle="slash/navigation/converter/gui/RouteConverter" key="ui-font-scale-option"/>
+                    </properties>
+                  </component>
+                  <component id="e7f8a" class="javax.swing.JSpinner" binding="spinnerUiFontScale">
+                    <constraints>
+                      <grid row="4" column="1" row-span="1" col-span="1" vsize-policy="0" hsize-policy="3" anchor="8" fill="0" indent="0" use-parent-layout="false"/>
+                    </constraints>
+                    <properties/>
+                  </component>
                   <grid id="4728" layout-manager="GridLayoutManager" row-count="1" column-count="1" same-size-horizontally="false" same-size-vertically="false" hgap="-1" vgap="-1">
                     <margin top="6" left="0" bottom="0" right="0"/>
                     <constraints>
-                      <grid row="4" column="0" row-span="1" col-span="2" vsize-policy="3" hsize-policy="3" anchor="0" fill="3" indent="0" use-parent-layout="false"/>
+                      <grid row="5" column="0" row-span="1" col-span="2" vsize-policy="3" hsize-policy="3" anchor="0" fill="3" indent="0" use-parent-layout="false"/>
                     </constraints>
                     <properties/>
                     <border type="none"/>

--- a/route-converter-gui/src/main/java/slash/navigation/converter/gui/dialogs/OptionsDialog.form
+++ b/route-converter-gui/src/main/java/slash/navigation/converter/gui/dialogs/OptionsDialog.form
@@ -92,29 +92,29 @@
                     </constraints>
                     <properties/>
                   </component>
-                  <component id="c1a5f" class="javax.swing.JLabel">
-                    <constraints>
-                      <grid row="3" column="0" row-span="1" col-span="1" vsize-policy="0" hsize-policy="0" anchor="8" fill="0" indent="0" use-parent-layout="false"/>
-                    </constraints>
-                    <properties>
-                      <text resource-bundle="slash/navigation/converter/gui/RouteConverter" key="send-crash-reports-option"/>
-                    </properties>
-                  </component>
-                  <component id="c1a60" class="javax.swing.JCheckBox" binding="checkBoxSendCrashReports">
-                    <constraints>
-                      <grid row="3" column="1" row-span="1" col-span="1" vsize-policy="0" hsize-policy="3" anchor="8" fill="0" indent="0" use-parent-layout="false"/>
-                    </constraints>
-                    <properties/>
-                  </component>
                   <component id="dff3f" class="javax.swing.JLabel">
                     <constraints>
-                      <grid row="4" column="0" row-span="1" col-span="1" vsize-policy="0" hsize-policy="0" anchor="8" fill="0" indent="0" use-parent-layout="false"/>
+                      <grid row="3" column="0" row-span="1" col-span="1" vsize-policy="0" hsize-policy="0" anchor="8" fill="0" indent="0" use-parent-layout="false"/>
                     </constraints>
                     <properties>
                       <text resource-bundle="slash/navigation/converter/gui/RouteConverter" key="ui-font-scale-option"/>
                     </properties>
                   </component>
                   <component id="e7f8a" class="javax.swing.JSpinner" binding="spinnerUiFontScale">
+                    <constraints>
+                      <grid row="3" column="1" row-span="1" col-span="1" vsize-policy="0" hsize-policy="3" anchor="8" fill="0" indent="0" use-parent-layout="false"/>
+                    </constraints>
+                    <properties/>
+                  </component>
+                  <component id="c1a5f" class="javax.swing.JLabel">
+                    <constraints>
+                      <grid row="4" column="0" row-span="1" col-span="1" vsize-policy="0" hsize-policy="0" anchor="8" fill="0" indent="0" use-parent-layout="false"/>
+                    </constraints>
+                    <properties>
+                      <text resource-bundle="slash/navigation/converter/gui/RouteConverter" key="send-crash-reports-option"/>
+                    </properties>
+                  </component>
+                  <component id="c1a60" class="javax.swing.JCheckBox" binding="checkBoxSendCrashReports">
                     <constraints>
                       <grid row="4" column="1" row-span="1" col-span="1" vsize-policy="0" hsize-policy="3" anchor="8" fill="0" indent="0" use-parent-layout="false"/>
                     </constraints>

--- a/route-converter-gui/src/main/java/slash/navigation/converter/gui/dialogs/OptionsDialog.java
+++ b/route-converter-gui/src/main/java/slash/navigation/converter/gui/dialogs/OptionsDialog.java
@@ -150,6 +150,7 @@ public class OptionsDialog extends SimpleDialog {
     private JLabel labelMapboxApiKey;
     private JLabel labelGeonamesUserName;
     private JCheckBox checkBoxSendCrashReports;
+    private JSpinner spinnerUiFontScale;
 
 
     public OptionsDialog() {
@@ -172,6 +173,9 @@ public class OptionsDialog extends SimpleDialog {
             Locale locale = (Locale) e.getItem();
             Application.getInstance().setLocale(locale);
         });
+
+        spinnerUiFontScale.setModel(new SpinnerNumberModel(UIHelper.getUiFontScalePercentage(), 50, 200, 10));
+        spinnerUiFontScale.addChangeListener(e -> UIHelper.setUiFontScalePercentage((Integer) spinnerUiFontScale.getValue()));
 
         List<MapViewImplementation> mapViews = r.getAvailableMapViews();
         ComboBoxModel<MapViewImplementation> mapViewModel =
@@ -830,7 +834,7 @@ public class OptionsDialog extends SimpleDialog {
         panel2.setLayout(new GridLayoutManager(5, 1, new Insets(5, 0, 0, 0), -1, -1));
         tabbedPane1.addTab(this.$$$getMessageFromBundle$$$("slash/navigation/converter/gui/RouteConverter", "general-options-tab"), panel2);
         final JPanel panel3 = new JPanel();
-        panel3.setLayout(new GridLayoutManager(5, 2, new Insets(3, 3, 3, 3), -1, -1));
+        panel3.setLayout(new GridLayoutManager(6, 2, new Insets(3, 3, 3, 3), -1, -1));
         panel2.add(panel3, new GridConstraints(0, 0, 1, 1, GridConstraints.ANCHOR_CENTER, GridConstraints.FILL_BOTH,
                 GridConstraints.SIZEPOLICY_CAN_SHRINK | GridConstraints.SIZEPOLICY_CAN_GROW,
                 GridConstraints.SIZEPOLICY_CAN_SHRINK | GridConstraints.SIZEPOLICY_CAN_GROW, null, null, null, 0, false));
@@ -862,9 +866,19 @@ public class OptionsDialog extends SimpleDialog {
         panel3.add(checkBoxSendCrashReports, new GridConstraints(3, 1, 1, 1, GridConstraints.ANCHOR_WEST, GridConstraints.FILL_NONE,
                 GridConstraints.SIZEPOLICY_CAN_SHRINK | GridConstraints.SIZEPOLICY_CAN_GROW, GridConstraints.SIZEPOLICY_FIXED, null, null,
                 null, 0, false));
+        final JLabel labelUiFontScale = new JLabel();
+        this.$$$loadLabelText$(labelUiFontScale,
+                this.$$$getMessageFromBundle$$$("slash/navigation/converter/gui/RouteConverter", "ui-font-scale-option"));
+        panel3.add(labelUiFontScale,
+                new GridConstraints(4, 0, 1, 1, GridConstraints.ANCHOR_WEST, GridConstraints.FILL_NONE, GridConstraints.SIZEPOLICY_FIXED,
+                        GridConstraints.SIZEPOLICY_FIXED, null, null, null, 0, false));
+        spinnerUiFontScale = new JSpinner();
+        panel3.add(spinnerUiFontScale, new GridConstraints(4, 1, 1, 1, GridConstraints.ANCHOR_WEST, GridConstraints.FILL_NONE,
+                GridConstraints.SIZEPOLICY_CAN_SHRINK | GridConstraints.SIZEPOLICY_CAN_GROW, GridConstraints.SIZEPOLICY_FIXED, null, null,
+                null, 0, false));
         final JPanel panel4 = new JPanel();
         panel4.setLayout(new GridLayoutManager(1, 1, new Insets(6, 0, 0, 0), -1, -1));
-        panel3.add(panel4, new GridConstraints(4, 0, 1, 2, GridConstraints.ANCHOR_CENTER, GridConstraints.FILL_BOTH,
+        panel3.add(panel4, new GridConstraints(5, 0, 1, 2, GridConstraints.ANCHOR_CENTER, GridConstraints.FILL_BOTH,
                 GridConstraints.SIZEPOLICY_CAN_SHRINK | GridConstraints.SIZEPOLICY_CAN_GROW,
                 GridConstraints.SIZEPOLICY_CAN_SHRINK | GridConstraints.SIZEPOLICY_CAN_GROW, null, null, null, 0, false));
         final JPanel panel5 = new JPanel();

--- a/route-converter-gui/src/main/java/slash/navigation/converter/gui/dialogs/OptionsDialog.java
+++ b/route-converter-gui/src/main/java/slash/navigation/converter/gui/dialogs/OptionsDialog.java
@@ -176,8 +176,8 @@ public class OptionsDialog extends SimpleDialog {
             Application.getInstance().setLocale(locale);
         });
 
-        spinnerUiFontScale.setModel(new SpinnerNumberModel(UIHelper.getUiFontScalePercentage(), 50, 200, 10));
-        spinnerUiFontScale.addChangeListener(e -> UIHelper.setUiFontScalePercentage((Integer) spinnerUiFontScale.getValue()));
+        spinnerUiFontScale.setModel(new SpinnerNumberModel(getUiFontScalePercentage(), 50, 200, 10));
+        spinnerUiFontScale.addChangeListener(e -> setUiFontScalePercentage((Integer) spinnerUiFontScale.getValue()));
 
         List<MapViewImplementation> mapViews = r.getAvailableMapViews();
         ComboBoxModel<MapViewImplementation> mapViewModel =
@@ -858,24 +858,24 @@ public class OptionsDialog extends SimpleDialog {
         panel3.add(separator1,
                 new GridConstraints(1, 0, 1, 2, GridConstraints.ANCHOR_CENTER, GridConstraints.FILL_BOTH, GridConstraints.SIZEPOLICY_FIXED,
                         GridConstraints.SIZEPOLICY_FIXED, null, null, null, 0, false));
+        final JLabel labelUiFontScale = new JLabel();
+        this.$$$loadLabelText$$$(labelUiFontScale,
+                this.$$$getMessageFromBundle$$$("slash/navigation/converter/gui/RouteConverter", "ui-font-scale-option"));
+        panel3.add(labelUiFontScale,
+                new GridConstraints(3, 0, 1, 1, GridConstraints.ANCHOR_WEST, GridConstraints.FILL_NONE, GridConstraints.SIZEPOLICY_FIXED,
+                        GridConstraints.SIZEPOLICY_FIXED, null, null, null, 0, false));
+        spinnerUiFontScale = new JSpinner();
+        panel3.add(spinnerUiFontScale, new GridConstraints(3, 1, 1, 1, GridConstraints.ANCHOR_WEST, GridConstraints.FILL_NONE,
+                GridConstraints.SIZEPOLICY_CAN_SHRINK | GridConstraints.SIZEPOLICY_CAN_GROW, GridConstraints.SIZEPOLICY_FIXED, null, null,
+                null, 0, false));
         final JLabel label3 = new JLabel();
         this.$$$loadLabelText$$$(label3,
                 this.$$$getMessageFromBundle$$$("slash/navigation/converter/gui/RouteConverter", "send-crash-reports-option"));
         panel3.add(label3,
-                new GridConstraints(3, 0, 1, 1, GridConstraints.ANCHOR_WEST, GridConstraints.FILL_NONE, GridConstraints.SIZEPOLICY_FIXED,
-                        GridConstraints.SIZEPOLICY_FIXED, null, null, null, 0, false));
-        checkBoxSendCrashReports = new JCheckBox();
-        panel3.add(checkBoxSendCrashReports, new GridConstraints(3, 1, 1, 1, GridConstraints.ANCHOR_WEST, GridConstraints.FILL_NONE,
-                GridConstraints.SIZEPOLICY_CAN_SHRINK | GridConstraints.SIZEPOLICY_CAN_GROW, GridConstraints.SIZEPOLICY_FIXED, null, null,
-                null, 0, false));
-        final JLabel labelUiFontScale = new JLabel();
-        this.$$$loadLabelText$(labelUiFontScale,
-                this.$$$getMessageFromBundle$$$("slash/navigation/converter/gui/RouteConverter", "ui-font-scale-option"));
-        panel3.add(labelUiFontScale,
                 new GridConstraints(4, 0, 1, 1, GridConstraints.ANCHOR_WEST, GridConstraints.FILL_NONE, GridConstraints.SIZEPOLICY_FIXED,
                         GridConstraints.SIZEPOLICY_FIXED, null, null, null, 0, false));
-        spinnerUiFontScale = new JSpinner();
-        panel3.add(spinnerUiFontScale, new GridConstraints(4, 1, 1, 1, GridConstraints.ANCHOR_WEST, GridConstraints.FILL_NONE,
+        checkBoxSendCrashReports = new JCheckBox();
+        panel3.add(checkBoxSendCrashReports, new GridConstraints(4, 1, 1, 1, GridConstraints.ANCHOR_WEST, GridConstraints.FILL_NONE,
                 GridConstraints.SIZEPOLICY_CAN_SHRINK | GridConstraints.SIZEPOLICY_CAN_GROW, GridConstraints.SIZEPOLICY_FIXED, null, null,
                 null, 0, false));
         final JPanel panel4 = new JPanel();

--- a/route-converter-gui/src/main/java/slash/navigation/converter/gui/dialogs/OptionsDialog.java
+++ b/route-converter-gui/src/main/java/slash/navigation/converter/gui/dialogs/OptionsDialog.java
@@ -89,6 +89,8 @@ import static slash.navigation.googlemaps.GoogleMapsServer.*;
 import static slash.navigation.gui.helpers.JMenuHelper.setMnemonic;
 import static slash.navigation.gui.helpers.UIHelper.chooseDirectory;
 import static slash.navigation.gui.helpers.UIHelper.chooseFile;
+import static slash.navigation.gui.helpers.UIHelper.getUiFontScalePercentage;
+import static slash.navigation.gui.helpers.UIHelper.setUiFontScalePercentage;
 
 /**
  * Dialog to show options for the program.

--- a/route-converter-gui/src/main/resources/slash/navigation/converter/gui/RouteConverter_de.properties
+++ b/route-converter-gui/src/main/resources/slash/navigation/converter/gui/RouteConverter_de.properties
@@ -437,6 +437,7 @@ gpsbabel-options=GPSBabel
 api-key-options=API-Schlüssel
 display-options=Anzeige
 preferred-locale=Bevorzugte Sprache (erfordert Neustart):
+ui-font-scale-option=Schriftgröße der Oberfläche in % (erfordert Neustart):
 google-maps-server=Google Maps Server:
 map-service=Kartenansicht:
 map-path=<html>Pfad zu Kartendaten<p>(leerlassen für Vorgabe):

--- a/route-converter-gui/src/main/resources/slash/navigation/converter/gui/RouteConverter_en.properties
+++ b/route-converter-gui/src/main/resources/slash/navigation/converter/gui/RouteConverter_en.properties
@@ -437,6 +437,7 @@ gpsbabel-options=GPSBabel
 api-key-options=API Keys
 display-options=Display
 preferred-locale=Preferred language (requires restart):
+ui-font-scale-option=UI font size in % (requires restart):
 google-maps-server=Google Maps Server:
 map-service=Map view:
 map-path=<html>Path to map data<p>(leave empty to use default):


### PR DESCRIPTION
I have successfully implemented the UI font-size setting feature for RouteConverter. Here's a summary of all the changes made:

## Changes Implemented

### 1. UIHelper.java (`common-gui/src/main/java/slash/navigation/gui/helpers/UIHelper.java`)
- Added preference storage constants and methods:
  - `UI_FONT_SCALE_PERCENTAGE_PREFERENCE` preference key
  - `DEFAULT_UI_FONT_SCALE_PERCENTAGE` constant (100)
  - `getUiFontScalePercentage()` getter
  - `setUiFontScalePercentage(int)` setter
  - `scaleFont(Font, int)` pure scaling function with proper rounding and minimum size clamping
- Modified `setLookAndFeel()` to apply font scaling at startup by iterating over UIManager defaults
- Added import for `FontUIResource`

### 2. UIHelperTest.java (`common-gui/src/test/java/slash/navigation/gui/helpers/UIHelperTest.java`)
- Created comprehensive test suite with 6 tests:
  - `testScaleFont100PercentReturnsSameSize` - verifies 100% returns original size
  - `testScaleFont150PercentIncreasesSize` - verifies 12pt → 18pt at 150%
  - `testScaleFont50PercentDecreasesSize` - verifies 12pt → 6pt at 50%
  - `testScaleFontRoundsToNearestInt` - verifies 11pt × 125% = 14pt (13.75 rounded)
  - `testScaleFontClampsToMinimumOnePoint` - verifies minimum size of 1pt
  - `testScaleFontPreservesFamilyAndStyle` - verifies font family and style are preserved

### 3. OptionsDialog.java (`route-converter-gui/src/main/java/slash/navigation/converter/gui/dialogs/OptionsDialog.java`)
- Added `spinnerUiFontScale` field declaration
- Added spinner initialization in constructor with `SpinnerNumberModel(50, 200, 10)` range
- Added ChangeListener to persist changes to preferences
- Updated `$$$setupUI$$$` method to match .form changes (grid row-count 5→6, new row 4 for spinner, filler grid moved to row 5)

### 4. OptionsDialog.form (`route-converter-gui/src/main/java/slash/navigation/converter/gui/dialogs/OptionsDialog.form`)
- Bumped General tab grid row-count from 5 to 6
- Added new label row (row 4, col 0) with i18n key `ui-font-scale-option`
- Added new spinner component (row 4, col 1)
- Moved filler grid from row 4 to row 5

### 5. i18n Properties Files
- **RouteConverter_en.properties**: Added `ui-font-scale-option=UI font size in % (requires restart):`
- **RouteConverter_de.properties**: Added `ui-font-scale-option=Schriftgröße der Oberfläche in % (erfordert Neustart):`

## Feature Behavior
- **Default**: 100% (no scaling applied)
- **Range**: 50% - 200% in 10% increments
- **Storage**: Persisted in user preferences
- **Application**: Applied at startup in `UIHelper.setLookAndFeel()` after LAF installation
- **Scope**: Scales all UIManager default fonts, affecting tables, dialogs, and all UI components
- **Live Update**: Changes are saved immediately but require app restart to take effect (consistent with locale setting)

The implementation follows the existing code patterns, uses pure Preferences API (no IntegerModel), preserves the `sun.java2d.uiScale=1.0` Windows map-blur fix, and provides a clean testable seam via the `scaleFont()` method.


Source issue: cpesch/RouteConverter#335

---
**Builder stats** · model `sonnet` · confidence `0` · 1m 34s across 1 round(s) · 6 file op(s)
[Workflow run](http://127.0.0.1:3000/cpesch/RouteConverter/actions/runs/24410)

⚠ UNVERIFIED: target not verifiable by the broker (non-rc/* target or no pom.xml — v1 is maven-only)

Closes #335

<!-- issue-body-sha:2a72cce2b6e6 -->