### PR TITLE
Cache the bundled jar under LOCALAPPDATA instead of re-extracting 60 MB per launch

### DIFF
--- a/.github/workflows/_build-windows.yml
+++ b/.github/workflows/_build-windows.yml
@@ -122,6 +122,91 @@ jobs:
         working-directory: TimeAlbumProWindows
         run: makensis "target\TimeAlbumPro.nsi"
 
+      - name: Smoke test — bundled-jar warm-launch caching (issue #372)
+        shell: pwsh
+        run: |
+          $ErrorActionPreference = 'Stop'
+
+          function Wait-ForWarmSignal($proc, $productRoot) {
+            $sw = [System.Diagnostics.Stopwatch]::StartNew()
+            $cap = [TimeSpan]::FromSeconds(90)
+            while ($sw.Elapsed -lt $cap) {
+              $stamp = Get-ChildItem -Path "$productRoot\app-*\.stamp" -ErrorAction SilentlyContinue
+              $javaChild = Get-CimInstance Win32_Process `
+                -Filter "Name='java.exe' AND ParentProcessId=$($proc.Id)" `
+                -ErrorAction SilentlyContinue
+              if ($stamp -and $javaChild) {
+                $sw.Stop()
+                return $sw.Elapsed
+              }
+              Start-Sleep -Milliseconds 100
+            }
+            throw "timed out waiting for warm signal ($($proc.Path))"
+          }
+
+          function Stop-ProcessTree($procId) {
+            taskkill /T /F /PID $procId | Out-Null
+            Start-Sleep -Milliseconds 500
+          }
+
+          function Test-WarmLaunchCaching($exePath, $productRoot, $jarName) {
+            Write-Host "=== warm-launch smoke test: $exePath ==="
+
+            # Run 1 (cold): first-ever launch must do the slow path and leave
+            # a cached jar + stamp behind (assertion A).
+            $p1 = Start-Process -FilePath $exePath -PassThru
+            $elapsed1 = Wait-ForWarmSignal $p1 $productRoot
+            Write-Host "run 1: warm signal after $($elapsed1.TotalSeconds) s"
+
+            $jar1 = Get-ChildItem -Path "$productRoot\app-*\$jarName" -ErrorAction SilentlyContinue
+            if (-not $jar1 -or $jar1.Length -le 10MB) {
+              throw "assertion A failed: $productRoot\app-*\$jarName missing or <= 10MB"
+            }
+            if (-not (Get-ChildItem -Path "$productRoot\app-*\.stamp" -ErrorAction SilentlyContinue)) {
+              throw "assertion A failed: .stamp missing after run 1"
+            }
+
+            Stop-ProcessTree $p1.Id
+
+            # Run 2 (warm): must take the fast path.
+            $p2 = Start-Process -FilePath $exePath -PassThru
+            $elapsed2 = Wait-ForWarmSignal $p2 $productRoot
+            Write-Host "run 2: warm signal after $($elapsed2.TotalSeconds) s"
+
+            # Assertion B: the app jar is never re-extracted into a fresh
+            # %TEMP%\ns*.tmp — only the small nsExec plugin DLL may land there.
+            $bigTmpJars = Get-ChildItem -Path "$env:TEMP\ns*.tmp" -Recurse -Filter *.jar -ErrorAction SilentlyContinue |
+                          Where-Object { $_.Length -gt 10MB }
+            if ($bigTmpJars) {
+              throw "assertion B failed: large jar under %TEMP%\ns*.tmp: $($bigTmpJars.FullName -join ', ')"
+            }
+
+            # Assertion C: warm path is a stamp read plus a string compare.
+            if ($elapsed2.TotalSeconds -ge 3) {
+              throw "assertion C failed: run 2 took $($elapsed2.TotalSeconds) s (expected < 3 s)"
+            }
+
+            Stop-ProcessTree $p2.Id
+
+            # Assertion D: pruning left exactly one app-* generation.
+            $appDirs = @(Get-ChildItem -Path $productRoot -Directory -Filter 'app-*' -ErrorAction SilentlyContinue)
+            if ($appDirs.Count -ne 1) {
+              throw "assertion D failed: expected exactly one app-* dir under $productRoot, found $($appDirs.Count): $($appDirs.FullName -join ', ')"
+            }
+
+            Write-Host "=== OK: $exePath ==="
+          }
+
+          Test-WarmLaunchCaching `
+            (Resolve-Path 'RouteConverterWindows\target\RouteConverterWindows.exe').Path `
+            "$env:LOCALAPPDATA\RouteConverter" `
+            'RouteConverterWindows.jar'
+
+          Test-WarmLaunchCaching `
+            (Resolve-Path 'TimeAlbumProWindows\target\TimeAlbumProWindows.exe').Path `
+            "$env:LOCALAPPDATA\TimeAlbumPro" `
+            'TimeAlbumProWindows.jar'
+
       - name: Cache PortableApps.com Installer
         id: pa-cache
         uses: actions/cache@v6

--- a/RouteConverterWindows/src/main/resources/RouteConverter.nsi
+++ b/RouteConverterWindows/src/main/resources/RouteConverter.nsi
@@ -11,6 +11,12 @@ ShowInstDetails hide
 !define JRE_SRC "..\jre-${JRE}"
 ; runtime extraction target (persisted across launches, namespaced under LocalAppData)
 !define JRE_DIR "$LOCALAPPDATA\RouteConverter\jre-${JRE}"
+; app jar generation, namespaced by build so a running instance's directory can
+; never be pulled out from under it; see issue #372.
+!define VERSION "${project.version}-${maven.build.number}"
+!define PRODUCT_DIR "$LOCALAPPDATA\RouteConverter"
+!define APP_DIR "${PRODUCT_DIR}\app-${VERSION}"
+!define STAMP_CONTENT "${VERSION}|${JRE}"
 OutFile "RouteConverterWindows.exe"
 
 Icon "RouteConverter.ico"
@@ -26,14 +32,48 @@ VIAddVersionKey OriginalFilename "RouteConverter.exe"
 Section
   SetOverwrite off
 
-  SetOutPath "${JRE_DIR}"
-  File /r "${JRE_SRC}\*"
+  ; fast path: a stamp matching this build+JRE means the app jar for this
+  ; generation is already extracted at ${APP_DIR} -- skip both extractions.
+  ClearErrors
+  FileOpen $1 "${APP_DIR}\.stamp" r
+  IfErrors slowpath
+  FileRead $1 $2
+  FileClose $1
+  StrCmp $2 "${STAMP_CONTENT}" fastpath slowpath
 
-  InitPluginsDir
-  SetOutPath $PluginsDir
-  File "RouteConverterWindows.jar"
+  slowpath:
+    ; best-effort prune of superseded generations; never disturbs a directory
+    ; still held open by a running instance (RMDir /r simply fails on it).
+    ClearErrors
+    FindFirst $3 $4 "${PRODUCT_DIR}\*.*"
+    IfErrors pruneDone
+    pruneLoop:
+      StrCmp $4 "" pruneDone
+      StrCmp $4 "." pruneNext
+      StrCmp $4 ".." pruneNext
+      StrCmp $4 "app-${VERSION}" pruneNext
+      StrCmp $4 "jre-${JRE}" pruneNext
+      RMDir /r "${PRODUCT_DIR}\$4"
+      pruneNext:
+      FindNext $3 $4
+      Goto pruneLoop
+    pruneDone:
+    FindClose $3
+
+    SetOutPath "${JRE_DIR}"
+    File /r "${JRE_SRC}\*"
+
+    SetOutPath "${APP_DIR}"
+    File "RouteConverterWindows.jar"
+
+    ; commit marker written last: an interrupted extraction leaves no valid
+    ; stamp, so the next launch redoes it instead of running a truncated jar.
+    FileOpen $1 "${APP_DIR}\.stamp" w
+    FileWrite $1 "${STAMP_CONTENT}"
+    FileClose $1
+
+  fastpath:
   SetOutPath $TEMP
   ${GetParameters} $R0
-  nsExec::Exec '"${JRE_DIR}\bin\java.exe" -server -Drouteconverter.bundledJre=true -jar $PluginsDir\RouteConverterWindows.jar $R0'
-  RMDir /r $PluginsDir
+  nsExec::Exec '"${JRE_DIR}\bin\java.exe" -server -Drouteconverter.bundledJre=true -jar "${APP_DIR}\RouteConverterWindows.jar" $R0'
 SectionEnd

--- a/TimeAlbumProWindows/src/main/resources/TimeAlbumPro.nsi
+++ b/TimeAlbumProWindows/src/main/resources/TimeAlbumPro.nsi
@@ -11,6 +11,12 @@ ShowInstDetails hide
 !define JRE_SRC "..\jre-${JRE}"
 ; runtime extraction target (persisted across launches, namespaced under LocalAppData)
 !define JRE_DIR "$LOCALAPPDATA\TimeAlbumPro\jre-${JRE}"
+; app jar generation, namespaced by build so a running instance's directory can
+; never be pulled out from under it; see issue #372.
+!define VERSION "${project.version}-${maven.build.number}"
+!define PRODUCT_DIR "$LOCALAPPDATA\TimeAlbumPro"
+!define APP_DIR "${PRODUCT_DIR}\app-${VERSION}"
+!define STAMP_CONTENT "${VERSION}|${JRE}"
 OutFile "TimeAlbumProWindows.exe"
 
 Icon "TimeAlbumPro.ico"
@@ -26,14 +32,48 @@ VIAddVersionKey OriginalFilename "TimeAlbumPro.exe"
 Section
   SetOverwrite off
 
-  SetOutPath "${JRE_DIR}"
-  File /r "${JRE_SRC}\*"
+  ; fast path: a stamp matching this build+JRE means the app jar for this
+  ; generation is already extracted at ${APP_DIR} -- skip both extractions.
+  ClearErrors
+  FileOpen $1 "${APP_DIR}\.stamp" r
+  IfErrors slowpath
+  FileRead $1 $2
+  FileClose $1
+  StrCmp $2 "${STAMP_CONTENT}" fastpath slowpath
 
-  InitPluginsDir
-  SetOutPath $PluginsDir
-  File "TimeAlbumProWindows.jar"
+  slowpath:
+    ; best-effort prune of superseded generations; never disturbs a directory
+    ; still held open by a running instance (RMDir /r simply fails on it).
+    ClearErrors
+    FindFirst $3 $4 "${PRODUCT_DIR}\*.*"
+    IfErrors pruneDone
+    pruneLoop:
+      StrCmp $4 "" pruneDone
+      StrCmp $4 "." pruneNext
+      StrCmp $4 ".." pruneNext
+      StrCmp $4 "app-${VERSION}" pruneNext
+      StrCmp $4 "jre-${JRE}" pruneNext
+      RMDir /r "${PRODUCT_DIR}\$4"
+      pruneNext:
+      FindNext $3 $4
+      Goto pruneLoop
+    pruneDone:
+    FindClose $3
+
+    SetOutPath "${JRE_DIR}"
+    File /r "${JRE_SRC}\*"
+
+    SetOutPath "${APP_DIR}"
+    File "TimeAlbumProWindows.jar"
+
+    ; commit marker written last: an interrupted extraction leaves no valid
+    ; stamp, so the next launch redoes it instead of running a truncated jar.
+    FileOpen $1 "${APP_DIR}\.stamp" w
+    FileWrite $1 "${STAMP_CONTENT}"
+    FileClose $1
+
+  fastpath:
   SetOutPath $TEMP
   ${GetParameters} $R0
-  nsExec::Exec '"${JRE_DIR}\bin\java.exe" -server -jar $PluginsDir\TimeAlbumProWindows.jar $R0'
-  RMDir /r $PluginsDir
+  nsExec::Exec '"${JRE_DIR}\bin\java.exe" -server -jar "${APP_DIR}\TimeAlbumProWindows.jar" $R0'
 SectionEnd


### PR DESCRIPTION
Implements #372 (crash-report #1343: 15-20s Windows startup). Both NSIS launchers extract app jar + JRE into $LOCALAPPDATA\<Product>\app-<version> gated by a version+jre stamp file (crash-safe: stamp written last); warm launches skip extraction entirely; superseded app-*/jre-* dirs pruned; -jar path quoted (latent space-in-path fix). CI gains a two-launch smoke on the built installers asserting cold-extract, no-TEMP-jar, warm-under-3s, single-surviving-dir.

Built by a maintainer session — the factory cannot push workflow-file changes by design (two builder runs died on exactly that; see the issue).

Closes #372

🤖 Generated with [Claude Code](https://claude.com/claude-code)