### PR TITLE
fix(map): keep the world-map background rendering after the layer stack is rebuilt

### DIFF
--- a/mapsforge-mapview/src/main/java/slash/navigation/mapview/mapsforge/BackgroundMapAttachment.java
+++ b/mapsforge-mapview/src/main/java/slash/navigation/mapview/mapsforge/BackgroundMapAttachment.java
@@ -49,6 +49,19 @@ public class BackgroundMapAttachment {
     }
 
     /**
+     * The displayed map layer has to sit directly above the world-map background. Inserting it there
+     * instead of always at index 0 and then moving the background back below it avoids removing and
+     * re-adding the background layer, which mapsforge's {@code TileRendererLayer} does not survive
+     * (see {@code ReattachableTileRendererLayer}).
+     *
+     * @param backgroundLayerIndex  index of the attached background layer in the layer list, or -1 if none is attached
+     * @return the index at which the displayed map layer has to be inserted
+     */
+    public static int displayedMapLayerIndex(int backgroundLayerIndex) {
+        return backgroundLayerIndex < 0 ? 0 : backgroundLayerIndex + 1;
+    }
+
+    /**
      * A layer-stack rebuild (map/theme change) can kill in-flight tile jobs of an already
      * attached background layer without re-issuing them, leaving unpainted tiles behind
      * until the user pans or zooms. Forcing one redraw afterwards lets

--- a/mapsforge-mapview/src/main/java/slash/navigation/mapview/mapsforge/MapsforgeMapView.java
+++ b/mapsforge-mapview/src/main/java/slash/navigation/mapview/mapsforge/MapsforgeMapView.java
@@ -584,6 +584,12 @@ public class MapsforgeMapView extends BaseMapView {
             log.severe(format("Cannot load background map %s (%d bytes): %s", backgroundMap, length, e));
             return;
         }
+        // a re-downloaded world.map replaces the previous layer: detach and destroy that one,
+        // otherwise it stays in the layer list underneath the new one for the whole session
+        if (backgroundLayer != null) {
+            getLayerManager().getLayers().remove(backgroundLayer);
+            destroyLayer(backgroundLayer);
+        }
         // the layer is built now; a no-op inside handleBackground() (e.g. no map displayed
         // yet) must not discard it, since nothing would rebuild it afterwards
         backgroundLayer = builtLayer;
@@ -745,15 +751,16 @@ public class MapsforgeMapView extends BaseMapView {
         for (Map.Entry<LocalMap, Layer> entry : mapsToLayers.entrySet()) {
             Layer remove = entry.getValue();
             layers.remove(remove);
-            remove.onDestroy();
-
-            if (remove instanceof TileLayer<?> tileLayer)
-                tileLayer.getTileCache().destroy();
+            destroyLayer(remove);
         }
         mapsToLayers.clear();
 
-        // add map as the first to be behind all additional layers
-        layers.add(0, layer);
+        // add map directly above the world-map background (or as the first layer if none is
+        // attached) to be behind all additional layers. Inserting it at index 0 and moving the
+        // background back below it would remove and re-add the background layer, and a re-added
+        // TileRendererLayer never renders another tile (see ReattachableTileRendererLayer)
+        int backgroundLayerIndex = backgroundLayer != null ? layers.indexOf(backgroundLayer) : -1;
+        layers.add(BackgroundMapAttachment.displayedMapLayerIndex(backgroundLayerIndex), layer);
         mapsToLayers.put(map, layer);
 
         handleBackground(true);
@@ -797,26 +804,34 @@ public class MapsforgeMapView extends BaseMapView {
         layers.add(index, trackLayer);
     }
 
-    private void handleBackground() {
-        handleBackground(false);
-    }
-
     // stackRebuilt is true when called from handleMapAndThemeUpdate(), which tears down and
     // rebuilds the displayed map layer stack; an in-flight tile job of an already attached
     // background layer can be killed by that rebuild and never re-issued (issue #376), so
     // force one redraw afterwards to let TileLayer.draw() re-queue the dropped job
     private void handleBackground(boolean stackRebuilt) {
         Layers layers = getLayerManager().getLayers();
-        if (backgroundLayer != null)
-            layers.remove(backgroundLayer);
+        boolean attached = backgroundLayer != null && layers.indexOf(backgroundLayer) >= 0;
 
         LocalMap map = getMapManager().getDisplayedMapModel().getItem();
         boolean backgroundAttached = BackgroundMapAttachment.shouldAttachBackground(backgroundLayer != null, map != null);
-        if (backgroundAttached)
+        // attach or detach only when the state changes: Layers.add() and Layers.remove() restart the
+        // layer's worker pool, and removing and re-adding a plain TileRendererLayer leaves its worker
+        // pool on a stale job queue so that it never renders again (see ReattachableTileRendererLayer).
+        // handleMapAndThemeUpdate() inserts the displayed map above the background, so an attached
+        // background is already at the bottom and never needs to move
+        if (backgroundAttached && !attached)
             layers.add(0, backgroundLayer);
+        else if (!backgroundAttached && attached)
+            layers.remove(backgroundLayer);
 
         if (BackgroundMapAttachment.shouldRedrawAfterStackRebuild(backgroundAttached, stackRebuilt))
             getLayerManager().redrawLayers();
+    }
+
+    private static void destroyLayer(Layer layer) {
+        layer.onDestroy();
+        if (layer instanceof TileLayer<?> tileLayer)
+            tileLayer.getTileCache().destroy();
     }
 
     private void handleNonSelectedPositionLists() {

--- a/mapsforge-mapview/src/main/java/slash/navigation/mapview/mapsforge/tiles/DefaultTileLayerFactory.java
+++ b/mapsforge-mapview/src/main/java/slash/navigation/mapview/mapsforge/tiles/DefaultTileLayerFactory.java
@@ -85,7 +85,10 @@ public class DefaultTileLayerFactory implements TileLayerFactory {
     }
 
     private TileRendererLayer createTileRendererLayer(MapFile mapFile, String cacheId) {
-        return new TileRendererLayer(createTileCache(cacheId), mapFile,
+        // a plain TileRendererLayer stops rendering once it has been removed from and re-added to
+        // the Layers, which happens to the background layer when the displayed map goes away and
+        // comes back (see ReattachableTileRendererLayer)
+        return new ReattachableTileRendererLayer(createTileCache(cacheId), mapFile,
                 mapViewPosition, true, true, true,
                 graphicFactory, hillsRenderConfig);
     }

--- a/mapsforge-mapview/src/main/java/slash/navigation/mapview/mapsforge/tiles/ReattachableTileRendererLayer.java
+++ b/mapsforge-mapview/src/main/java/slash/navigation/mapview/mapsforge/tiles/ReattachableTileRendererLayer.java
@@ -36,7 +36,7 @@ import org.mapsforge.map.model.MapViewPosition;
  * A {@link TileRendererLayer} that keeps rendering after it has been removed from and re-added to
  * the {@link Layers} of a map view.
  * <p>
- * Works around a mapsforge (0.30.0) bug: {@link Layers#add} calls {@link #setDisplayModel} on every add,
+ * Works around a mapsforge (0.30.0) bug, reported as mapsforge/mapsforge#1817: {@link Layers#add} calls {@link #setDisplayModel} on every add,
  * and {@link TileLayer#setDisplayModel} replaces the layer's {@link JobQueue} with a fresh instance each
  * time, but {@link TileRendererLayer#setDisplayModel} creates its {@link MapWorkerPool} only once, bound
  * to the queue that existed on the first add. After a re-add, {@code TileLayer.draw()} queues tile jobs

--- a/mapsforge-mapview/src/main/java/slash/navigation/mapview/mapsforge/tiles/ReattachableTileRendererLayer.java
+++ b/mapsforge-mapview/src/main/java/slash/navigation/mapview/mapsforge/tiles/ReattachableTileRendererLayer.java
@@ -1,0 +1,70 @@
+/*
+    This file is part of RouteConverter.
+
+    RouteConverter is free software; you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation; either version 2 of the License, or
+    (at your option) any later version.
+
+    RouteConverter is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with RouteConverter; if not, write to the Free Software
+    Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
+
+    Copyright (C) 2007 Christian Pesch. All Rights Reserved.
+*/
+package slash.navigation.mapview.mapsforge.tiles;
+
+import org.mapsforge.core.graphics.GraphicFactory;
+import org.mapsforge.map.datastore.MapDataStore;
+import org.mapsforge.map.layer.Layers;
+import org.mapsforge.map.layer.TileLayer;
+import org.mapsforge.map.layer.cache.TileCache;
+import org.mapsforge.map.layer.hills.HillsRenderConfig;
+import org.mapsforge.map.layer.queue.JobQueue;
+import org.mapsforge.map.layer.renderer.MapWorkerPool;
+import org.mapsforge.map.layer.renderer.RendererJob;
+import org.mapsforge.map.layer.renderer.TileRendererLayer;
+import org.mapsforge.map.model.DisplayModel;
+import org.mapsforge.map.model.MapViewPosition;
+
+/**
+ * A {@link TileRendererLayer} that keeps rendering after it has been removed from and re-added to
+ * the {@link Layers} of a map view.
+ * <p>
+ * Works around a mapsforge (0.30.0) bug: {@link Layers#add} calls {@link #setDisplayModel} on every add,
+ * and {@link TileLayer#setDisplayModel} replaces the layer's {@link JobQueue} with a fresh instance each
+ * time, but {@link TileRendererLayer#setDisplayModel} creates its {@link MapWorkerPool} only once, bound
+ * to the queue that existed on the first add. After a re-add, {@code TileLayer.draw()} queues tile jobs
+ * into the new queue while the worker pool waits on the old one forever, so the layer never renders
+ * another tile. This is what left the world map background blank (issue #376).
+ * <p>
+ * Keeping the first queue for the whole lifetime of the layer keeps {@code draw()} and the worker pool
+ * on the same queue. The queue only captures the map view position and display model, which stay the
+ * same objects for a map view, so reusing it is safe.
+ */
+public class ReattachableTileRendererLayer extends TileRendererLayer {
+    private JobQueue<RendererJob> firstJobQueue;
+
+    public ReattachableTileRendererLayer(TileCache tileCache, MapDataStore mapDataStore, MapViewPosition mapViewPosition,
+                                         boolean isTransparent, boolean renderLabels, boolean cacheLabels,
+                                         GraphicFactory graphicFactory, HillsRenderConfig hillsRenderConfig) {
+        super(tileCache, mapDataStore, mapViewPosition, isTransparent, renderLabels, cacheLabels, graphicFactory, hillsRenderConfig);
+    }
+
+    @Override
+    public synchronized void setDisplayModel(DisplayModel displayModel) {
+        super.setDisplayModel(displayModel);
+        if (displayModel == null)
+            return;
+
+        if (firstJobQueue == null)
+            firstJobQueue = jobQueue;
+        else
+            jobQueue = firstJobQueue;
+    }
+}

--- a/mapsforge-mapview/src/test/java/slash/navigation/mapview/mapsforge/BackgroundMapAttachmentTest.java
+++ b/mapsforge-mapview/src/test/java/slash/navigation/mapview/mapsforge/BackgroundMapAttachmentTest.java
@@ -21,8 +21,10 @@ package slash.navigation.mapview.mapsforge;
 
 import org.junit.Test;
 
+import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
+import static slash.navigation.mapview.mapsforge.BackgroundMapAttachment.displayedMapLayerIndex;
 import static slash.navigation.mapview.mapsforge.BackgroundMapAttachment.shouldAttachBackground;
 import static slash.navigation.mapview.mapsforge.BackgroundMapAttachment.shouldRedrawAfterStackRebuild;
 
@@ -68,5 +70,16 @@ public class BackgroundMapAttachmentTest {
         // background attached and the stack was rebuilt under it: force one redraw
         // so a tile job dropped during the rebuild gets re-queued
         assertTrue(shouldRedrawAfterStackRebuild(true, true));
+    }
+
+    @Test
+    public void displayedMapIsTheBottomLayerWhenNoBackgroundIsAttached() {
+        assertEquals(0, displayedMapLayerIndex(-1));
+    }
+
+    @Test
+    public void displayedMapSitsDirectlyAboveAnAttachedBackground() {
+        // inserting it there instead of at 0 avoids moving (removing and re-adding) the background layer
+        assertEquals(1, displayedMapLayerIndex(0));
     }
 }

--- a/mapsforge-mapview/src/test/java/slash/navigation/mapview/mapsforge/tiles/ReattachableTileRendererLayerTest.java
+++ b/mapsforge-mapview/src/test/java/slash/navigation/mapview/mapsforge/tiles/ReattachableTileRendererLayerTest.java
@@ -1,0 +1,105 @@
+/*
+    This file is part of RouteConverter.
+
+    RouteConverter is free software; you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation; either version 2 of the License, or
+    (at your option) any later version.
+
+    RouteConverter is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with RouteConverter; if not, write to the Free Software
+    Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
+
+    Copyright (C) 2007 Christian Pesch. All Rights Reserved.
+*/
+package slash.navigation.mapview.mapsforge.tiles;
+
+import org.junit.After;
+import org.junit.Test;
+import org.mapsforge.map.datastore.MultiMapDataStore;
+import org.mapsforge.map.layer.TileLayer;
+import org.mapsforge.map.layer.cache.InMemoryTileCache;
+import org.mapsforge.map.layer.renderer.TileRendererLayer;
+import org.mapsforge.map.model.DisplayModel;
+import org.mapsforge.map.model.MapViewPosition;
+
+import java.lang.reflect.Field;
+
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNotSame;
+import static org.junit.Assert.assertSame;
+import static org.mapsforge.map.awt.graphics.AwtGraphicFactory.INSTANCE;
+
+public class ReattachableTileRendererLayerTest {
+    private final DisplayModel displayModel = new DisplayModel();
+    private TileRendererLayer layer;
+
+    private TileRendererLayer plainLayer() {
+        return new TileRendererLayer(new InMemoryTileCache(1), new MultiMapDataStore(), new MapViewPosition(displayModel),
+                true, true, true, INSTANCE, null);
+    }
+
+    private TileRendererLayer reattachableLayer() {
+        return new ReattachableTileRendererLayer(new InMemoryTileCache(1), new MultiMapDataStore(), new MapViewPosition(displayModel),
+                true, true, true, INSTANCE, null);
+    }
+
+    @After
+    public void tearDown() {
+        if (layer != null)
+            layer.setDisplayModel(null); // stops the MapWorkerPool
+    }
+
+    private static Object field(Object object, Class<?> declaringClass, String name) throws Exception {
+        Field field = declaringClass.getDeclaredField(name);
+        field.setAccessible(true);
+        return field.get(object);
+    }
+
+    /** the queue {@code TileLayer.draw()} adds tile jobs to */
+    private static Object layerQueue(TileRendererLayer layer) throws Exception {
+        return field(layer, TileLayer.class, "jobQueue");
+    }
+
+    /** the queue the layer's MapWorkerPool takes tile jobs from */
+    private static Object workerPoolQueue(TileRendererLayer layer) throws Exception {
+        Object mapWorkerPool = field(layer, TileRendererLayer.class, "mapWorkerPool");
+        assertNotNull("MapWorkerPool is created on the first setDisplayModel()", mapWorkerPool);
+        return field(mapWorkerPool, mapWorkerPool.getClass(), "jobQueue");
+    }
+
+    @Test
+    public void workerPoolStaysOnTheLayersQueueAfterReAdd() throws Exception {
+        layer = reattachableLayer();
+
+        layer.setDisplayModel(displayModel); // Layers.add()
+        Object firstQueue = layerQueue(layer);
+        assertSame(firstQueue, workerPoolQueue(layer));
+
+        layer.setDisplayModel(displayModel); // Layers.remove() + Layers.add()
+        assertSame("draw() and the worker pool must use the same queue after a re-add", firstQueue, layerQueue(layer));
+        assertSame(firstQueue, workerPoolQueue(layer));
+    }
+
+    /**
+     * Documents the mapsforge bug the subclass works around. When this test fails after a mapsforge
+     * upgrade, the bug is fixed upstream and ReattachableTileRendererLayer can be dropped.
+     */
+    @Test
+    public void plainTileRendererLayerLosesItsWorkerPoolQueueOnReAdd() throws Exception {
+        layer = plainLayer();
+
+        layer.setDisplayModel(displayModel);
+        Object firstQueue = layerQueue(layer);
+        assertSame(firstQueue, workerPoolQueue(layer));
+
+        layer.setDisplayModel(displayModel);
+        assertNotSame("mapsforge replaces the layer's queue on every setDisplayModel()", firstQueue, layerQueue(layer));
+        assertSame("but keeps the worker pool on the first one", firstQueue, workerPoolQueue(layer));
+    }
+}

--- a/mapsforge-mapview/src/test/java/slash/navigation/mapview/mapsforge/tiles/ReattachableTileRendererLayerTest.java
+++ b/mapsforge-mapview/src/test/java/slash/navigation/mapview/mapsforge/tiles/ReattachableTileRendererLayerTest.java
@@ -87,7 +87,7 @@ public class ReattachableTileRendererLayerTest {
     }
 
     /**
-     * Documents the mapsforge bug the subclass works around. When this test fails after a mapsforge
+     * Documents the mapsforge bug (mapsforge/mapsforge#1817) the subclass works around. When this test fails after a mapsforge
      * upgrade, the bug is fixed upstream and ReattachableTileRendererLayer can be dropped.
      */
     @Test


### PR DESCRIPTION
## Summary

The world-map background stopped rendering right after startup and stayed blank for the whole session (#376, and the "grey hole" that #377 chased). Both earlier fixes addressed symptoms; the layer itself was dead.

## Root cause

mapsforge 0.30.0 bug (still on mapsforge master, reported upstream as mapsforge/mapsforge#1817): `Layers.add()` calls `setDisplayModel()` on every add, `TileLayer.setDisplayModel()` replaces the layer's `JobQueue` with a fresh instance each time, but `TileRendererLayer.setDisplayModel()` creates its `MapWorkerPool` only once, bound to the first queue. After a remove + re-add, `TileLayer.draw()` queues tile jobs into the new queue while the worker pool waits on the old one forever.

`handleBackground()` always removed and re-added the background layer to move it below the freshly inserted displayed-map layer. So the first `handleMapAndThemeUpdate()` after `setBackgroundMap()` killed the background for good. The forced redraw from #377 only fed the orphaned queue.

Evidence: the background's `FileSystemTileCache` dir (`$TMPDIR/routeconverter-$USER/world.map/`) stayed empty while the displayed map cached 58 tiles; a thread dump showed the background's `MapWorkerPool` loop parked in `JobQueue.get()` with its worker threads never spawned; the heap held two `JobQueue`s for that layer.

## Changes

- `ReattachableTileRendererLayer` keeps the first `JobQueue` for the lifetime of the layer so `draw()` and the worker pool stay on the same queue. `DefaultTileLayerFactory` creates it for displayed maps and the background.
- `handleMapAndThemeUpdate()` inserts the displayed map directly above an attached background (`BackgroundMapAttachment.displayedMapLayerIndex`) instead of at index 0, so the background never has to move. `handleBackground()` only attaches or detaches on a state change.
- `setBackgroundMap()` detaches and destroys the previous background layer when `world.map` is re-downloaded mid-session instead of leaving it in the layer list.
- Dropped the unused no-arg `handleBackground()`.

## Verification

- Headless harness: a plain `TileRendererLayer` renders 0 tiles after remove + re-add, the reattachable one renders all 20.
- `ReattachableTileRendererLayerTest` (2 tests, one documents the upstream bug so a mapsforge upgrade that fixes it makes the workaround removable), `BackgroundMapAttachmentTest` +2. `mvn -pl mapsforge-mapview test`: 153 tests green.
- Running app with `schleswig-holstein.map` + world background: `world.map` tile cache fills at startup (59 tiles), whole viewport shows land and sea at zoom 5 with no grey area, no `InterruptedException` in the log.

Refs #376, supersedes #377.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
