### PR TITLE
world map background leaves a permanent grey hole after startup

### DIFF
--- a/mapsforge-mapview/src/main/java/slash/navigation/mapview/mapsforge/BackgroundMapAttachment.java
+++ b/mapsforge-mapview/src/main/java/slash/navigation/mapview/mapsforge/BackgroundMapAttachment.java
@@ -47,4 +47,18 @@ public class BackgroundMapAttachment {
     public static boolean shouldAttachBackground(boolean layerReady, boolean hasDisplayedMap) {
         return layerReady && hasDisplayedMap;
     }
+
+    /**
+     * A layer-stack rebuild (map/theme change) can kill in-flight tile jobs of an already
+     * attached background layer without re-issuing them, leaving unpainted tiles behind
+     * until the user pans or zooms. Forcing one redraw afterwards lets
+     * {@code TileLayer.draw()} re-queue whatever job the rebuild dropped.
+     *
+     * @param backgroundAttached    whether the background layer is attached as the base layer now
+     * @param stackRebuilt          whether the displayed map/theme layer stack was just torn down and rebuilt
+     * @return true iff one redraw of the layer stack should be forced to repair a job dropped during the rebuild
+     */
+    public static boolean shouldRedrawAfterStackRebuild(boolean backgroundAttached, boolean stackRebuilt) {
+        return backgroundAttached && stackRebuilt;
+    }
 }

--- a/mapsforge-mapview/src/main/java/slash/navigation/mapview/mapsforge/MapsforgeMapView.java
+++ b/mapsforge-mapview/src/main/java/slash/navigation/mapview/mapsforge/MapsforgeMapView.java
@@ -751,7 +751,7 @@ public class MapsforgeMapView extends BaseMapView {
         layers.add(0, layer);
         mapsToLayers.put(map, layer);
 
-        handleBackground();
+        handleBackground(true);
         handleOverlays();
         handleTrackLayer();
         handleNonSelectedPositionLists();
@@ -793,13 +793,25 @@ public class MapsforgeMapView extends BaseMapView {
     }
 
     private void handleBackground() {
+        handleBackground(false);
+    }
+
+    // stackRebuilt is true when called from handleMapAndThemeUpdate(), which tears down and
+    // rebuilds the displayed map layer stack; an in-flight tile job of an already attached
+    // background layer can be killed by that rebuild and never re-issued (issue #376), so
+    // force one redraw afterwards to let TileLayer.draw() re-queue the dropped job
+    private void handleBackground(boolean stackRebuilt) {
         Layers layers = getLayerManager().getLayers();
         if (backgroundLayer != null)
             layers.remove(backgroundLayer);
 
         LocalMap map = getMapManager().getDisplayedMapModel().getItem();
-        if (BackgroundMapAttachment.shouldAttachBackground(backgroundLayer != null, map != null))
+        boolean backgroundAttached = BackgroundMapAttachment.shouldAttachBackground(backgroundLayer != null, map != null);
+        if (backgroundAttached)
             layers.add(0, backgroundLayer);
+
+        if (BackgroundMapAttachment.shouldRedrawAfterStackRebuild(backgroundAttached, stackRebuilt))
+            getLayerManager().redrawLayers();
     }
 
     private void handleNonSelectedPositionLists() {

--- a/mapsforge-mapview/src/test/java/slash/navigation/mapview/mapsforge/BackgroundMapAttachmentTest.java
+++ b/mapsforge-mapview/src/test/java/slash/navigation/mapview/mapsforge/BackgroundMapAttachmentTest.java
@@ -24,6 +24,7 @@ import org.junit.Test;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 import static slash.navigation.mapview.mapsforge.BackgroundMapAttachment.shouldAttachBackground;
+import static slash.navigation.mapview.mapsforge.BackgroundMapAttachment.shouldRedrawAfterStackRebuild;
 
 /**
  * Tests for {@link BackgroundMapAttachment}.
@@ -48,5 +49,24 @@ public class BackgroundMapAttachmentTest {
         // selectable map is the online OpenStreetMap default still shows a map
         // instead of staying gray when those tiles cannot be reached
         assertTrue(shouldAttachBackground(true, true));
+    }
+
+    @Test
+    public void doesNotRedrawWhenNothingAttached() {
+        // nothing attached, nothing to repair
+        assertFalse(shouldRedrawAfterStackRebuild(false, true));
+    }
+
+    @Test
+    public void doesNotRedrawWhenNoStackRebuildHappened() {
+        // no rebuild happened, do not force redraws on every update
+        assertFalse(shouldRedrawAfterStackRebuild(true, false));
+    }
+
+    @Test
+    public void redrawsWhenBackgroundAttachedAndStackWasRebuilt() {
+        // background attached and the stack was rebuilt under it: force one redraw
+        // so a tile job dropped during the rebuild gets re-queued
+        assertTrue(shouldRedrawAfterStackRebuild(true, true));
     }
 }


### PR DESCRIPTION
## Summary

Fixed the permanent grey hole in the world-map background (issue #376) by forcing one layer-stack redraw after `handleMapAndThemeUpdate()` rebuilds the map/theme layers, so a background tile job interrupted by that rebuild gets re-queued by mapsforge's `TileLayer.draw()` instead of staying unpainted for the rest of the session.

**Root cause (per the issue's diagnosis):** `handleMapAndThemeUpdate()` tears down and rebuilds the displayed-map layer stack on every map/theme change. If the async background-download callback (`setBackgroundMap`) had already attached the background layer and had tile jobs in flight, that rebuild kills them without re-issuing them. Nothing repaints the view afterward, so the hole (interrupted tiles) persists until the user pans or zooms.

**Changes:**
- `BackgroundMapAttachment.java` — added the sibling predicate `shouldRedrawAfterStackRebuild(boolean backgroundAttached, boolean stackRebuilt)`, covering exactly the three cases from the issue: no background attached → false; background attached but no rebuild happened → false (don't force redraws on every update); both true → force a redraw.
- `BackgroundMapAttachmentTest.java` — added the three corresponding unit tests.
- `MapsforgeMapView.java` — split `handleBackground()` into a no-arg wrapper (`stackRebuilt=false`, used by `setBackgroundMap`) and `handleBackground(boolean stackRebuilt)`. `handleMapAndThemeUpdate()` now calls `handleBackground(true)`; when the predicate is true, it calls `getLayerManager().redrawLayers()` (the same mechanism already used elsewhere in this file to force a repaint), which lets `TileLayer.draw()` re-queue the tile job the rebuild dropped.

**Verification:** unavailable in this environment — `factory-verify` returned a broker error (`repo not allowed (rc/* only)`), and no JDK is reachable on `PATH` or via sdkman outside the sandboxed working directory, so I could not run `mvn -pl mapsforge-mapview test` myself. The new tests are plain JUnit against the pure predicate (mirroring the existing `attachesWhenLayerReadyAndAnyMapDisplayed` pattern) and should pass; please run `./mvnw -pl mapsforge-mapview -am test` to confirm, and do the manual startup check described in the issue (partial offline map + world background, no flat `#EEEEEE` rectangle after startup).


Source issue: cpesch/RouteConverter#376

---
**Builder stats** · model `sonnet` · confidence `0` · 2m 2s across 1 round(s) · 3 file op(s)
[Workflow run](http://127.0.0.1:3000/cpesch/RouteConverter/actions/runs/26215)

⚠ UNVERIFIED: target not verifiable by the broker (non-rc/* target or no pom.xml — v1 is maven-only)

Closes #376

<!-- issue-body-sha:1877033a99f4 -->