### PR TITLE
ChecksumSender reports the checksum of a download that failed validation, polluting the catalog

### DIFF
--- a/download/src/main/java/slash/navigation/download/ChecksumReportPolicy.java
+++ b/download/src/main/java/slash/navigation/download/ChecksumReportPolicy.java
@@ -41,15 +41,16 @@ public class ChecksumReportPolicy {
     private ChecksumReportPolicy() {}
 
     /**
-     * @param state the terminal state of the failed download
+     * @param state the terminal state of the download
      * @param announcedContentLength the Content-Length announced by the HTTP response, if any
      * @param actualContentLength the size of the file that was written
      * @param announcedLastModified the Last-Modified announced by the HTTP response, if any
      * @param actualLastModified the last-modified of the file that was written
-     * @return true iff the checksum of this download may be reported to the server as a new known-good build
+     * @return true iff this checksum is trustworthy enough to be reported to the server as a
+     * new known-good build
      */
-    public static boolean shouldReportFailedDownload(State state, Long announcedContentLength, Long actualContentLength,
-                                                     Long announcedLastModified, Long actualLastModified) {
+    public static boolean isReportableChecksum(State state, Long announcedContentLength, Long actualContentLength,
+                                               Long announcedLastModified, Long actualLastModified) {
         // only a validation failure happens on a completely transferred file; a transport error
         // leaves the content in an unknown state whose checksum is meaningless
         if (state != State.ChecksumError)

--- a/download/src/main/java/slash/navigation/download/ChecksumReportPolicy.java
+++ b/download/src/main/java/slash/navigation/download/ChecksumReportPolicy.java
@@ -1,0 +1,71 @@
+/*
+    This file is part of RouteConverter.
+
+    RouteConverter is free software; you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation; either version 2 of the License, or
+    (at your option) any later version.
+
+    RouteConverter is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with RouteConverter; if not, write to the Free Software
+    Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
+
+    Copyright (C) 2007 Christian Pesch. All Rights Reserved.
+*/
+
+package slash.navigation.download;
+
+import static slash.common.io.Transfer.roundMillisecondsToSecondPrecision;
+
+/**
+ * Decides whether the checksum of a {@link Download} that failed may be reported to the catalog
+ * server as a new known-good build.
+ * <p>
+ * A failed download only carries a reportable checksum if the transfer provably completed and the
+ * failure came from validation: the response announced a Content-Length the written file matches
+ * exactly, and a Last-Modified the file still carries. That is the genuine "the upstream rebuilt
+ * the file and the catalog is stale" case the catalog wants to learn about. Anything else — a
+ * truncated transfer, a response without a Content-Length, a transport error, a different
+ * Last-Modified — describes content the server never announced, and reporting its checksum would
+ * pollute the catalog's known-good checksums (see GitHub #382).
+ *
+ * @author Christian Pesch
+ */
+public class ChecksumReportPolicy {
+
+    private ChecksumReportPolicy() {}
+
+    /**
+     * @param state the terminal state of the failed download
+     * @param announcedContentLength the Content-Length announced by the HTTP response, if any
+     * @param actualContentLength the size of the file that was written
+     * @param announcedLastModified the Last-Modified announced by the HTTP response, if any
+     * @param actualLastModified the last-modified of the file that was written
+     * @return true iff the checksum of this download may be reported to the server as a new known-good build
+     */
+    public static boolean shouldReportFailedDownload(State state, Long announcedContentLength, Long actualContentLength,
+                                                     Long announcedLastModified, Long actualLastModified) {
+        // only a validation failure happens on a completely transferred file; a transport error
+        // leaves the content in an unknown state whose checksum is meaningless
+        if (state != State.ChecksumError)
+            return false;
+
+        // without an announced Content-Length the transfer cannot be proven complete, and a size
+        // that differs from it means the content is not the announced one
+        if (announcedContentLength == null || actualContentLength == null ||
+                !announcedContentLength.equals(actualContentLength))
+            return false;
+
+        // without an announced Last-Modified the file cannot be proven to be the announced build;
+        // both sides are truncated to second precision, as HTTP dates and file systems carry no
+        // milliseconds
+        return announcedLastModified != null && actualLastModified != null &&
+                roundMillisecondsToSecondPrecision(announcedLastModified) ==
+                        roundMillisecondsToSecondPrecision(actualLastModified);
+    }
+}

--- a/download/src/main/java/slash/navigation/download/Download.java
+++ b/download/src/main/java/slash/navigation/download/Download.java
@@ -53,6 +53,8 @@ public class Download {
     private State state;
     private long processedBytes;
     private Long expectedBytes;
+    private Long announcedContentLength;
+    private Long announcedLastModified;
 
     public Download(String description, String url, Action action, FileAndChecksum file,
                     List<FileAndChecksum> fragments, String eTag, State state, File tempFile) {
@@ -156,6 +158,30 @@ public class Download {
 
     public void setExpectedBytes(Long expectedBytes) {
         this.expectedBytes = expectedBytes;
+    }
+
+    /**
+     * The Content-Length the last HTTP response announced, before it is folded into any
+     * {@link Checksum}; lets listeners tell a completely transferred file from a truncated one.
+     */
+    public Long getAnnouncedContentLength() {
+        return announcedContentLength;
+    }
+
+    public void setAnnouncedContentLength(Long announcedContentLength) {
+        this.announcedContentLength = announcedContentLength;
+    }
+
+    /**
+     * The Last-Modified the last HTTP response announced, in epoch milliseconds; lets listeners
+     * compare the written file against the build the server announced.
+     */
+    public Long getAnnouncedLastModified() {
+        return announcedLastModified;
+    }
+
+    public void setAnnouncedLastModified(Long announcedLastModified) {
+        this.announcedLastModified = announcedLastModified;
     }
 
     private static final Set<State> DOWNLOADED = new HashSet<>(asList(NotModified, Succeeded));

--- a/download/src/main/java/slash/navigation/download/performer/GetPerformer.java
+++ b/download/src/main/java/slash/navigation/download/performer/GetPerformer.java
@@ -125,13 +125,18 @@ public class GetPerformer implements ActionPerformer {
                 if (length != null)
                     getModelUpdater().expectingBytes(length);
                 new Copier(getModelUpdater()).copyAndClose(inputStream, new FileOutputStream(getDownload().getTempFile()), 0, length);
-                return new Result(request, true, request.getLastModified());
+                return new Result(request, true, request.getLastModified(), request.getContentLength());
             }
             return new Result(request, request.isSuccessful(), request.isNotModified());
         });
     }
 
     public void run() throws IOException {
+        // only the values announced by the response of this attempt may vouch for the
+        // transferred file; a leftover from a previous attempt must not
+        getDownload().setAnnouncedContentLength(null);
+        getDownload().setAnnouncedLastModified(null);
+
         Result result = new Result(null, false);
         if (canResume())
             result = resume();
@@ -143,6 +148,9 @@ public class GetPerformer implements ActionPerformer {
             downloadExecutor.notModified();
 
         } else if (result.success) {
+            getDownload().setAnnouncedContentLength(result.contentLength());
+            getDownload().setAnnouncedLastModified(result.lastModified);
+
             updateDownload(getDownload(), result.request, false);
 
             if(!getDownload().getTempFile().exists())
@@ -247,18 +255,18 @@ public class GetPerformer implements ActionPerformer {
         }
     }
 
-    private record Result(Get request, boolean success, boolean notModified, Long lastModified) {
+    private record Result(Get request, boolean success, boolean notModified, Long lastModified, Long contentLength) {
             public Result(Get request, boolean success) {
-                this(request, success, null);
-            }
-
-            public Result(Get request, boolean success, Long lastModified) {
-                this(request, success, false, lastModified);
+                this(request, success, false, null, null);
             }
 
             private Result(Get request, boolean success, boolean notModified) {
-                this(request, success, notModified, null);
+                this(request, success, notModified, null, null);
             }
 
+            // a full-body transfer: the response vouches for both the build and its length
+            public Result(Get request, boolean success, Long lastModified, Long contentLength) {
+                this(request, success, false, lastModified, contentLength);
+            }
     }
 }

--- a/download/src/test/java/slash/navigation/download/ChecksumReportPolicyTest.java
+++ b/download/src/test/java/slash/navigation/download/ChecksumReportPolicyTest.java
@@ -42,7 +42,9 @@ public class ChecksumReportPolicyTest {
     private static final long WORLD_MAP_SIZE = 3_276_950L;
     private static final long TRUNCATED_SIZE = 1_662_901L;
     private static final long LAST_MODIFIED = 1_700_000_000_123L;
-    private static final long LAST_MODIFIED_OTHER = 1_700_000_000_456L;
+    // a genuinely different build: whole seconds apart, not just sub-second noise the
+    // second-precision comparison is designed to ignore
+    private static final long LAST_MODIFIED_OTHER = 1_700_000_001_456L;
 
     private static final Long ANNOUNCED = WORLD_MAP_SIZE;
     private static final Long ANNOUNCED_LAST_MODIFIED = LAST_MODIFIED;

--- a/download/src/test/java/slash/navigation/download/ChecksumReportPolicyTest.java
+++ b/download/src/test/java/slash/navigation/download/ChecksumReportPolicyTest.java
@@ -1,0 +1,128 @@
+/*
+    This file is part of RouteConverter.
+
+    RouteConverter is free software; you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation; either version 2 of the License, or
+    (at your option) any later version.
+
+    RouteConverter is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with RouteConverter; if not, write to the Free Software
+    Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
+
+    Copyright (C) 2007 Christian Pesch. All Rights Reserved.
+*/
+
+package slash.navigation.download;
+
+import org.junit.Test;
+
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+import static slash.navigation.download.ChecksumReportPolicy.shouldReportFailedDownload;
+import static slash.navigation.download.State.ChecksumError;
+import static slash.navigation.download.State.Failed;
+import static slash.navigation.download.State.NoFileError;
+import static slash.navigation.download.State.Succeeded;
+
+/**
+ * Unit tests for {@link ChecksumReportPolicy}: the checksum of a download that failed validation
+ * may only be reported to the catalog server when the transfer provably completed — the response
+ * announced a Content-Length the file matches and a Last-Modified the file still carries, and the
+ * failure is a validation failure, not a transport failure (see GitHub #382).
+ *
+ * @author Christian Pesch
+ */
+public class ChecksumReportPolicyTest {
+    private static final long WORLD_MAP_SIZE = 3_276_950L;
+    private static final long TRUNCATED_SIZE = 1_662_901L;
+    private static final long LAST_MODIFIED = 1_700_000_000_123L;
+    private static final long LAST_MODIFIED_OTHER = 1_700_000_000_456L;
+
+    private static final Long ANNOUNCED = WORLD_MAP_SIZE;
+    private static final Long ANNOUNCED_LAST_MODIFIED = LAST_MODIFIED;
+
+    @Test
+    public void genuineRebuildIsReported() {
+        // upstream rebuilt the file; catalog is stale but the download is complete and correct
+        assertTrue(shouldReportFailedDownload(ChecksumError, ANNOUNCED, WORLD_MAP_SIZE,
+                ANNOUNCED_LAST_MODIFIED, LAST_MODIFIED));
+    }
+
+    @Test
+    public void truncatedDownloadIsNotReported() {
+        // interrupted transfer: the file is smaller than the announced Content-Length
+        assertFalse(shouldReportFailedDownload(ChecksumError, ANNOUNCED, TRUNCATED_SIZE,
+                ANNOUNCED_LAST_MODIFIED, LAST_MODIFIED));
+    }
+
+    @Test
+    public void largerThanAnnouncedDownloadIsNotReported() {
+        assertFalse(shouldReportFailedDownload(ChecksumError, ANNOUNCED, WORLD_MAP_SIZE + 1,
+                ANNOUNCED_LAST_MODIFIED, LAST_MODIFIED));
+    }
+
+    @Test
+    public void missingAnnouncedContentLengthIsNotReported() {
+        // without a Content-Length completeness cannot be proven
+        assertFalse(shouldReportFailedDownload(ChecksumError, null, WORLD_MAP_SIZE,
+                ANNOUNCED_LAST_MODIFIED, LAST_MODIFIED));
+    }
+
+    @Test
+    public void missingActualContentLengthIsNotReported() {
+        assertFalse(shouldReportFailedDownload(ChecksumError, ANNOUNCED, null,
+                ANNOUNCED_LAST_MODIFIED, LAST_MODIFIED));
+    }
+
+    @Test
+    public void differingLastModifiedIsNotReported() {
+        // sizes match, but the file is not the build the server announced
+        assertFalse(shouldReportFailedDownload(ChecksumError, ANNOUNCED, WORLD_MAP_SIZE,
+                ANNOUNCED_LAST_MODIFIED, LAST_MODIFIED_OTHER));
+    }
+
+    @Test
+    public void missingAnnouncedLastModifiedIsNotReported() {
+        assertFalse(shouldReportFailedDownload(ChecksumError, ANNOUNCED, WORLD_MAP_SIZE,
+                null, LAST_MODIFIED));
+    }
+
+    @Test
+    public void missingActualLastModifiedIsNotReported() {
+        assertFalse(shouldReportFailedDownload(ChecksumError, ANNOUNCED, WORLD_MAP_SIZE,
+                ANNOUNCED_LAST_MODIFIED, null));
+    }
+
+    @Test
+    public void transportFailureIsNotReported() {
+        // even with matching sizes, a transport error leaves the content in an unknown state
+        assertFalse(shouldReportFailedDownload(Failed, ANNOUNCED, WORLD_MAP_SIZE,
+                ANNOUNCED_LAST_MODIFIED, LAST_MODIFIED));
+    }
+
+    @Test
+    public void missingFileErrorIsNotReported() {
+        assertFalse(shouldReportFailedDownload(NoFileError, ANNOUNCED, WORLD_MAP_SIZE,
+                ANNOUNCED_LAST_MODIFIED, LAST_MODIFIED));
+    }
+
+    @Test
+    public void successIsNeverRoutedThroughThePredicate() {
+        // Succeeded is reported by the unchanged succeeded() path, not by this predicate
+        assertFalse(shouldReportFailedDownload(Succeeded, ANNOUNCED, WORLD_MAP_SIZE,
+                ANNOUNCED_LAST_MODIFIED, LAST_MODIFIED));
+    }
+
+    @Test
+    public void lastModifiedComparisonIgnoresMillisecondPrecision() {
+        // HTTP dates and file mtimes carry no milliseconds; sub-second drift must not reject a report
+        assertTrue(shouldReportFailedDownload(ChecksumError, ANNOUNCED, WORLD_MAP_SIZE,
+                ANNOUNCED_LAST_MODIFIED, LAST_MODIFIED + 42));
+    }
+}

--- a/download/src/test/java/slash/navigation/download/ChecksumReportPolicyTest.java
+++ b/download/src/test/java/slash/navigation/download/ChecksumReportPolicyTest.java
@@ -24,7 +24,7 @@ import org.junit.Test;
 
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
-import static slash.navigation.download.ChecksumReportPolicy.shouldReportFailedDownload;
+import static slash.navigation.download.ChecksumReportPolicy.isReportableChecksum;
 import static slash.navigation.download.State.ChecksumError;
 import static slash.navigation.download.State.Failed;
 import static slash.navigation.download.State.NoFileError;
@@ -50,79 +50,79 @@ public class ChecksumReportPolicyTest {
     @Test
     public void genuineRebuildIsReported() {
         // upstream rebuilt the file; catalog is stale but the download is complete and correct
-        assertTrue(shouldReportFailedDownload(ChecksumError, ANNOUNCED, WORLD_MAP_SIZE,
+        assertTrue(isReportableChecksum(ChecksumError, ANNOUNCED, WORLD_MAP_SIZE,
                 ANNOUNCED_LAST_MODIFIED, LAST_MODIFIED));
     }
 
     @Test
     public void truncatedDownloadIsNotReported() {
         // interrupted transfer: the file is smaller than the announced Content-Length
-        assertFalse(shouldReportFailedDownload(ChecksumError, ANNOUNCED, TRUNCATED_SIZE,
+        assertFalse(isReportableChecksum(ChecksumError, ANNOUNCED, TRUNCATED_SIZE,
                 ANNOUNCED_LAST_MODIFIED, LAST_MODIFIED));
     }
 
     @Test
     public void largerThanAnnouncedDownloadIsNotReported() {
-        assertFalse(shouldReportFailedDownload(ChecksumError, ANNOUNCED, WORLD_MAP_SIZE + 1,
+        assertFalse(isReportableChecksum(ChecksumError, ANNOUNCED, WORLD_MAP_SIZE + 1,
                 ANNOUNCED_LAST_MODIFIED, LAST_MODIFIED));
     }
 
     @Test
     public void missingAnnouncedContentLengthIsNotReported() {
         // without a Content-Length completeness cannot be proven
-        assertFalse(shouldReportFailedDownload(ChecksumError, null, WORLD_MAP_SIZE,
+        assertFalse(isReportableChecksum(ChecksumError, null, WORLD_MAP_SIZE,
                 ANNOUNCED_LAST_MODIFIED, LAST_MODIFIED));
     }
 
     @Test
     public void missingActualContentLengthIsNotReported() {
-        assertFalse(shouldReportFailedDownload(ChecksumError, ANNOUNCED, null,
+        assertFalse(isReportableChecksum(ChecksumError, ANNOUNCED, null,
                 ANNOUNCED_LAST_MODIFIED, LAST_MODIFIED));
     }
 
     @Test
     public void differingLastModifiedIsNotReported() {
         // sizes match, but the file is not the build the server announced
-        assertFalse(shouldReportFailedDownload(ChecksumError, ANNOUNCED, WORLD_MAP_SIZE,
+        assertFalse(isReportableChecksum(ChecksumError, ANNOUNCED, WORLD_MAP_SIZE,
                 ANNOUNCED_LAST_MODIFIED, LAST_MODIFIED_OTHER));
     }
 
     @Test
     public void missingAnnouncedLastModifiedIsNotReported() {
-        assertFalse(shouldReportFailedDownload(ChecksumError, ANNOUNCED, WORLD_MAP_SIZE,
+        assertFalse(isReportableChecksum(ChecksumError, ANNOUNCED, WORLD_MAP_SIZE,
                 null, LAST_MODIFIED));
     }
 
     @Test
     public void missingActualLastModifiedIsNotReported() {
-        assertFalse(shouldReportFailedDownload(ChecksumError, ANNOUNCED, WORLD_MAP_SIZE,
+        assertFalse(isReportableChecksum(ChecksumError, ANNOUNCED, WORLD_MAP_SIZE,
                 ANNOUNCED_LAST_MODIFIED, null));
     }
 
     @Test
     public void transportFailureIsNotReported() {
         // even with matching sizes, a transport error leaves the content in an unknown state
-        assertFalse(shouldReportFailedDownload(Failed, ANNOUNCED, WORLD_MAP_SIZE,
+        assertFalse(isReportableChecksum(Failed, ANNOUNCED, WORLD_MAP_SIZE,
                 ANNOUNCED_LAST_MODIFIED, LAST_MODIFIED));
     }
 
     @Test
     public void missingFileErrorIsNotReported() {
-        assertFalse(shouldReportFailedDownload(NoFileError, ANNOUNCED, WORLD_MAP_SIZE,
+        assertFalse(isReportableChecksum(NoFileError, ANNOUNCED, WORLD_MAP_SIZE,
                 ANNOUNCED_LAST_MODIFIED, LAST_MODIFIED));
     }
 
     @Test
     public void successIsNeverRoutedThroughThePredicate() {
         // Succeeded is reported by the unchanged succeeded() path, not by this predicate
-        assertFalse(shouldReportFailedDownload(Succeeded, ANNOUNCED, WORLD_MAP_SIZE,
+        assertFalse(isReportableChecksum(Succeeded, ANNOUNCED, WORLD_MAP_SIZE,
                 ANNOUNCED_LAST_MODIFIED, LAST_MODIFIED));
     }
 
     @Test
     public void lastModifiedComparisonIgnoresMillisecondPrecision() {
         // HTTP dates and file mtimes carry no milliseconds; sub-second drift must not reject a report
-        assertTrue(shouldReportFailedDownload(ChecksumError, ANNOUNCED, WORLD_MAP_SIZE,
+        assertTrue(isReportableChecksum(ChecksumError, ANNOUNCED, WORLD_MAP_SIZE,
                 ANNOUNCED_LAST_MODIFIED, LAST_MODIFIED + 42));
     }
 }

--- a/download/src/test/java/slash/navigation/download/performer/GetPerformerTest.java
+++ b/download/src/test/java/slash/navigation/download/performer/GetPerformerTest.java
@@ -31,6 +31,7 @@ import slash.navigation.download.DownloadManager;
 import slash.navigation.download.FileAndChecksum;
 import slash.navigation.download.State;
 import slash.navigation.download.executor.DownloadExecutor;
+import slash.navigation.rest.RFC2616;
 
 import java.io.File;
 import java.io.IOException;
@@ -47,6 +48,7 @@ import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
 import static slash.navigation.download.Action.Copy;
+import static slash.navigation.download.ChecksumReportPolicy.isReportableChecksum;
 
 /**
  * Hermetic (no external network) tests that a download's scratch temp file is deleted on the
@@ -58,6 +60,8 @@ import static slash.navigation.download.Action.Copy;
  */
 public class GetPerformerTest {
     private static final String BODY = "Lorem ipsum dolor sit amet";
+    // second precision: HTTP dates carry no milliseconds, so this round-trips through RFC 1123
+    private static final long LAST_MODIFIED = 1_700_000_123_000L;
 
     @Rule
     public final Timeout testTimeout = Timeout.seconds(30);
@@ -81,6 +85,16 @@ public class GetPerformerTest {
         });
         server.createContext("/missing", exchange -> {
             exchange.sendResponseHeaders(404, -1);
+            exchange.close();
+        });
+        server.createContext("/ok-last-modified", exchange -> {
+            byte[] body = BODY.getBytes(StandardCharsets.UTF_8);
+            bodiesServed.incrementAndGet();
+            exchange.getResponseHeaders().add("Last-Modified", RFC2616.formatDate(LAST_MODIFIED));
+            exchange.sendResponseHeaders(200, body.length);
+            try (OutputStream out = exchange.getResponseBody()) {
+                out.write(body);
+            }
             exchange.close();
         });
         server.start();
@@ -131,6 +145,33 @@ public class GetPerformerTest {
         assertEquals(State.ChecksumError, download.getState());
         assertEquals((long) BODY.length(), (long) download.getAnnouncedContentLength());
         assertEquals((long) BODY.length(), (long) download.getFile().getActualChecksum().getContentLength());
+    }
+
+    @Test
+    public void testValidateFailureCarriesAnnouncedLastModifiedEndToEnd() {
+        // the genuine-rebuild path (see GitHub #382): a completed transfer whose validation fails
+        // must carry the announced Last-Modified through to the actual checksum, because that is
+        // what lets a listener prove the file is the build the server announced rather than a
+        // truncated fragment of it
+        Checksum wrongChecksum = new Checksum(null, (long) BODY.length() + 999L, "wrong-sha1");
+        Download download = manager.queueForDownload("mismatching checksum", url("/ok-last-modified"),
+                Copy, new FileAndChecksum(target, wrongChecksum), null);
+        manager.waitForCompletion(singletonList(download));
+
+        assertEquals(State.ChecksumError, download.getState());
+        assertEquals((long) BODY.length(), (long) download.getAnnouncedContentLength());
+        assertEquals(LAST_MODIFIED, (long) download.getAnnouncedLastModified());
+
+        Checksum actual = download.getFile().getActualChecksum();
+        assertEquals((long) BODY.length(), (long) actual.getContentLength());
+        // copy() stamps the target with the announced Last-Modified and createChecksum() reads it
+        // back, so the actual checksum's mtime mirrors the announced one
+        assertEquals(LAST_MODIFIED, actual.getLastModified().getTimeInMillis());
+
+        // exactly what ChecksumSender.failed() asks the policy, with the real download's values
+        assertTrue(isReportableChecksum(download.getState(), download.getAnnouncedContentLength(),
+                actual.getContentLength(), download.getAnnouncedLastModified(),
+                actual.getLastModified().getTimeInMillis()));
     }
 
     @Test

--- a/download/src/test/java/slash/navigation/download/performer/GetPerformerTest.java
+++ b/download/src/test/java/slash/navigation/download/performer/GetPerformerTest.java
@@ -44,6 +44,7 @@ import static java.io.File.createTempFile;
 import static java.util.Collections.singletonList;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
 import static slash.navigation.download.Action.Copy;
 
@@ -116,6 +117,37 @@ public class GetPerformerTest {
         assertEquals(State.ChecksumError, download.getState());
         assertEquals(1, bodiesServed.get());
         assertFalse("temp file must be deleted after a failed validation", download.getTempFile().exists());
+    }
+
+    @Test
+    public void testValidateFailureCarriesAnnouncedContentLength() {
+        // the Content-Length the response announced survives the failed validation, so a listener
+        // can tell a completely transferred file from a truncated one (see GitHub #382)
+        Checksum wrongChecksum = new Checksum(null, (long) BODY.length() + 999L, "wrong-sha1");
+        Download download = manager.queueForDownload("mismatching checksum", url("/ok"), Copy,
+                new FileAndChecksum(target, wrongChecksum), null);
+        manager.waitForCompletion(singletonList(download));
+
+        assertEquals(State.ChecksumError, download.getState());
+        assertEquals((long) BODY.length(), (long) download.getAnnouncedContentLength());
+        assertEquals((long) BODY.length(), (long) download.getFile().getActualChecksum().getContentLength());
+    }
+
+    @Test
+    public void testFailedTransferDoesNotCarryAnnouncedValues() throws IOException {
+        // a transport failure must not leave announced values behind that could vouch for
+        // the content of the failed attempt
+        Download download = new Download("missing resource", url("/missing"), Copy,
+                new FileAndChecksum(target, null), null);
+        manager.getModel().setDownloads(singletonList(download));
+        DownloadExecutor executor = new DownloadExecutor(download, manager);
+        GetPerformer performer = new GetPerformer();
+        performer.setDownloadExecutor(executor);
+        performer.run();
+
+        assertEquals(State.Failed, download.getState());
+        assertNull(download.getAnnouncedContentLength());
+        assertNull(download.getAnnouncedLastModified());
     }
 
     @Test

--- a/route-converter-gui/src/main/java/slash/navigation/converter/gui/helpers/ChecksumSender.java
+++ b/route-converter-gui/src/main/java/slash/navigation/converter/gui/helpers/ChecksumSender.java
@@ -20,6 +20,8 @@
 package slash.navigation.converter.gui.helpers;
 
 import slash.navigation.converter.gui.BaseRouteConverter;
+import slash.navigation.download.Checksum;
+import slash.navigation.download.ChecksumReportPolicy;
 import slash.navigation.download.Download;
 import slash.navigation.download.DownloadListener;
 import slash.navigation.download.FileAndChecksum;
@@ -43,9 +45,17 @@ public class ChecksumSender implements DownloadListener {
         FileAndChecksum file = download.getFile();
         if (file.getActualChecksum() == null)
             return;
-        if (file.getActualChecksum().laterThan(file.getExpectedChecksum()) ||
-                file.getExpectedChecksum().getSHA1() == null && file.getActualChecksum().getSHA1() != null)
+        // the file's checksum is only a new known-good build if the transfer provably completed
+        // and validation failed on the complete content; anything else is a broken download whose
+        // checksum must not be published (see GitHub #382)
+        if (ChecksumReportPolicy.shouldReportFailedDownload(download.getState(),
+                download.getAnnouncedContentLength(), file.getActualChecksum().getContentLength(),
+                download.getAnnouncedLastModified(), lastModifiedMillis(file.getActualChecksum())))
             sendChecksums(download);
+    }
+
+    private Long lastModifiedMillis(Checksum checksum) {
+        return checksum.getLastModified() != null ? checksum.getLastModified().getTimeInMillis() : null;
     }
 
     public void succeeded(Download download) {

--- a/route-converter-gui/src/main/java/slash/navigation/converter/gui/helpers/ChecksumSender.java
+++ b/route-converter-gui/src/main/java/slash/navigation/converter/gui/helpers/ChecksumSender.java
@@ -48,7 +48,7 @@ public class ChecksumSender implements DownloadListener {
         // the file's checksum is only a new known-good build if the transfer provably completed
         // and validation failed on the complete content; anything else is a broken download whose
         // checksum must not be published (see GitHub #382)
-        if (ChecksumReportPolicy.shouldReportFailedDownload(download.getState(),
+        if (ChecksumReportPolicy.isReportableChecksum(download.getState(),
                 download.getAnnouncedContentLength(), file.getActualChecksum().getContentLength(),
                 download.getAnnouncedLastModified(), lastModifiedMillis(file.getActualChecksum())))
             sendChecksums(download);


### PR DESCRIPTION
Build tooling (`mvnw`, `mvn`, `factory-verify`) is blocked in this session, and `factory-verify`'s broker additionally rejects this repo (`repo not allowed (rc/* only)`), so I could not compile or run tests. Here is the summary.

## Verification result: **unavailable**

- `factory-verify` fails with a broker error: `repo not allowed (rc/* only)` — this checkout is not an allowlisted repo.
- `./mvnw` / `mvn` invocations are denied by the tool policy; no JDK is on PATH (`java: command not found`).
- In lieu of compiling, I traced every API I touched against its source: `ReadRequest.getContentLength()`/`getLastModified()`, `CompactCalendar.getTimeInMillis()`, `Transfer.roundMillisecondsToSecondPrecision`, the `Result` record constructor chain in `GetPerformer`, and the existing `GetPerformerTest` harness (`/ok` serves a 200 with `Content-Length`, `/missing` serves 404). All line up.

## What changed and why

`ChecksumSender.failed()` used `Checksum.laterThan()` — a last-modified comparison that a freshly written file almost always wins — to decide whether to publish a failed download's checksum. Any truncated or otherwise broken transfer therefore got reported as a known-good build, which repeatedly evicted the real `world.map` checksum from the server's served top-5 and forced a global re-download. The fix reports a failed download's checksum **only when the transfer provably completed**:

- **`download/…/ChecksumReportPolicy.java` (new)** — pure predicate `shouldReportFailedDownload(state, announcedContentLength, actualContentLength, announcedLastModified, actualLastModified)` as specified in the issue. Requires `ChecksumError` (validation ran on a complete file), an announced Content-Length exactly equal to the written size, and an announced Last-Modified equal to the file's mtime (both sides rounded to second precision, since HTTP dates and filesystems carry no milliseconds). Missing/`null` inputs fail closed.
- **`download/…/Download.java`** — carries `announcedContentLength` / `announcedLastModified` (the response's `Content-Length` / `Last-Modified`), which were previously folded into `actualChecksum` only when the target file didn't yet exist, so the listener could no longer see them.
- **`download/…/performer/GetPerformer.java`** — clears both announced values at the start of `run()` so a previous attempt's values can't vouch for this attempt; sets them on the success path from the response headers via an extended `Result` record. The length is captured in `download()`'s handler rather than read back through `request` in `run()`: on the `resume()` path a 206's `Content-Length` describes only the remaining range, so a value read later would misrepresent the resource — the full-body `download()` path is the only place a whole-resource length exists.
- **`route-converter-gui/…/helpers/ChecksumSender.java`** — `failed()` now delegates to the policy. `succeeded()` is unchanged; the `#155` case (stale catalog entry, complete download) still reports.
- **`download/src/test/…/ChecksumReportPolicyTest.java` (new)** — 12 tests covering every case in the issue's seam list (genuine rebuild → true; truncated, oversize, missing lengths, last-modified mismatch, transport failure, `NoFileError`, `Succeeded` → false) plus sub-second mtime drift tolerance.
- **`download/src/test/…/performer/GetPerformerTest.java`** — two hermetic wiring tests: a `ChecksumError` download retains the announced `Content-Length` matching the served body, and a `Failed` transfer clears both announced values.

The manually-verifiable acceptance path stands: with a truncated `world.map`, the log should show the `matched none of … known-good checksum(s)` warning and the re-download, but no `Sending checksums … contentLength=1662901` line; the complete re-download still reports via `succeeded()`.


Source issue: cpesch/RouteConverter#382

---
**Builder stats** · model `sonnet` · confidence `0` · 27m 8s across 1 round(s) · 6 file op(s)
[Workflow run](http://127.0.0.1:3000/cpesch/RouteConverter/actions/runs/27155)

⚠ UNVERIFIED: target not verifiable by the broker (non-rc/* target or no pom.xml — v1 is maven-only)

Closes #382

<!-- issue-body-sha:27b3b409c1f1 -->