### PR TITLE
Fix UTF-8/ISO-8859-1 charset mismatch mangling non-ASCII descriptions on copy/paste

### DIFF
--- a/navigation-formats/src/main/java/slash/navigation/base/NavigationFormatParser.java
+++ b/navigation-formats/src/main/java/slash/navigation/base/NavigationFormatParser.java
@@ -47,6 +47,7 @@ import static java.lang.Math.min;
 import static java.lang.String.format;
 import static slash.common.io.Files.getExtension;
 import static slash.common.io.Files.toUrl;
+import static slash.common.io.Transfer.UTF8_ENCODING;
 import static slash.common.io.Transfer.ceiling;
 import static slash.common.type.CompactCalendar.UTC;
 import static slash.common.type.CompactCalendar.fromCalendar;
@@ -268,7 +269,7 @@ public class NavigationFormatParser {
     }
 
     public ParserResult read(String source) throws IOException {
-        return read(new ByteArrayInputStream(source.getBytes()));
+        return read(new ByteArrayInputStream(source.getBytes(UTF8_ENCODING)));
     }
 
     public ParserResult read(InputStream source) throws IOException {

--- a/navigation-formats/src/main/java/slash/navigation/simple/GlopusFormat.java
+++ b/navigation-formats/src/main/java/slash/navigation/simple/GlopusFormat.java
@@ -23,6 +23,8 @@ package slash.navigation.simple;
 import slash.navigation.base.*;
 import slash.navigation.common.NavigationPosition;
 
+import java.io.IOException;
+import java.io.InputStream;
 import java.io.PrintWriter;
 import java.util.List;
 import java.util.regex.Matcher;
@@ -71,6 +73,13 @@ public class GlopusFormat extends SimpleLineBasedFormat<Wgs84Route> {
     @SuppressWarnings("unchecked")
     public <P extends NavigationPosition> Wgs84Route createRoute(RouteCharacteristics characteristics, String name, List<P> positions) {
         return new Wgs84Route(this, characteristics, name, (List<Wgs84Position>) positions);
+    }
+
+    // Glopus (.tk) is RouteConverter's own clipboard/file format: both write (PositionSelection)
+    // and read happen inside RouteConverter, so UTF-8 keeps the round-trip lossless instead of
+    // inheriting TextNavigationFormat's ISO-8859-1 default meant for legacy external file formats.
+    public void read(InputStream source, ParserContext<Wgs84Route> context) throws IOException {
+        read(source, UTF8_ENCODING, context);
     }
 
     protected boolean isPosition(String line) {

--- a/navigation-formats/src/test/java/slash/navigation/base/NavigationFormatParserTest.java
+++ b/navigation-formats/src/test/java/slash/navigation/base/NavigationFormatParserTest.java
@@ -228,6 +228,13 @@ public class NavigationFormatParserTest {
     }
 
     @Test
+    public void testReadFromStringPreservesNonAsciiCharacters() throws IOException {
+        ParserResult result = parser.read("51.0450383,7.0508300,San Nicolò");
+        assertTrue(result.isSuccessful());
+        assertEquals("San Nicolò", result.getTheRoute().getPositions().get(0).getDescription());
+    }
+
+    @Test
     public void testReadEmptyInputIsLenientlySuccessful() throws IOException {
         // documents the firstSuccessfulFormat fallback: with no positions parsed,
         // the parser still reports the first format that did not throw

--- a/navigation-formats/src/test/java/slash/navigation/simple/GlopusFormatTest.java
+++ b/navigation-formats/src/test/java/slash/navigation/simple/GlopusFormatTest.java
@@ -20,13 +20,39 @@
 package slash.navigation.simple;
 
 import org.junit.Test;
+import slash.navigation.base.NavigationFormatParser;
+import slash.navigation.base.NavigationFormatRegistry;
+import slash.navigation.base.ParserResult;
+import slash.navigation.base.RouteCharacteristics;
 import slash.navigation.base.Wgs84Position;
+import slash.navigation.base.Wgs84Route;
+
+import java.io.IOException;
+import java.io.PrintWriter;
+import java.io.StringWriter;
+import java.util.Collections;
 
 import static org.junit.Assert.*;
 import static slash.common.TestCase.assertDoubleEquals;
 
 public class GlopusFormatTest {
     GlopusFormat format = new GlopusFormat();
+
+    @Test
+    public void testWriteThenReadBackPreservesNonAsciiDescription() throws IOException {
+        Wgs84Position position = new Wgs84Position(7.0508300, 51.0450383, null, null, null, "San Nicolò");
+        Wgs84Route route = format.createRoute(RouteCharacteristics.Waypoints, null, Collections.singletonList(position));
+
+        StringWriter stringWriter = new StringWriter();
+        PrintWriter printWriter = new PrintWriter(stringWriter);
+        format.write(route, printWriter, 0, 1);
+        printWriter.flush();
+
+        NavigationFormatParser parser = new NavigationFormatParser(new NavigationFormatRegistry());
+        ParserResult result = parser.read(stringWriter.toString());
+        assertTrue(result.isSuccessful());
+        assertEquals("San Nicolò", result.getTheRoute().getPositions().get(0).getDescription());
+    }
 
     @Test
     public void testIsPosition() {


### PR DESCRIPTION
All four files match the issue's file list. Here's the summary.

## Summary

Fixed the UTF-8/ISO-8859-1 charset mismatch that mangled non-ASCII position descriptions (e.g. "San Nicolò" → "San NicolÃ²") on copy/paste between RouteConverter instances.

**Root cause:** `PositionSelection`'s clipboard payload is written char-based (no encoding issue), but `NavigationFormatParser.read(String)` re-encoded it via `source.getBytes()` (platform-default charset) while `GlopusFormat` (inherited from `TextNavigationFormat`) always decoded as ISO-8859-1. The two sides never agreed on an encoding.

**Changes:**
- `NavigationFormatParser.java`: `read(String source)` now explicitly encodes with `UTF8_ENCODING` instead of the JVM platform-default charset.
- `GlopusFormat.java`: overrides `read(InputStream, ParserContext)` to decode with `UTF8_ENCODING` instead of inheriting the ISO-8859-1 default (which stays correct for every other `TextNavigationFormat` subclass reading legacy external files — untouched).
- `NavigationFormatParserTest.java`: added `testReadFromStringPreservesNonAsciiCharacters()`.
- `GlopusFormatTest.java`: added `testWriteThenReadBackPreservesNonAsciiDescription()` — round-trips a route with a non-ASCII description through `GlopusFormat.write()` and `NavigationFormatParser.read(String)`.

**Intentional side effect for the changelog:** on-disk `.tk` files are now decoded as UTF-8 instead of ISO-8859-1. Since Glopus/`.tk` is RouteConverter's own internal clipboard/file format (no external producer/consumer), this makes read/write symmetric and is safe — but is a behavior change worth noting for the maintainer.

**Verification:** `factory-verify` returned exit 2 (broker rejected this checkout: "repo not allowed (rc/* only)") — sandboxed build/test is unavailable in this environment, and no local JDK/Maven toolchain was available either, so I could not run `mvn -pl navigation-formats test`. I instead manually traced the type hierarchy (`GlopusFormat extends SimpleLineBasedFormat<Wgs84Route> extends SimpleFormat<Wgs84Route> extends TextNavigationFormat<Wgs84Route>`) to confirm the override signature matches, confirmed `UTF8_ENCODING`/`ISO_LATIN1_ENCODING` constants and the protected `read(InputStream, String, ParserContext)` helper already exist as referenced in the issue, and checked the new tests' write path flushes the `PrintWriter` before reading the buffered string back. Please run the test suite in CI to confirm.


Source issue: cpesch/RouteConverter#340

---
**Builder stats** · model `sonnet` · confidence `0` · 1m 44s across 1 round(s) · 4 file op(s)
[Workflow run](http://127.0.0.1:3000/cpesch/RouteConverter/actions/runs/24825)

⚠ UNVERIFIED: target not verifiable by the broker (non-rc/* target or no pom.xml — v1 is maven-only)

Closes #340

<!-- issue-body-sha:a98f83952023 -->