### PR TITLE
Coordinates complete-action must not overwrite positions that already have coordinates

### DIFF
--- a/route-converter-gui/src/main/java/slash/navigation/converter/gui/helpers/PositionAugmenter.java
+++ b/route-converter-gui/src/main/java/slash/navigation/converter/gui/helpers/PositionAugmenter.java
@@ -102,7 +102,7 @@ public class PositionAugmenter {
         executor.shutdownNow();
     }
 
-    private interface OverwritePredicate {
+    interface OverwritePredicate {
         boolean shouldOverwrite(NavigationPosition position);
     }
 
@@ -115,6 +115,12 @@ public class PositionAugmenter {
     private static final OverwritePredicate COORDINATE_PREDICATE = new OverwritePredicate() {
         public boolean shouldOverwrite(NavigationPosition position) {
             return position.hasCoordinates();
+        }
+    };
+
+    static final OverwritePredicate NO_COORDINATE_PREDICATE = new OverwritePredicate() {
+        public boolean shouldOverwrite(NavigationPosition position) {
+            return !position.hasCoordinates();
         }
     };
 
@@ -252,7 +258,7 @@ public class PositionAugmenter {
     public void addCoordinates() {
         int[] rows = positionsView.getSelectedRows();
         if (rows.length > 0)
-            processCoordinates(positionsView, positionsModel, rows, TAUTOLOGY_PREDICATE);
+            processCoordinates(positionsView, positionsModel, rows, NO_COORDINATE_PREDICATE);
     }
 
 

--- a/route-converter-gui/src/test/java/slash/navigation/converter/gui/helpers/PositionAugmenterTest.java
+++ b/route-converter-gui/src/test/java/slash/navigation/converter/gui/helpers/PositionAugmenterTest.java
@@ -23,6 +23,7 @@ package slash.navigation.converter.gui.helpers;
 import org.junit.Before;
 import org.junit.Test;
 import slash.navigation.base.BaseRoute;
+import slash.navigation.base.Wgs84Position;
 import slash.navigation.converter.gui.models.PositionsModelImpl;
 import slash.navigation.converter.gui.models.TimeZoneModel;
 import slash.navigation.converter.gui.panels.PositionsModelCallbackImpl;
@@ -34,6 +35,8 @@ import java.util.TimeZone;
 
 import static java.util.Arrays.asList;
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
 import static slash.common.TestCase.calendar;
 
 public class PositionAugmenterTest {
@@ -97,5 +100,19 @@ public class PositionAugmenterTest {
         assertEquals(3, augmenter.findSuccessorWithTime(model, 2));
         assertEquals(3, augmenter.findSuccessorWithTime(model, 3));
         assertEquals(-1, augmenter.findSuccessorWithTime(model, 4));
+    }
+
+    @Test
+    public void testNoCoordinatePredicateSkipsPositionWithCoordinates() {
+        Wgs84Position position = new Wgs84Position(1.0, 2.0, null, null, null, "description");
+
+        assertFalse(PositionAugmenter.NO_COORDINATE_PREDICATE.shouldOverwrite(position));
+    }
+
+    @Test
+    public void testNoCoordinatePredicateAcceptsPositionWithoutCoordinates() {
+        Wgs84Position position = new Wgs84Position(null, null, null, null, null, "description");
+
+        assertTrue(PositionAugmenter.NO_COORDINATE_PREDICATE.shouldOverwrite(position));
     }
 }


### PR DESCRIPTION
## Summary

Fixed `PositionAugmenter.addCoordinates()` so it only fills in coordinates for positions that don't already have them, matching the "skip if already populated" pattern used by every sibling Complete action (`addElevations`, `addAddresses`, `addTimes`, etc.).

### Changes

**`PositionAugmenter.java`**
- Added a new `NO_COORDINATE_PREDICATE` (`shouldOverwrite` returns `!position.hasCoordinates()`), the inverse of the existing `COORDINATE_PREDICATE`.
- Widened the `OverwritePredicate` interface from `private` to package-private so the test (same package) can reference the predicate's static type.
- Rewired `addCoordinates()`'s call to `processCoordinates(...)` from `TAUTOLOGY_PREDICATE` to `NO_COORDINATE_PREDICATE`. No other callers touched — `TAUTOLOGY_PREDICATE` is still used by `addDepartureTimes()`.

**`PositionAugmenterTest.java`**
- Added `testNoCoordinatePredicateSkipsPositionWithCoordinates()` and `testNoCoordinatePredicateAcceptsPositionWithoutCoordinates()`, constructing real `Wgs84Position` objects with/without lat/lon and asserting the predicate's boolean result directly — no GUI/table/executor involved.

### Verify result: **unavailable**
`factory-verify` returned exit 2 with `broker error HTTP 400: repo not allowed (rc/* only)` — the sandboxed verify service only accepts `rc/*` repos, not `cpesch/RouteConverter`. No local JDK/Maven was available in this environment either (`java: command not found`), so I could not run `mvn -pl route-converter-gui test` myself. The change is minimal and mechanically verified by inspection: `NO_COORDINATE_PREDICATE` mirrors the existing `COORDINATE_PREDICATE` pattern exactly (inverted), the single call site swap is the only behavioral change, and the test additions follow the file's existing style/imports. Recommend running `./mvnw --batch-mode -pl route-converter-gui -am test` in CI to confirm green before merge.


Source issue: cpesch/RouteConverter#339

---
**Builder stats** · model `sonnet` · confidence `0` · 1m 9s across 1 round(s) · 2 file op(s)
[Workflow run](http://127.0.0.1:3000/cpesch/RouteConverter/actions/runs/24827)

⚠ UNVERIFIED: target not verifiable by the broker (non-rc/* target or no pom.xml — v1 is maven-only)

Closes #339

<!-- issue-body-sha:a2dd8050e8bd -->