### PR TITLE
Waypoints' Marker layers should share one GroupLayer, not one Layer each (3/3: Waypoints, independent)

### DIFF
--- a/mapsforge-mapview/src/main/java/slash/navigation/mapview/mapsforge/MapsforgeMapView.java
+++ b/mapsforge-mapview/src/main/java/slash/navigation/mapview/mapsforge/MapsforgeMapView.java
@@ -216,6 +216,7 @@ public class MapsforgeMapView extends BaseMapView {
     private SelectionUpdater selectionUpdater;
     private EventMapUpdater routeUpdater, trackUpdater, waypointUpdater;
     private UpdateDecoupler updateDecoupler;
+    private final GroupLayer waypointLayer = new GroupLayer();
 
     // initialization
 
@@ -320,17 +321,54 @@ public class MapsforgeMapView extends BaseMapView {
                     positionWithLayer.setLayer(marker);
                     withLayers.add(positionWithLayer);
                 }
-                addObjectsWithLayer(withLayers);
+                synchronized (waypointLayer) {
+                    for (PositionWithLayer positionWithLayer : withLayers)
+                        waypointLayer.layers.add(positionWithLayer.getLayer());
+                }
+                waypointLayer.requestRedraw();
             }
 
             public void update(List<PositionWithLayer> positionWithLayers) {
                 List<Layer> remove = toLayers(positionWithLayers);
-                removeLayers(remove);
+                synchronized (waypointLayer) {
+                    if (remove.size() == waypointLayer.layers.size()) {
+                        waypointLayer.layers.clear();
+                    } else {
+                        Set<Layer> toRemove = new HashSet<>(remove.size());
+                        for (Layer layer : remove) {
+                            if (layer != null)
+                                toRemove.add(layer);
+                            else
+                                log.warning("Could not find layer to remove for " + layer);
+                        }
+                        waypointLayer.layers.removeAll(toRemove);
+                    }
+                }
+                waypointLayer.requestRedraw();
                 add(positionWithLayers);
             }
 
             public void remove(List<PositionWithLayer> positionWithLayers) {
-                removeObjectWithLayers(positionWithLayers);
+                synchronized (waypointLayer) {
+                    if (positionWithLayers.size() == waypointLayer.layers.size()) {
+                        waypointLayer.layers.clear();
+                    } else {
+                        Set<Layer> toRemove = new HashSet<>(positionWithLayers.size());
+                        for (PositionWithLayer positionWithLayer : positionWithLayers) {
+                            Layer layer = positionWithLayer.getLayer();
+                            if (layer != null)
+                                toRemove.add(layer);
+                            else
+                                log.warning("Could not find layer to remove for " + positionWithLayer);
+                        }
+                        waypointLayer.layers.removeAll(toRemove);
+                    }
+                }
+                waypointLayer.requestRedraw();
+                // keep the existing bookkeeping
+                for (PositionWithLayer positionWithLayer : positionWithLayers) {
+                    positionWithLayer.setLayer(null);
+                }
             }
         });
 
@@ -733,6 +771,11 @@ public class MapsforgeMapView extends BaseMapView {
 
         // catch position lists that were loaded before the map was initialized
         nonSelectedPositionListsRenderer.update();
+
+        // add the waypoint layer if not already present
+        if (!layers.contains(waypointLayer)) {
+            layers.add(waypointLayer);
+        }
     }
 
     private void updateNonSelectedPositionLists() {


### PR DESCRIPTION
Excellent! The implementation is complete. Let me create a summary of the changes:

## Summary

I have successfully implemented the fix for **Issue #361**: Waypoints' Marker layers now share one GroupLayer instead of having individual layers.

### Changes Made

**File Modified:** `mapsforge-mapview/src/main/java/slash/navigation/mapview/mapsforge/MapsforgeMapView.java`

#### 1. Added new `waypointLayer` field (line 219)
```java
private final GroupLayer waypointLayer = new GroupLayer();
```

#### 2. Modified `WaypointOperation.add()` method (lines 324-328)
- Replaced the call to `addObjectsWithLayer(withLayers)` with direct layer management
- Added synchronized block to safely add marker layers to the `waypointLayer`
- Calls `requestRedraw()` after adding layers

#### 3. Modified `WaypointOperation.update()` method (lines 331-348)
- Replaced `removeLayers(remove)` call with synchronized block that:
  - Uses fast path (`clear()`) when removing all layers
  - Uses `HashSet` for efficient partial removal
  - Calls `requestRedraw()` after removal
- Still calls `add()` afterward to recreate the updated markers

#### 4. Modified `WaypointOperation.remove()` method (lines 351-371)
- Replaced `removeObjectWithLayers()` call with synchronized block that:
  - Uses fast path (`clear()`) when removing all layers
  - Uses `HashSet` for efficient partial removal with proper null checks
  - Calls `requestRedraw()` after removal
- Maintains existing bookkeeping by setting each layer reference to null

#### 5. Added waypointLayer to map layers (lines 774-778)
- Added waypointLayer to the Layers collection in `handleNonSelectedPositionLists()`
- Uses `contains()` check to avoid duplicate additions

### Benefits

This change prevents UI freezes when handling large waypoint files by:
- **Eliminating individual layer adds/removes**: Instead of adding each marker as a separate layer to the shared `Layers` collection, all markers are now managed within a single `GroupLayer`
- **Batch redraws**: A single `requestRedraw()` call replaces what would have been many individual layer operations
- **Thread-safe**: All operations are properly synchronized on the `waypointLayer` monitor
- **Performance**: Uses fast-path clearing for bulk operations and efficient `HashSet` lookups for partial removals

### Testing

The changes follow the same pattern as the previously implemented fixes for Tracks (#359) and Routes (#360), ensuring consistency across the codebase. The existing `WaypointUpdaterTest` should remain green as it exercises `WaypointUpdater`'s delta logic against a mocked `WaypointOperation`, fully decoupled from this rewrite.


Source issue: cpesch/RouteConverter#361

---
**Builder stats** · model `sonnet` · confidence `0` · 2m 8s across 1 round(s) · 1 file op(s)
[Workflow run](http://127.0.0.1:3000/cpesch/RouteConverter/actions/runs/25299)

⚠ UNVERIFIED: target not verifiable by the broker (non-rc/* target or no pom.xml — v1 is maven-only)

Closes #361

<!-- issue-body-sha:ea12efc8b2fe -->