### PR TITLE
GraphHopper OutOfMemoryError during route insertion is silently swallowed

### DIFF
--- a/route-converter-gui/src/main/java/slash/navigation/converter/gui/helpers/InsertPositionFacade.java
+++ b/route-converter-gui/src/main/java/slash/navigation/converter/gui/helpers/InsertPositionFacade.java
@@ -43,6 +43,7 @@ import static slash.common.helpers.ThreadHelper.createSingleThreadExecutor;
 import static slash.common.io.Transfer.toArray;
 import static slash.navigation.common.Interpolation.interpolate;
 import static slash.navigation.gui.helpers.WindowHelper.getFrame;
+import static slash.navigation.gui.helpers.WindowHelper.handleOutOfMemoryError;
 import static slash.navigation.routing.RoutingResult.Validity.Valid;
 
 /**
@@ -73,9 +74,11 @@ public class InsertPositionFacade {
         executor.execute(() -> {
             try {
                 doInsertStraightLinePositions(intervalMetres, selectedRows);
-            } catch (Exception e) {
-                log.severe(format("Cannot insert positions: %s, %s", e, printStackTrace(e)));
-                showError(getFrame(), format(Application.getInstance().getContext().getBundle().getString("cannot-insert-positions"), getLocalizedMessage(e)),
+            } catch (OutOfMemoryError ooem) {
+                handleOutOfMemoryError(ooem);
+            } catch (Throwable t) {
+                log.severe(format("Cannot insert positions: %s, %s", t, printStackTrace(t)));
+                showError(getFrame(), format(Application.getInstance().getContext().getBundle().getString("cannot-insert-positions"), getLocalizedMessage(t)),
                         getFrame().getTitle());
             }
         });
@@ -126,9 +129,11 @@ public class InsertPositionFacade {
         executor.execute(() -> {
             try {
                 doInsertWithRoutingService(routingService, selectedRows);
-            } catch (Exception e) {
-                log.severe(format("Cannot insert positions: %s, %s", e, printStackTrace(e)));
-                showError(getFrame(), format(Application.getInstance().getContext().getBundle().getString("cannot-insert-positions"), getLocalizedMessage(e)),
+            } catch (OutOfMemoryError ooem) {
+                handleOutOfMemoryError(ooem);
+            } catch (Throwable t) {
+                log.severe(format("Cannot insert positions: %s, %s", t, printStackTrace(t)));
+                showError(getFrame(), format(Application.getInstance().getContext().getBundle().getString("cannot-insert-positions"), getLocalizedMessage(t)),
                         getFrame().getTitle());
             }
         });


### PR DESCRIPTION
The diff exactly matches the mandated shape. Verification via `factory-verify` was attempted but returned a broker error ("repo not allowed (rc/* only)"), so build/test verification is unavailable in this sandbox — noted below.

## Summary

Fixed silent app-freeze on `OutOfMemoryError` (or any other uncaught `Error`/`Throwable`) during route/position insertion.

**Root cause:** both `executor.execute(...)` blocks in `InsertPositionFacade` (`insertStraightLinePositions` and `insertWithRoutingService`) caught only `Exception`. Since `OutOfMemoryError extends Error`, it slipped past the catch clause, killed the single-thread executor's worker silently, and left no UI feedback.

**Change:** `route-converter-gui/src/main/java/slash/navigation/converter/gui/helpers/InsertPositionFacade.java` — both catch blocks now mirror the existing `FrameAction.actionPerformed` idiom exactly:
```java
} catch (OutOfMemoryError ooem) {
    handleOutOfMemoryError(ooem);
} catch (Throwable t) {
    log.severe(...);
    showError(...);
}
```
Added the static import `slash.navigation.gui.helpers.WindowHelper.handleOutOfMemoryError`. No changes to `GraphHopper.java`, `WindowHelper.java`, executor setup, or resource bundles — confirmed `cannot-insert-positions` and `out-of-memory-error` keys already exist across all locale property files, so no new i18n strings were needed.

**Verify result:** unavailable — `factory-verify` returned a broker error (`repo not allowed (rc/* only)`), so I could not run `mvn -pl route-converter-gui -am install` in the sandbox. The change is a mechanical catch-clause widening identical in shape to the already-shipped `FrameAction` idiom, so it should compile cleanly, but the maintainer should confirm with a local build.


Source issue: cpesch/RouteConverter#337

---
**Builder stats** · model `sonnet` · confidence `0` · 0m 51s across 1 round(s) · 1 file op(s)
[Workflow run](http://127.0.0.1:3000/cpesch/RouteConverter/actions/runs/24828)

⚠ UNVERIFIED: target not verifiable by the broker (non-rc/* target or no pom.xml — v1 is maven-only)

Closes #337

<!-- issue-body-sha:497dcf6c5b24 -->