### PR TITLE
ci(crowdin): pin manual disable in-file — if:false + banner (rc-meta#127)

### DIFF
--- a/.github/workflows/crowdin.yml
+++ b/.github/workflows/crowdin.yml
@@ -1,3 +1,17 @@
+# ---------------------------------------------------------------------------
+# DISABLED MANUALLY (see rc/rc-meta#127) — do not re-enable without review.
+#
+# This workflow pushes translation commits and opens pull requests using
+# repo secrets (GITHUB_TOKEN, CROWDIN_PROJECT_ID, CROWDIN_PERSONAL_TOKEN).
+# Re-enabling requires a maintainer to review current CROWDIN_* secret
+# usage first. When re-enabling, remove the `if: false` below AND
+# re-enable the workflow in the GitHub UI together — doing only one
+# leaves it in an inconsistent state.
+#
+# Note: GH_BUILDER_PAT (the factory's automation token) deliberately
+# lacks the `workflow` scope, so this file can only ever be changed by
+# a human/maintainer-credentialed push, never by the factory.
+# ---------------------------------------------------------------------------
 name: Crowdin sync
 
 on:
@@ -13,6 +27,7 @@ permissions:
 
 jobs:
   synchronize:
+    if: false # disabled manually — see banner above (rc/rc-meta#127)
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v7


### PR DESCRIPTION
Makes the manual UI-disable of the Crowdin sync workflow self-documenting in the file itself: `if: false` on the single job plus a banner explaining why it is off (rc/rc-meta#127), what secrets it consumes, and that re-enabling requires removing the `if: false` AND re-enabling in the UI together. The factory's GH_BUILDER_PAT deliberately lacks the workflow scope, so this file only ever changes via a maintainer-credentialed push.

🤖 Generated with [Claude Code](https://claude.com/claude-code)