### PR TITLE
Auto-detect Windows display scaling as default UI font size (follow-up to #335)

### DIFF
--- a/common-gui/src/main/java/slash/navigation/gui/helpers/UIHelper.java
+++ b/common-gui/src/main/java/slash/navigation/gui/helpers/UIHelper.java
@@ -46,11 +46,27 @@ public class UIHelper {
     private static final int DEFAULT_UI_FONT_SCALE_PERCENTAGE = 100;
 
     public static int getUiFontScalePercentage() {
-        return preferences.getInt(UI_FONT_SCALE_PERCENTAGE_PREFERENCE, DEFAULT_UI_FONT_SCALE_PERCENTAGE);
+        return preferences.getInt(UI_FONT_SCALE_PERCENTAGE_PREFERENCE, getDefaultUiFontScalePercentage());
     }
 
     public static void setUiFontScalePercentage(int percentage) {
         preferences.putInt(UI_FONT_SCALE_PERCENTAGE_PREFERENCE, percentage);
+    }
+
+    private static int getDefaultUiFontScalePercentage() {
+        if (!isWindows())
+            return DEFAULT_UI_FONT_SCALE_PERCENTAGE;
+        try {
+            int dpi = Toolkit.getDefaultToolkit().getScreenResolution();
+            return dpiToPercentage(dpi);
+        } catch (HeadlessException e) {
+            return DEFAULT_UI_FONT_SCALE_PERCENTAGE;
+        }
+    }
+
+    static int dpiToPercentage(int dpi) {
+        int percentage = Math.round(dpi / 96f * 100f);
+        return Math.max(50, Math.min(200, percentage));
     }
 
     public static Font scaleFont(Font font, int percentage) {

--- a/common-gui/src/test/java/slash/navigation/gui/helpers/UIHelperTest.java
+++ b/common-gui/src/test/java/slash/navigation/gui/helpers/UIHelperTest.java
@@ -85,4 +85,34 @@ public class UIHelperTest {
         assertEquals("Serif", result.getFamily());
         assertEquals(Font.BOLD | Font.ITALIC, result.getStyle());
     }
+
+    @Test
+    public void testDpiToPercentage96DpiIs100Percent() {
+        assertEquals(100, UIHelper.dpiToPercentage(96));
+    }
+
+    @Test
+    public void testDpiToPercentage120DpiIs125Percent() {
+        assertEquals(125, UIHelper.dpiToPercentage(120));
+    }
+
+    @Test
+    public void testDpiToPercentage144DpiIs150Percent() {
+        assertEquals(150, UIHelper.dpiToPercentage(144));
+    }
+
+    @Test
+    public void testDpiToPercentage192DpiIs200Percent() {
+        assertEquals(200, UIHelper.dpiToPercentage(192));
+    }
+
+    @Test
+    public void testDpiToPercentageClampsLowExtremeTo50() {
+        assertEquals(50, UIHelper.dpiToPercentage(40));
+    }
+
+    @Test
+    public void testDpiToPercentageClampsHighExtremeTo200() {
+        assertEquals(200, UIHelper.dpiToPercentage(500));
+    }
 }


### PR DESCRIPTION
The diff is clean, correct, and matches the spec exactly. `Toolkit`, `HeadlessException`, and `isWindows` are all already in scope via the existing `java.awt.*` and static imports — no new imports needed.

## Summary

Implemented issue #338: auto-detect Windows display scaling as the default UI font size, building on #336's `UIHelper` scaffolding.

**`common-gui/src/main/java/slash/navigation/gui/helpers/UIHelper.java`**
- Added package-private `static int dpiToPercentage(int dpi)` — converts a DPI reading to a percentage relative to 96 DPI baseline, clamped to `[50, 200]`.
- Added private `static int getDefaultUiFontScalePercentage()` — on Windows, reads `Toolkit.getDefaultToolkit().getScreenResolution()` and converts via `dpiToPercentage`; falls back to the flat 100% default on non-Windows platforms or if `HeadlessException` is thrown.
- Changed `getUiFontScalePercentage()`'s fallback from the hardcoded `DEFAULT_UI_FONT_SCALE_PERCENTAGE` to `getDefaultUiFontScalePercentage()`. Since `Preferences.getInt(key, fallback)` only evaluates the fallback when no value was ever stored, a user's explicit spinner choice (from #336) is untouched — this only changes the very first, never-configured default.

**`common-gui/src/test/java/slash/navigation/gui/helpers/UIHelperTest.java`**
- Added the 6 specified test cases for `dpiToPercentage`: 96→100, 120→125, 144→150, 192→200, and clamping at both extremes (40→50, 500→200).

No `.form`/`OptionsDialog` changes were needed — the spinner already reads its initial value through `getUiFontScalePercentage()`.

**Verify result: unavailable.** `factory-verify -pl common-gui -am test` exited 2 with a broker error (`repo not allowed (rc/* only)` — this repo isn't in the sandbox's allowed verification set), so I could not run `mvn test` in this environment. I manually reviewed the diff for correctness: all imports used (`Toolkit`, `HeadlessException`) are already covered by the existing `java.awt.*` wildcard import and `isWindows` static import, so this should compile cleanly, but the test suite itself has not been executed here.


Source issue: cpesch/RouteConverter#338

---
**Builder stats** · model `sonnet` · confidence `0` · 0m 46s across 1 round(s) · 2 file op(s)
[Workflow run](http://127.0.0.1:3000/cpesch/RouteConverter/actions/runs/24829)

⚠ UNVERIFIED: target not verifiable by the broker (non-rc/* target or no pom.xml — v1 is maven-only)

Closes #338

<!-- issue-body-sha:422b84be2edb -->