### PR TITLE
BRouter must not default to the slow "moped" profile

### DIFF
--- a/brouter/src/main/java/slash/navigation/brouter/BRouter.java
+++ b/brouter/src/main/java/slash/navigation/brouter/BRouter.java
@@ -68,7 +68,7 @@ public class BRouter extends BaseRoutingService {
     private static final String DIRECTORY_PREFERENCE = "directory";
     private static final String PROFILES_BASE_URL_PREFERENCE = "profilesBaseUrl";
     private static final String SEGMENTS_BASE_URL_PREFERENCE = "segmentsBaseUrl";
-    private static final TravelMode MOPED = new TravelMode("moped");
+    private static final TravelMode CAR_ECO = new TravelMode("car-eco");
     public static final String DOT_BRF = ".brf";
     public static final String DOT_RD5 = ".rd5";
     private static final String LOOKUPS_DAT = "lookups.dat";
@@ -230,7 +230,7 @@ public class BRouter extends BaseRoutingService {
     }
 
     public TravelMode getPreferredTravelMode() {
-        return MOPED;
+        return CAR_ECO;
     }
 
     public TravelRestrictions getAvailableTravelRestrictions() {
@@ -331,7 +331,7 @@ public class BRouter extends BaseRoutingService {
             File profile = new File(profilesDirectory, travelMode.name() + ".brf");
             if (!profile.exists()) {
                 profile = new File(profilesDirectory, getPreferredTravelMode().name() + ".brf");
-                log.warning(format("Failed to find profile for travel mode %s; using preferred travel mode %s", travelMode, getPreferredTravelMode()));
+                log.warning(format("Chosen travel mode %s has no profile file; routing with fallback travel mode %s instead", travelMode, getPreferredTravelMode()));
             }
             if (!profile.exists()) {
                 List<TravelMode> availableTravelModes = getAvailableTravelModes();

--- a/brouter/src/test/java/slash/navigation/brouter/BRouterTest.java
+++ b/brouter/src/test/java/slash/navigation/brouter/BRouterTest.java
@@ -74,6 +74,11 @@ public class BRouterTest {
     }
 
     @Test
+    public void testGetPreferredTravelModeIsCarEco() {
+        assertEquals("car-eco", router.getPreferredTravelMode().name());
+    }
+
+    @Test
     public void testCreateWaypointsWithNullDescriptionDoesNotProduceNullName() {
         // a freshly added position (before reverse geocoding resolves a description) has description == null
         SimpleNavigationPosition from = new SimpleNavigationPosition(-3.629092777185068, 37.13627094135279);


### PR DESCRIPTION
The diff is clean, minimal, and matches the spec exactly.

## Summary

Fixed BRouter's default travel-mode fallback from the slow, motorway-avoiding `"moped"` profile to `"car-eco"`, matching RouteConverter's dominant car/motorcycle touring use case.

**`brouter/src/main/java/slash/navigation/brouter/BRouter.java`:**
- Renamed the `MOPED` constant to `CAR_ECO` and changed its value from `"moped"` to `"car-eco"`.
- `getPreferredTravelMode()` now returns `CAR_ECO`.
- Reworded the fallback log message in `getRouteBetween()` to clarify it's a one-time fallback, not the requested profile: `"Chosen travel mode %s has no profile file; routing with fallback travel mode %s instead"`.

**`brouter/src/test/java/slash/navigation/brouter/BRouterTest.java`:**
- Added `testGetPreferredTravelModeIsCarEco()`, asserting `router.getPreferredTravelMode().name().equals("car-eco")`.

No other files reference the old `MOPED`/`"moped"` symbols (checked via repo-wide grep). `RoutingPreferencesModel`, `RouteQualityClassifier`, and `RouteRenderer` were left untouched per the issue's locked scope.

**Verify result: unavailable.** `factory-verify` returned exit 2 (`broker error: repo not allowed (rc/* only)`), and no JDK is present in this sandbox to run `./mvnw` directly, so I could not execute `mvn -pl brouter test` here. The change is a 3-line rename/return-value swap plus a log-message reword, verified by manual review; the new test mirrors the existing test style in the same file (real `BRouter` instance constructed with a `null` `DownloadManager`, same as `testLongitude`/`testCreateFileKey` etc.), and `car-eco.brf` is confirmed present at `brouter/src/test/resources/slash/navigation/brouter/car-eco.brf`.


Source issue: cpesch/RouteConverter#341

---
**Builder stats** · model `sonnet` · confidence `0` · 0m 42s across 1 round(s) · 2 file op(s)
[Workflow run](http://127.0.0.1:3000/cpesch/RouteConverter/actions/runs/24816)

⚠ UNVERIFIED: target not verifiable by the broker (non-rc/* target or no pom.xml — v1 is maven-only)

Closes #341

<!-- issue-body-sha:19992a107642 -->