### PR TITLE
Delete download scratch temp files on failure/removal, not only on success

### DIFF
--- a/download/src/main/java/slash/navigation/download/DownloadManager.java
+++ b/download/src/main/java/slash/navigation/download/DownloadManager.java
@@ -148,6 +148,9 @@ public class DownloadManager {
 
         for (Download download : downloads) {
             log.info("Removing download " + download);
+            File tempFile = download.getTempFile();
+            if (tempFile.exists() && !tempFile.delete())
+                log.warning("Cannot delete temp file " + tempFile);
             model.removeDownload(download);
         }
 

--- a/download/src/main/java/slash/navigation/download/performer/GetPerformer.java
+++ b/download/src/main/java/slash/navigation/download/performer/GetPerformer.java
@@ -152,8 +152,10 @@ public class GetPerformer implements ActionPerformer {
             } else
                 downloadExecutor.postProcessFailed();
 
-        } else
+        } else {
             downloadExecutor.downloadFailed();
+            deleteTempFileQuietly();
+        }
     }
 
     private boolean postProcess(Long lastModified) throws IOException {
@@ -161,8 +163,10 @@ public class GetPerformer implements ActionPerformer {
 
         bringToTarget(lastModified);
 
-        if (!validate())
+        if (!validate()) {
+            deleteTempFileQuietly();
             return false;
+        }
 
         if (getDownload().getTempFile().exists())
             if (!getDownload().getTempFile().delete())
@@ -170,6 +174,12 @@ public class GetPerformer implements ActionPerformer {
 
         log.fine(format("Postprocess from %s successful", getDownload().getUrl()));
         return true;
+    }
+
+    private void deleteTempFileQuietly() {
+        File tempFile = getDownload().getTempFile();
+        if (tempFile.exists() && !tempFile.delete())
+            log.warning(format("Cannot delete temp file %s", tempFile));
     }
 
     private void bringToTarget(Long lastModified) throws IOException {

--- a/download/src/test/java/slash/navigation/download/DownloadManagerTest.java
+++ b/download/src/test/java/slash/navigation/download/DownloadManagerTest.java
@@ -1,0 +1,95 @@
+/*
+    This file is part of RouteConverter.
+
+    RouteConverter is free software; you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation; either version 2 of the License, or
+    (at your option) any later version.
+
+    RouteConverter is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with RouteConverter; if not, write to the Free Software
+    Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
+
+    Copyright (C) 2007 Christian Pesch. All Rights Reserved.
+*/
+package slash.navigation.download;
+
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+
+import java.io.File;
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+
+import static java.io.File.createTempFile;
+import static java.util.Collections.singletonList;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+import static slash.navigation.download.Action.Copy;
+import static slash.navigation.download.State.Queued;
+
+/**
+ * Tests that {@link DownloadManager} deletes a download's scratch temp file when it's explicitly
+ * removed from the queue, but never when it's merely stopped (a stopped-but-not-removed download
+ * stays restartable via {@link DownloadManager#restartDownloads} and resumes from that temp file).
+ *
+ * @author Christian Pesch
+ */
+public class DownloadManagerTest {
+    private File queueFile, target, tempFile;
+    private DownloadManager manager;
+
+    @Before
+    public void setUp() throws IOException {
+        queueFile = createTempFile("queueFile", ".xml");
+        manager = new DownloadManager(queueFile);
+        target = createTempFile("local", ".txt");
+        tempFile = createTempFile("download", ".tmp");
+        Files.write(tempFile.toPath(), "partial content".getBytes(StandardCharsets.UTF_8));
+    }
+
+    @After
+    public void tearDown() {
+        manager.dispose();
+        if (target.exists())
+            target.delete();
+        if (tempFile.exists())
+            tempFile.delete();
+        if (queueFile.exists() && !queueFile.delete())
+            queueFile.deleteOnExit();
+    }
+
+    private Download queuedDownload() {
+        Download download = new Download("desc", "http://example.com/f", Copy,
+                new FileAndChecksum(target, null), null, null, Queued, tempFile);
+        manager.queue(download, false);
+        return download;
+    }
+
+    @Test
+    public void testRemoveDownloadsDeletesTempFile() {
+        Download download = queuedDownload();
+        assertTrue(download.getTempFile().exists());
+
+        manager.removeDownloads(singletonList(download));
+
+        assertFalse("temp file must be deleted when a download is removed", download.getTempFile().exists());
+    }
+
+    @Test
+    public void testStopDownloadsDoesNotDeleteTempFile() {
+        Download download = queuedDownload();
+        assertTrue(download.getTempFile().exists());
+
+        manager.stopDownloads(singletonList(download));
+
+        assertTrue("temp file must survive a stop so a restart can resume from it", download.getTempFile().exists());
+    }
+}

--- a/download/src/test/java/slash/navigation/download/performer/GetPerformerTest.java
+++ b/download/src/test/java/slash/navigation/download/performer/GetPerformerTest.java
@@ -1,0 +1,142 @@
+/*
+    This file is part of RouteConverter.
+
+    RouteConverter is free software; you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation; either version 2 of the License, or
+    (at your option) any later version.
+
+    RouteConverter is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with RouteConverter; if not, write to the Free Software
+    Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
+
+    Copyright (C) 2007 Christian Pesch. All Rights Reserved.
+*/
+package slash.navigation.download.performer;
+
+import com.sun.net.httpserver.HttpServer;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.Timeout;
+import slash.navigation.download.Checksum;
+import slash.navigation.download.Download;
+import slash.navigation.download.DownloadManager;
+import slash.navigation.download.FileAndChecksum;
+import slash.navigation.download.State;
+import slash.navigation.download.executor.DownloadExecutor;
+
+import java.io.File;
+import java.io.IOException;
+import java.io.OutputStream;
+import java.net.InetSocketAddress;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import static java.io.File.createTempFile;
+import static java.util.Collections.singletonList;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+import static slash.navigation.download.Action.Copy;
+
+/**
+ * Hermetic (no external network) tests that a download's scratch temp file is deleted on the
+ * failure paths added for the "delete download scratch temp files on failure/removal" fix:
+ * a completed-but-invalid transfer ({@link GetPerformer#postProcess}) and a failed transfer
+ * that never reaches {@code postProcess} ({@link GetPerformer#run}'s final {@code else} branch).
+ *
+ * @author Christian Pesch
+ */
+public class GetPerformerTest {
+    private static final String BODY = "Lorem ipsum dolor sit amet";
+
+    @Rule
+    public final Timeout testTimeout = Timeout.seconds(30);
+
+    private HttpServer server;
+    private final AtomicInteger bodiesServed = new AtomicInteger();
+    private DownloadManager manager;
+    private File target, queueFile;
+
+    @Before
+    public void setUp() throws IOException {
+        server = HttpServer.create(new InetSocketAddress("127.0.0.1", 0), 0);
+        server.createContext("/ok", exchange -> {
+            byte[] body = BODY.getBytes(StandardCharsets.UTF_8);
+            bodiesServed.incrementAndGet();
+            exchange.sendResponseHeaders(200, body.length);
+            try (OutputStream out = exchange.getResponseBody()) {
+                out.write(body);
+            }
+            exchange.close();
+        });
+        server.createContext("/missing", exchange -> {
+            exchange.sendResponseHeaders(404, -1);
+            exchange.close();
+        });
+        server.start();
+
+        queueFile = createTempFile("queueFile", ".xml");
+        manager = new DownloadManager(queueFile);
+        target = createTempFile("local", ".txt");
+        assertTrue(target.delete());
+    }
+
+    @After
+    public void tearDown() {
+        manager.dispose();
+        server.stop(0);
+        if (target.exists())
+            target.delete();
+        if (queueFile.exists() && !queueFile.delete())
+            queueFile.deleteOnExit();
+    }
+
+    private String url(String path) {
+        return "http://127.0.0.1:" + server.getAddress().getPort() + path;
+    }
+
+    @Test
+    public void testValidateFailureDeletesTempFile() {
+        // a checksum that can never match the downloaded bytes forces validate() to fail
+        // after a fully completed transfer, exercising postProcess()'s cleanup
+        Checksum wrongChecksum = new Checksum(null, (long) BODY.length() + 999L, "wrong-sha1");
+        Download download = manager.queueForDownload("mismatching checksum", url("/ok"), Copy,
+                new FileAndChecksum(target, wrongChecksum), null);
+        manager.waitForCompletion(singletonList(download));
+
+        assertEquals(State.ChecksumError, download.getState());
+        assertEquals(1, bodiesServed.get());
+        assertFalse("temp file must be deleted after a failed validation", download.getTempFile().exists());
+    }
+
+    @Test
+    public void testFailedTransferDeletesTempFile() throws IOException {
+        // a stale temp file left over from an earlier attempt must not survive a subsequent
+        // failed transfer that never reaches postProcess() (run()'s final else branch)
+        Download download = new Download("missing resource", url("/missing"), Copy,
+                new FileAndChecksum(target, null), null);
+        Files.write(download.getTempFile().toPath(), "leftover".getBytes(StandardCharsets.UTF_8));
+        assertTrue(download.getTempFile().exists());
+
+        // seed the model directly (queueForDownload()/queue() would build their own Download
+        // with a fresh, empty temp file, defeating the pre-populated stale-file setup above)
+        // and drive GetPerformer synchronously, exactly as DownloadExecutor.run() does
+        manager.getModel().setDownloads(singletonList(download));
+        DownloadExecutor executor = new DownloadExecutor(download, manager);
+        GetPerformer performer = new GetPerformer();
+        performer.setDownloadExecutor(executor);
+        performer.run();
+
+        assertEquals(State.Failed, download.getState());
+        assertFalse("stale temp file must be deleted after a failed download", download.getTempFile().exists());
+    }
+}


### PR DESCRIPTION
No hidden dependency on the temp file surviving removal — this is a simple UI action forwarding to `removeDownloads`. The implementation is complete and consistent with the rest of the codebase.

## Summary

Implemented the three fixes specified in the issue to stop orphaning per-download scratch temp files on failure/removal, without touching resume-across-restart behavior:

1. **`GetPerformer.postProcess()`** — deletes the temp file when `validate()` returns `false` (reached only after a fully completed transfer, per the issue's analysis).
2. **`GetPerformer.run()`** — deletes the temp file in the final `else` branch (both `resume()` and `download()` failed to produce a successful result).
3. **`DownloadManager.removeDownloads()`** — deletes each download's temp file when explicitly removed from the queue.

Added a shared private `deleteTempFileQuietly()` helper in `GetPerformer` (log-and-continue, matching existing style). Left `stopDownloads()`, `restartDownloads()`, `canResume()`, and the `resume()`/`download()` HTTP methods untouched, as required.

Added tests:
- `download/src/test/java/slash/navigation/download/performer/GetPerformerTest.java` — hermetic (local `HttpServer`) tests for a checksum-mismatch triggering `postProcess()` cleanup, and a failed transfer triggering `run()`'s cleanup of a stale pre-existing temp file.
- `download/src/test/java/slash/navigation/download/DownloadManagerTest.java` — `testRemoveDownloadsDeletesTempFile()` and the regression guard `testStopDownloadsDoesNotDeleteTempFile()`.

**Verify result: unavailable.** No JDK is present in this sandbox (`java`/`javac` not on `PATH`), and `factory-verify -pl download test` returned exit 2 with `repo not allowed (rc/* only)` — this repo isn't in the verify broker's allowed scope. I could not run `mvn -pl download test`. I instead did a careful manual trace of both new test files against the actual `GetPerformer`/`DownloadManager`/`Download` control flow (canResume/resume/download branching, model registration requirements for `updateDownload`/`removeDownload`, package-private access constraints) to confirm they exercise the intended paths and assertions correctly — but this is not a substitute for an actual test run, so please run `./mvnw -pl download test` to confirm before merging.


Source issue: cpesch/RouteConverter#342

---
**Builder stats** · model `sonnet` · confidence `0` · 6m 9s across 1 round(s) · 4 file op(s)
[Workflow run](http://127.0.0.1:3000/cpesch/RouteConverter/actions/runs/24812)

⚠ UNVERIFIED: target not verifiable by the broker (non-rc/* target or no pom.xml — v1 is maven-only)

Closes #342

<!-- issue-body-sha:515675c2aad0 -->