### PR TITLE
test(download): fix the 304 test racing its own HTTP handler

### DIFF
--- a/download/src/test/java/slash/navigation/download/DownloadManager304Test.java
+++ b/download/src/test/java/slash/navigation/download/DownloadManager304Test.java
@@ -22,7 +22,9 @@ package slash.navigation.download;
 import com.sun.net.httpserver.HttpServer;
 import org.junit.After;
 import org.junit.Before;
+import org.junit.Rule;
 import org.junit.Test;
+import org.junit.rules.Timeout;
 
 import java.io.File;
 import java.io.IOException;
@@ -58,6 +60,9 @@ public class DownloadManager304Test {
     private static final String ETAG = "\"abc123\"";
     private static final String BODY = "Lorem ipsum dolor sit amet";
 
+    @Rule
+    public final Timeout testTimeout = Timeout.seconds(30);
+
     private HttpServer server;
     private final AtomicInteger bodiesServed = new AtomicInteger();
     private DownloadManager manager;
@@ -73,11 +78,15 @@ public class DownloadManager304Test {
                 exchange.sendResponseHeaders(304, -1); // no body
             } else {
                 byte[] body = BODY.getBytes(StandardCharsets.UTF_8);
+                // Count the body BEFORE writing it: with Content-Length set the client can read the
+                // whole body, complete the download and let the test's waitForCompletion() return
+                // while this handler thread has not yet run the counter bump, so a test asserting
+                // on the count would race the handler (see DownloadManagerStateMachineTest).
+                bodiesServed.incrementAndGet();
                 exchange.sendResponseHeaders(200, body.length);
                 try (OutputStream out = exchange.getResponseBody()) {
                     out.write(body);
                 }
-                bodiesServed.incrementAndGet();
             }
             exchange.close();
         });


### PR DESCRIPTION
## Problem

`DownloadManager304Test` is flaky in CI. The Publish Javadoc run on 91ea8c5ef failed with

```
DownloadManager304Test.testOutdatedFileDropsETagSoReDownloadIsUnconditional:136 expected:<1> but was:<0>
```

while RouteConverter CI was green on the same commit. The flake already cost us a bogus patch (#368, since closed), which "fixed" an unrelated mapsforge file.

## Cause

The test's own HTTP handler counted a served body *after* writing it to the exchange:

```java
exchange.sendResponseHeaders(200, body.length);
try (OutputStream out = exchange.getResponseBody()) { out.write(body); }
bodiesServed.incrementAndGet();   // too late
```

With `Content-Length` set, the client can read the whole body, finish the download and let `waitForCompletion()` return while the handler thread has not yet run the increment. That is exactly what the failure shows: `Succeeded` and a non-null ETag assert fine one line earlier, so the body *was* served — only the count was not yet visible. A same-second mtime or a wall clock is not involved.

Reproduced reliably by stalling the handler thread for 300 ms after the body write: both tests then fail with the CI message.

## Fix

Count the body before sending the response headers, so the increment happens-before the first body byte can reach the client. This is the fix `DownloadManagerStateMachineTest` and `GetPerformerTest` already carry, with the same reasoning in a comment — this class was the leftover. Also adds the 30 s `Timeout` rule both siblings use.

No production code changes. The Outdated/ETag path itself is deterministic: the first successful download stores a real SHA-1 through `expectedChecksumIsCurrentChecksum()`, and `Validator.matches()` treats SHA-1 as authoritative, so the corrupted target is detected by content and the "locally later than remote" mtime heuristic is never consulted. The fix is OS-independent, so it holds on a Windows runner too.

## Verification

| Run | Result |
| --- | --- |
| `DownloadManager304Test` x10 | 2/2 pass each |
| Full `download` module x3 | 88 tests, 0 failures |
| `download` module with jacoco (as Publish Javadoc) | 88 tests, 0 failures |
| `DownloadManager304Test` x5 with `-XX:ActiveProcessorCount=1` | 2/2 pass each |